### PR TITLE
Fix large payload bugs in ByteArrayBodyGenerator.

### DIFF
--- a/src/main/java/com/ning/http/client/generators/ByteArrayBodyGenerator.java
+++ b/src/main/java/com/ning/http/client/generators/ByteArrayBodyGenerator.java
@@ -43,14 +43,16 @@ public class ByteArrayBodyGenerator implements BodyGenerator {
                 return -1;
             }
 
-            if (bytes.length - lastPosition <= byteBuffer.capacity()) {
-                byteBuffer.put(bytes, lastPosition, bytes.length);
+            final int remaining = bytes.length - lastPosition;
+            if (remaining <= byteBuffer.capacity()) {
+                byteBuffer.put(bytes, lastPosition, remaining);
                 eof = true;
+                return remaining;
             } else {
                 byteBuffer.put(bytes, lastPosition, byteBuffer.capacity());
-                lastPosition = bytes.length - byteBuffer.capacity();
+                lastPosition = lastPosition + byteBuffer.capacity();
+                return byteBuffer.capacity();
             }
-            return bytes.length;
         }
 
         public void close() throws IOException {

--- a/src/test/java/com/ning/http/client/generators/ByteArrayBodyGeneratorTest.java
+++ b/src/test/java/com/ning/http/client/generators/ByteArrayBodyGeneratorTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2010-2012 Sonatype, Inc. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+package com.ning.http.client.generators;
+
+import com.ning.http.client.Body;
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author Bryan Davis bpd@keynetics.com
+ */
+public class ByteArrayBodyGeneratorTest {
+
+    private final Random random = new Random();
+    private final int chunkSize = 1024 * 8;
+
+    @Test(groups = "standalone")
+    public void testSingleRead() throws IOException {
+        final int srcArraySize = chunkSize - 1;
+        final byte[] srcArray = new byte[srcArraySize];
+        random.nextBytes(srcArray);
+
+        final ByteArrayBodyGenerator babGen =
+            new ByteArrayBodyGenerator(srcArray);
+        final Body body = babGen.createBody();
+
+        final ByteBuffer chunkBuffer = ByteBuffer.allocate(chunkSize);
+
+        // should take 1 read to get through the srcArray
+        assertEquals(body.read(chunkBuffer), srcArraySize);
+        assertEquals(chunkBuffer.position(), srcArraySize, "bytes read");
+        chunkBuffer.clear();
+
+        assertEquals(body.read(chunkBuffer), -1, "body at EOF");
+    }
+
+    @Test(groups = "standalone")
+    public void testMultipleReads() throws IOException {
+        final int srcArraySize = (3 * chunkSize) + 42;
+        final byte[] srcArray = new byte[srcArraySize];
+        random.nextBytes(srcArray);
+
+        final ByteArrayBodyGenerator babGen =
+            new ByteArrayBodyGenerator(srcArray);
+        final Body body = babGen.createBody();
+
+        final ByteBuffer chunkBuffer = ByteBuffer.allocate(chunkSize);
+
+        int reads = 0;
+        int bytesRead = 0;
+        while (body.read(chunkBuffer) != -1) {
+          reads += 1;
+          bytesRead += chunkBuffer.position();
+          chunkBuffer.clear();
+        }
+        assertEquals(reads, 4, "reads to drain generator");
+        assertEquals(bytesRead, srcArraySize, "bytes read");
+    }
+
+}


### PR DESCRIPTION
Fixes three bugs exposed when a ByteArrayBodyGenerator is used to
pass a POST body to the AsyncHttpProvider that is larger than the
AsyncHttpProvider's BodyChunkedInput buffer size. Found when using the Netty
provider to pass a 50k+ POST body.

A read from a ByteBody having more content than the buffer could hold would
return a full read buffer but incorrectly compute the internal pointer for the
remaining content by subtracting the read length from the total content size
rather than adding it to the current read position.

A subsequent read from the same ByteBody would result in
a java.lang.IndexOutOfBoundsException due to improperly passing the total
length of the current body as the length argument to ByteBuffer.put() rather
than the number of bytes to read from the offset.

ByteArrayBodyGenerator.ByteBody also incorrectly implemented the Body
interface by returning the total body length for each non-EOF read rather
than the actual number of bytes read.

All three of these bugs would not be seen unless the body size was greater
than the capacity of a single buffer.
