### PR TITLE
Handle charsets that are quoted as if they were not (trim them). 

### DIFF
--- a/src/main/java/com/ning/http/util/AsyncHttpProviderUtils.java
+++ b/src/main/java/com/ning/http/util/AsyncHttpProviderUtils.java
@@ -429,7 +429,14 @@ public class AsyncHttpProviderUtils {
             if (part.trim().startsWith("charset=")) {
                 String[] val = part.split("=");
                 if (val.length > 1) {
-                    return val[1].trim();
+                    String charset = val[1].trim();
+                    // Quite a lot of sites have charset="CHARSET",
+                    // e.g. charset="utf-8". Note the quotes. This is 
+                    // not correct, but client should be able to handle
+                    // it (all browsers do, Apache HTTP Client and Grizzly 
+                    // strip it by default)
+                    // This is a poor man's trim("\"").trim("'")
+                    return charset.replaceAll("\"", "").replaceAll("'", "")
                 }
             }
         }


### PR DESCRIPTION
Handle charsets that are quoted as if they were not (trim them). I encountered some sites that have charset="utf-8" instead of charset=utf-8 and can not access their content. All browsers however accept the charset.

Testcases: 
1.) parseCharset("\"utf-8\"") == "utf-8"
2.) parseCharset("'utf-8'")   == "utf-8"
