### PR TITLE
HTTP 1.1 keepalive is only determined by presence of Connection: close.

### DIFF
--- a/providers/netty/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/providers/netty/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -2072,7 +2072,7 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
                     int statusCode = response.getStatus().getCode();
 
                     String ka = response.getHeader(HttpHeaders.Names.CONNECTION);
-                    future.setKeepAlive(ka == null || ka.toLowerCase().equals("keep-alive"));
+                    future.setKeepAlive(ka == null || ! ka.toLowerCase().equals("close"));
 
                     List<String> wwwAuth = getAuthorizationToken(response.getHeaders(), HttpHeaders.Names.WWW_AUTHENTICATE);
                     Realm realm = request.getRealm() != null ? request.getRealm() : config.getRealm();


### PR DESCRIPTION
The RFC for HTTP 1.1 only states that keepalive should be terminated on presence of Connection:close. The default behavior in 1.1 is to keep the connection open, so the presence of a Connection: keep-alive is optional. I believe the keep-alive status was for 1.0 persistent connection negotiation.

This patch doesn't look at the HTTP version. The existing code would have had issues with 1.0 as well, so I'm assuming we can safely ignore that. 

The grizly provider seems to have the proper logic in it already.
