### PR TITLE
Javadoc typo

### DIFF
--- a/api/src/main/java/com/ning/http/client/AsyncHttpClientConfig.java
+++ b/api/src/main/java/com/ning/http/client/AsyncHttpClientConfig.java
@@ -906,7 +906,7 @@ public class AsyncHttpClientConfig {
         /**
          * Set the number of times a request will be retried when an {@link java.io.IOException} occurs because of a Network exception.
          *
-         * @param maxRequestRetry the number of time a request will be retried
+         * @param maxRequestRetry the number of times a request will be retried
          * @return this
          */
         public Builder setMaxRequestRetry(int maxRequestRetry) {


### PR DESCRIPTION
a tiny typo I found in the javadocs for setMaxRequestRetry
