### PR TITLE
Enhanced Javadoc rendering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,15 @@
         <system>jira</system>
         <url>https://issues.sonatype.org/browse/AHC</url>
     </issueManagement>
+    <mailingLists>
+        <mailingList>
+            <name>asynchttpclient</name>
+            <archive>http://groups.google.com/group/asynchttpclient/topics</archive>
+            <subscribe>http://groups.google.com/group/asynchttpclient/subscribe</subscribe>
+            <unsubscribe>http://groups.google.com/group/asynchttpclient/subscribe</unsubscribe>
+            <post>asynchttpclient@googlegroups.com</post>
+        </mailingList>
+    </mailingLists>
 
     <prerequisites>
         <maven>2.0.9</maven>


### PR DESCRIPTION
With the proposed pull request I intend to replace the default Javadoc rendering with the Google Doclava (aka Droidoc)

A live sample on my ASF space: http://people.apache.org/~simonetripodi/ahc/apidocs/reference/packages.html

Hope you'll like it!
Best,
-Simo
