### PR TITLE
reset statusReceived when retrying connection

### DIFF
--- a/providers/netty/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/providers/netty/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -1415,6 +1415,7 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
         }
 
         future.setState(NettyResponseFuture.STATE.RECONNECTED);
+        future.getAndSetStatusReceived(false);
 
         log.debug("Trying to recover request {}\n", future.getNettyRequest());
 


### PR DESCRIPTION
otherwise handler.onStatusReceived is never called on the retry.
