### PR TITLE
Handles params & queryParams only if maps are not empty

### DIFF
--- a/src/main/java/com/ning/http/client/RequestBuilderBase.java
+++ b/src/main/java/com/ning/http/client/RequestBuilderBase.java
@@ -134,7 +134,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
                 throw new IllegalArgumentException("Illegal URL: " + url, e);
             }
 
-            if (queryParams != null) {
+            if (queryParams != null && !queryParams.isEmpty()) {
 
                 StringBuilder builder = new StringBuilder();
                 if (!url.substring(8).contains("/")) { // no other "/" than http[s]:// -> http://localhost:1234

--- a/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -712,7 +712,7 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
                     int length = lengthWrapper[0];
                     nettyRequest.setHeader(HttpHeaders.Names.CONTENT_LENGTH, String.valueOf(length));
                     nettyRequest.setContent(ChannelBuffers.wrappedBuffer(bytes, 0, length));
-                } else if (request.getParams() != null) {
+                } else if (request.getParams() != null && !request.getParams().isEmpty()) {
                     StringBuilder sb = new StringBuilder();
                     for (final Entry<String, List<String>> paramEntry : request.getParams()) {
                         final String key = paramEntry.getKey();


### PR DESCRIPTION
Params were set in the request even if the map of params was empty, this could lead to
requests with no body even if we set one.
This commit fixes this behaviour for Netty provider.
The same has been done for queryParams (in RequestBuilderBase) to prevent '?' to be added even if not wanted
