### PR TITLE
Don't retry if not realm-bound

### DIFF
--- a/providers/netty/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/providers/netty/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -2114,6 +2114,7 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
                     //}
 
                     if (statusCode == 401
+                            && realm != null
                             && wwwAuth.size() > 0
                             && !future.getAndSetAuth(true)) {
 
@@ -2171,6 +2172,7 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
 
                     List<String> proxyAuth = getAuthorizationToken(response.getHeaders(), HttpHeaders.Names.PROXY_AUTHENTICATE);
                     if (statusCode == 407
+                            && realm != null
                             && proxyAuth.size() > 0
                             && !future.getAndSetAuth(true)) {
 


### PR DESCRIPTION
Netty will retry the request when a 401 or 407 reponse is received even if there is no realm info at all. 
That just doesn't make sense. It's meat to be failed.
