### PR TITLE
close channel on request timeout

### DIFF
--- a/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -1746,8 +1746,8 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
                 if (p != null && p.getRequestTimeoutInMs() != -1) {
                     requestTimeout = p.getRequestTimeoutInMs();
                 }
-                abort(this.nettyResponseFuture, new TimeoutException(String.format("No response received after %s", requestTimeout)));
                 markChannelNotReadable(channel.getPipeline().getContext(NettyAsyncHttpProvider.class));
+                abort(this.nettyResponseFuture, new TimeoutException(String.format("No response received after %s", requestTimeout)));
 
                 this.nettyResponseFuture = null;
                 this.channel = null;


### PR DESCRIPTION
abort sets channel to null (but does not close channel), yielding NPE on channel.getPipeline, which is caught in FutureTask.innerRunAndReset ==> future is canceled, but markChannelNotReadable never executed & channel never closed. 
