### PR TITLE
FIX ISSUE #127 NettyAsyncHttpProdiver redirects ignoring case

### DIFF
--- a/providers/netty/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/providers/netty/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -1987,7 +1987,7 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
                 String location = response.getHeader(HttpHeaders.Names.LOCATION);
                 URI uri = AsyncHttpProviderUtils.getRedirectUri(future.getURI(), location);
                 boolean stripQueryString = config.isRemoveQueryParamOnRedirect();
-                if (!uri.toString().equalsIgnoreCase(future.getURI().toString())) {
+                if (!uri.toString().equals(future.getURI().toString())) {
                     final RequestBuilder nBuilder = stripQueryString ?
                             new RequestBuilder(future.getRequest()).setQueryParameters(null)
                             : new RequestBuilder(future.getRequest());


### PR DESCRIPTION
Issue #127 mentions that the NettyHttpProvider ignores case when checking for equality between the redirect Uri and the Future's Uri. This commit simply changes the equalsIgnoreCase to equals.
