### PR TITLE
on bad websocket upgrade, include the bad status code in the exception

### DIFF
--- a/src/main/java/com/ning/http/client/websocket/WebSocketUpgradeHandler.java
+++ b/src/main/java/com/ning/http/client/websocket/WebSocketUpgradeHandler.java
@@ -64,7 +64,7 @@ public class WebSocketUpgradeHandler implements UpgradeHandler<WebSocket>, Async
         if (responseStatus.getStatusCode() == 101) {
             return STATE.UPGRADE;
         } else {
-            throw new IllegalStateException("Invalid Upgrade protocol");
+            throw new IllegalStateException("Invalid upgrade protocol, status should be 101 but was " + responseStatus.getStatusCode());
         }
     }
 


### PR DESCRIPTION
"Invalid Upgrade protocol" isn't very clear that the problem is
1) a bad status or 2) what the bad status was.
