### PR TITLE
Support for setting cookies on 302 redirects

### DIFF
--- a/src/main/java/com/ning/http/client/RequestBuilder.java
+++ b/src/main/java/com/ning/http/client/RequestBuilder.java
@@ -160,4 +160,9 @@ public class RequestBuilder extends RequestBuilderBase<RequestBuilder> {
     public RequestBuilder setFollowRedirects(boolean followRedirects) {
         return super.setFollowRedirects(followRedirects);
     }
+
+    @Override
+    public RequestBuilder addOrReplaceCookie(Cookie c) {
+	return super.addOrReplaceCookie(c);		
+    }
 }

--- a/src/main/java/com/ning/http/client/RequestBuilderBase.java
+++ b/src/main/java/com/ning/http/client/RequestBuilderBase.java
@@ -563,4 +563,23 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
             return true;
         }
     }
+    
+      public T addOrReplaceCookie(Cookie cookie) {
+    	String cookieKey=cookie.getName();
+    	boolean replace=false;
+    	int index=0;
+    	for(Cookie c : request.cookies) {
+    		if(c.getName().equals(cookieKey)){
+    			replace=true;
+    			break;
+    		};
+    		index++;
+    	}
+    	if(replace) {
+    		((ArrayList<Cookie>)request.cookies).set(index, cookie);
+    	} else {
+            request.cookies.add(cookie);
+    	}
+        return derived.cast(this);
+    }
 }

--- a/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -1161,6 +1161,15 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
                             final String newUrl = uri.toString();
 
                             log.debug("Redirecting to {}", newUrl);
+                            for(String cookieStr : future.getHttpResponse().getHeaders(HttpHeaders.Names.SET_COOKIE)){
+                                Cookie c=AsyncHttpProviderUtils.parseCookie(cookieStr);
+                                nBuilder.addOrReplaceCookie(c);
+                            }
+                            for(String cookieStr : future.getHttpResponse().getHeaders(HttpHeaders.Names.SET_COOKIE2)){
+                                Cookie c=AsyncHttpProviderUtils.parseCookie(cookieStr);
+                                nBuilder.addOrReplaceCookie(c);
+                            }
+    
 
                             AsyncCallable ac = new AsyncCallable(future) {
                                 public Object call() throws Exception {


### PR DESCRIPTION
currently async-http-client does not support setting cookies on 302 redirect.  Unfortunately this is required for some sites I track, based on Invision Power Board. That patch adds that support only for netty provider, but it is easy to port to others
This is example of that problem found in safari:
http://stackoverflow.com/questions/1144894/safari-doesnt-set-cookie-but-ie-ff-does
