### PR TITLE
This commit should fix issue AHC-116

### DIFF
--- a/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -631,7 +631,7 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
             }
 
             if (proxyServer.getPrincipal() != null) {
-                if (proxyServer.getNtlmDomain() != null) {
+                if (proxyServer.getNtlmDomain() != "") {
 
                     List<String> auth = request.getHeaders().get(HttpHeaders.Names.PROXY_AUTHORIZATION);
                     if (!(auth != null && auth.size() > 0 && auth.get(0).startsWith("NTLM"))) {


### PR DESCRIPTION
Now proxyServer.getNtlmDomain() is tested for inequality with "" instead of null.

Indeed, it is defined as private String ntlmDomain = System.getProperty("http.auth.ntlm.domain", ""); in ProxyServer.java.
