### PR TITLE
fixes issue with useRawUrl, queryString decode/encode and redirecting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.ning</groupId>
     <artifactId>async-http-client</artifactId>
     <name>Asynchronous Http Client</name>
-    <version>1.6.4</version>
+    <version>1.6.4_rawUrlFix</version>
     <packaging>jar</packaging>
     <description>
         Async Http Client library purpose is to allow Java applications to easily execute HTTP requests and

--- a/src/main/java/com/ning/http/client/AsyncHttpClient.java
+++ b/src/main/java/com/ning/http/client/AsyncHttpClient.java
@@ -215,8 +215,8 @@ public class AsyncHttpClient {
          */
         protected String baseURL;
         
-        private BoundRequestBuilder(String reqType) {
-            super(BoundRequestBuilder.class, reqType);
+        private BoundRequestBuilder(String reqType, boolean useRawUrl) {
+            super(BoundRequestBuilder.class, reqType, useRawUrl);
         }
 
         private BoundRequestBuilder(Request prototype) {
@@ -557,7 +557,7 @@ public class AsyncHttpClient {
     }
 
     protected BoundRequestBuilder requestBuilder(String reqType, String url) {
-        return new BoundRequestBuilder(reqType).setUrl(url).setSignatureCalculator(signatureCalculator);
+        return new BoundRequestBuilder(reqType, config.isUseRawUrl()).setUrl(url).setSignatureCalculator(signatureCalculator);
     }
 
     protected BoundRequestBuilder requestBuilder(Request prototype) {

--- a/src/main/java/com/ning/http/client/Request.java
+++ b/src/main/java/com/ning/http/client/Request.java
@@ -190,4 +190,6 @@ public interface Request {
      */
     public String getBodyEncoding();
 
+    public boolean isUseRawUrl();
+
 }

--- a/src/main/java/com/ning/http/client/RequestBuilder.java
+++ b/src/main/java/com/ning/http/client/RequestBuilder.java
@@ -25,12 +25,17 @@ import java.util.Map;
  * Builder for a {@link Request}.
  */
 public class RequestBuilder extends RequestBuilderBase<RequestBuilder> {
+
     public RequestBuilder() {
-        super(RequestBuilder.class, "GET");
+        super(RequestBuilder.class, "GET", false);
     }
 
     public RequestBuilder(String method) {
-        super(RequestBuilder.class, method);
+        super(RequestBuilder.class, method, false);
+    }
+
+    public RequestBuilder(String method, boolean useRawUrl) {
+        super(RequestBuilder.class, method, useRawUrl);
     }
 
     public RequestBuilder(Request prototype) {

--- a/src/main/java/com/ning/http/client/SimpleAsyncHttpClient.java
+++ b/src/main/java/com/ning/http/client/SimpleAsyncHttpClient.java
@@ -403,7 +403,7 @@ public class SimpleAsyncHttpClient {
         private SimpleAHCTransferListener listener = null;
 
         public Builder() {
-            requestBuilder = new RequestBuilder("GET");
+            requestBuilder = new RequestBuilder("GET", false);
         }
 
         private Builder(SimpleAsyncHttpClient client) {


### PR DESCRIPTION
Hi,

Play Framework uses AHC. When we needed AHC to support multiple encodings, we had to encode everything ourself before passing it to AHC. For this to work we must use "useRawUrl" to prevent AHC from destroying our preencoded QueryStrring-params by trying to reencode it with utf-8 right before using the rebuilded url. We managed to get around all problems by tweaking how/when we gave the info to AHC.

The only problem that we found no solution for was how AHC was handling redirects with useRawUrl on.

If AHC gets the following redirect-Location when useRawUrls is on:
  http://localhost:9003/rest/redirecttarget?data2=x%3D%26y
it wil first decode x%3D%26y into x=&y, then later add it to the rebuilded url as is.

The url used in the redirect will end up like this:
  http://localhost:9003/rest/redirecttarget?data2=x=&y

This pullrequest fixes this issue by preventing AHC from decoding queryString-param names and values before adding them with addQueryParameter when useRawUrl is on.

This patch it by no means perfect, but it do fix the problem..
