### PR TITLE
Upload large file issue

### DIFF
--- a/src/main/java/com/ning/http/multipart/MultipartBody.java
+++ b/src/main/java/com/ning/http/multipart/MultipartBody.java
@@ -458,7 +458,7 @@ public class MultipartBody implements RandomAccessBody {
                         if (nWrite == 0) {
                             logger.info("Waiting for writing...");
                             try {
-                                fc.wait(1000);
+                                fc.wait(50);
                             } catch (InterruptedException e) {
                                 logger.trace(e.getMessage(), e);
                             }


### PR DESCRIPTION
On the Mac this hits the wait every other time through the while.  The 1 second wait cause the upload to take a long time and time out.  Decreasing the wait time increases the upload speed.
