### PR TITLE
SpnegoEngine modifications for thread safety

### DIFF
--- a/src/main/java/com/ning/http/client/providers/netty/spnego/SpnegoEngine.java
+++ b/src/main/java/com/ning/http/client/providers/netty/spnego/SpnegoEngine.java
@@ -62,15 +62,6 @@ public class SpnegoEngine {
 
     private final SpnegoTokenGenerator spnegoGenerator;
 
-    private GSSContext gssContext = null;
-
-    /**
-     * base64 decoded challenge *
-     */
-    private byte[] token;
-
-    private Oid negotiationOid = null;
-
     public SpnegoEngine(final SpnegoTokenGenerator spnegoGenerator) {
         this.spnegoGenerator = spnegoGenerator;
     }
@@ -80,6 +71,9 @@ public class SpnegoEngine {
     }
 
     public String generateToken(String server) throws Throwable {
+        GSSContext gssContext = null;
+        byte[] token = null; // base64 decoded challenge
+        Oid negotiationOid = null;
 
         try {
             log.debug("init {}", server);


### PR DESCRIPTION
Some class attributes should be defined as local variables for thread safety.
(mainly gssContext, it must not be thread safe as it makes NPE under load). Problem discovered using gatling to load test a CAS / SPNEGO server.
