### PR TITLE
Fix for issue #72

### DIFF
--- a/src/main/java/com/ning/http/client/HttpResponseBodyPartsInputStream.java
+++ b/src/main/java/com/ning/http/client/HttpResponseBodyPartsInputStream.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2010 Ning, Inc.
+ * 
+ * Ning licenses this file to you under the Apache License, version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ning.http.client;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * An {@link InputStream} that reads all the elements in an array of {@link HttpResponseBodyPart}s.
+ */
+public class HttpResponseBodyPartsInputStream extends InputStream {
+
+    private final HttpResponseBodyPart[] parts;
+
+    private int currentPos = 0;
+    private int bytePos = -1;
+    private byte[] active;
+    private int available = 0;
+
+    public HttpResponseBodyPartsInputStream(HttpResponseBodyPart[] parts) {
+        this.parts = parts;
+        active = parts[0].getBodyPartBytes();
+        computeLength(parts);
+    }
+
+    private void computeLength(HttpResponseBodyPart[] parts) {
+        if (available == 0) {
+            for (HttpResponseBodyPart p : parts) {
+                available += p.getBodyPartBytes().length;
+            }
+        }
+    }
+
+    @Override
+    public int available() throws IOException {
+        return available;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (++bytePos >= active.length) {
+            // No more bytes, so step to the next array.
+            if (++currentPos >= parts.length) {
+                return -1;
+            }
+
+            bytePos = 0;
+            active = parts[currentPos].getBodyPartBytes();
+        }
+
+        return active[bytePos] & 0xFF;
+    }
+}

--- a/src/main/java/com/ning/http/client/providers/apache/ApacheResponse.java
+++ b/src/main/java/com/ning/http/client/providers/apache/ApacheResponse.java
@@ -15,6 +15,7 @@ package com.ning.http.client.providers.apache;
 import com.ning.http.client.Cookie;
 import com.ning.http.client.FluentCaseInsensitiveStringsMap;
 import com.ning.http.client.HttpResponseBodyPart;
+import com.ning.http.client.HttpResponseBodyPartsInputStream;
 import com.ning.http.client.HttpResponseHeaders;
 import com.ning.http.client.HttpResponseStatus;
 import com.ning.http.client.Response;
@@ -91,7 +92,7 @@ public class ApacheResponse implements Response {
     /* @Override */
     public InputStream getResponseBodyAsStream() throws IOException {
         if (bodyParts.size() > 0) {
-            return new ByteArrayInputStream(bodyParts.toArray(new HttpResponseBodyPart[bodyParts.size()])[0].getBodyPartBytes());
+            return new HttpResponseBodyPartsInputStream(bodyParts.toArray(new HttpResponseBodyPart[bodyParts.size()]));
         } else {
             return new ByteArrayInputStream("".getBytes());
         }

--- a/src/main/java/com/ning/http/client/providers/jdk/JDKResponse.java
+++ b/src/main/java/com/ning/http/client/providers/jdk/JDKResponse.java
@@ -15,6 +15,7 @@ package com.ning.http.client.providers.jdk;
 import com.ning.http.client.Cookie;
 import com.ning.http.client.FluentCaseInsensitiveStringsMap;
 import com.ning.http.client.HttpResponseBodyPart;
+import com.ning.http.client.HttpResponseBodyPartsInputStream;
 import com.ning.http.client.HttpResponseHeaders;
 import com.ning.http.client.HttpResponseStatus;
 import com.ning.http.client.Response;
@@ -102,53 +103,9 @@ public class JDKResponse implements Response {
         }
 
         if (bodyParts.size() > 0) {
-            return new ByteArrayCollectionInputStream(bodyParts.toArray(new HttpResponseBodyPart[bodyParts.size()]));
+            return new HttpResponseBodyPartsInputStream(bodyParts.toArray(new HttpResponseBodyPart[bodyParts.size()]));
         } else {
             return new ByteArrayInputStream("".getBytes());
-        }
-    }
-
-    private static class ByteArrayCollectionInputStream extends InputStream {
-
-        private final HttpResponseBodyPart[] parts;
-
-        private int currentPos = 0;
-        private int bytePos = -1;
-        private byte[] active;
-        private int available = 0;
-
-        public ByteArrayCollectionInputStream(HttpResponseBodyPart[] parts) {
-            this.parts = parts;
-            active = parts[0].getBodyPartBytes();
-            computeLength(parts);
-        }
-
-        private void computeLength(HttpResponseBodyPart[] parts) {
-            if (available == 0) {
-                for (HttpResponseBodyPart p : parts) {
-                    available += p.getBodyPartBytes().length;
-                }
-            }
-        }
-
-        @Override
-        public int available() throws IOException {
-            return available;
-        }
-
-        @Override
-        public int read() throws IOException {
-            if (++bytePos >= active.length) {
-                // No more bytes, so step to the next array.
-                if (++currentPos >= parts.length) {
-                    return -1;
-                }
-
-                bytePos = 0;
-                active = parts[currentPos].getBodyPartBytes();
-            }
-
-            return active[bytePos] & 0xFF;
         }
     }
 


### PR DESCRIPTION
This fixes ApacheResponse.getResponseBodyAsStream() to return all the bytes in the body.

I'm not sure if I put the new class in the right package, or if the name was optimal (ByteArrayCollectionInputStream).  Please re-arrange as you desire.
