### PR TITLE
AHC-119, NETTY-430: Upgrade to Netty 3.2.6-Final to fix NullPointerException in ChunkedWriteHandler.discard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.jboss.netty</groupId>
             <artifactId>netty</artifactId>
-            <version>3.2.5.Final</version>
+            <version>3.2.6.Final</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.servlet</groupId>


### PR DESCRIPTION
https://issues.sonatype.org/browse/AHC-119
