### PR TITLE
Allow an override of InetAddress in the Request object

### DIFF
--- a/src/main/java/com/ning/http/client/Request.java
+++ b/src/main/java/com/ning/http/client/Request.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetAddress;
 import java.util.Collection;
 import java.util.List;
 
@@ -64,6 +65,13 @@ public interface Request {
      * @return the decoded url
      */
     public String getUrl();
+
+    /**
+     * Return the InetAddress to override
+     *
+     * @return the InetAddress
+     */
+    public InetAddress getInetAddress();
 
     /**
      * Return the undecoded url

--- a/src/main/java/com/ning/http/client/RequestBuilderBase.java
+++ b/src/main/java/com/ning/http/client/RequestBuilderBase.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.util.ArrayList;
@@ -44,6 +45,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
     private static final class RequestImpl implements Request {
         private String method;
         private String url = null;
+        private InetAddress address = null;
         private FluentCaseInsensitiveStringsMap headers = new FluentCaseInsensitiveStringsMap();
         private Collection<Cookie> cookies = new ArrayList<Cookie>();
         private byte[] byteData;
@@ -74,6 +76,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
                 this.method = prototype.getMethod();
                 int pos = prototype.getUrl().indexOf("?");
                 this.url = pos > 0 ? prototype.getUrl().substring(0, pos) : prototype.getUrl();
+                this.address = prototype.getInetAddress();
                 this.headers = new FluentCaseInsensitiveStringsMap(prototype.getHeaders());
                 this.cookies = new ArrayList<Cookie>(prototype.getCookies());
                 this.byteData = prototype.getByteData();
@@ -111,6 +114,10 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
 
         public String getUrl() {
             return toUrl(true);
+        }
+
+        public InetAddress getInetAddress() {
+            return address;
         }
 
         private String toUrl(boolean encode) {
@@ -308,6 +315,11 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
     public T setUrl(String url) {
         request.url = buildUrl(url);
         return derived.cast(this);
+    }
+
+    public T setInetAddress(InetAddress address) {
+    	request.address = address;
+    	return derived.cast(this);
     }
 
     private String buildUrl(String url) {

--- a/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -905,7 +905,10 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
         }
 
         try {
-            if (proxyServer == null || avoidProxy) {
+        	if (request.getInetAddress() != null) {
+        		channelFuture = bootstrap.connect(new InetSocketAddress(request.getInetAddress(), AsyncHttpProviderUtils.getPort(uri)));
+        	}
+        	else if (proxyServer == null || avoidProxy) {
                 channelFuture = bootstrap.connect(new InetSocketAddress(AsyncHttpProviderUtils.getHost(uri), AsyncHttpProviderUtils.getPort(uri)));
             } else {
                 channelFuture = bootstrap.connect(new InetSocketAddress(proxyServer.getHost(), proxyServer.getPort()));


### PR DESCRIPTION
This is a small patch to allow the caller to provide an InetAddress to override DNS. I've only implemented the netty provider, as that's what we're using.

This may only be useful for our use case but I've found it extremely helpful in cases where DNS returns a list of IPs for a given hostname and you cannot trust the behavior of the JVM and AHC w.r.t. round robin DNS.
