### PR TITLE
Include units TimeoutException message

### DIFF
--- a/providers/netty/src/main/java/com/ning/http/client/providers/netty/NettyResponseFuture.java
+++ b/providers/netty/src/main/java/com/ning/http/client/providers/netty/NettyResponseFuture.java
@@ -212,7 +212,7 @@ public final class NettyResponseFuture<V> extends AbstractListenableFuture<V> {
 
             if (expired) {
                 isCancelled.set(true);
-                TimeoutException te = new TimeoutException(String.format("No response received after %s", l));
+                TimeoutException te = new TimeoutException(String.format("No response received after %s %s", l, tu.name().toLowerCase()));
                 if (!throwableCalled.getAndSet(true)) {
                     try {
                         asyncHandler.onThrowable(te);


### PR DESCRIPTION
Hey,

I was using AsyncHttpClient in a situation where the timeouts were being processed, and because of that were normalized to nanoseconds. When I saw the message on the TimeoutException, I was confused because it seemed as if the timeout I had specified (in ms) had been multiplied by 1000000. I fixed the message to include the time unit.

thanks,
/brian
