### PR TITLE
Fixed nonProxyHosts handling for SSL hosts

### DIFF
--- a/providers/grizzly/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyAsyncHttpProvider.java
+++ b/providers/grizzly/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyAsyncHttpProvider.java
@@ -850,7 +850,8 @@ public class GrizzlyAsyncHttpProvider implements AsyncHttpProvider {
                 }
             }
             final ProxyServer proxy = getProxyServer(request);
-            final boolean useProxy = (proxy != null);
+            boolean avoidProxy = ProxyUtils.avoidProxy(proxy, request);
+            final boolean useProxy = !(avoidProxy || proxy == null);
             if (useProxy) {
                 if ((secure || httpCtx.isWSRequest) && !httpCtx.isTunnelEstablished(ctx.getConnection())) {
                     secure = false;
@@ -898,16 +899,13 @@ public class GrizzlyAsyncHttpProvider implements AsyncHttpProvider {
             addCookies(request, requestPacket);
 
             if (useProxy) {
-                boolean avoidProxy = ProxyUtils.avoidProxy(proxy, request);
-                if (!avoidProxy) {
-                    if (!requestPacket.getHeaders().contains(Header.ProxyConnection)) {
-                        requestPacket.setHeader(Header.ProxyConnection, "keep-alive");
-                    }
+                if (!requestPacket.getHeaders().contains(Header.ProxyConnection)) {
+                    requestPacket.setHeader(Header.ProxyConnection, "keep-alive");
+                }
 
-                    if (proxy.getPrincipal() != null) {
-                        requestPacket.setHeader(Header.ProxyAuthorization,
-                                AuthenticatorUtils.computeBasicAuthentication(proxy));
-                    }
+                if (proxy.getPrincipal() != null) {
+                    requestPacket.setHeader(Header.ProxyAuthorization,
+                            AuthenticatorUtils.computeBasicAuthentication(proxy));
                 }
             }
             final AsyncHandler h = httpCtx.handler;


### PR DESCRIPTION
When connecting to an HTTPS host that matches a configured nonProxyHost, both the grizzly and the netty providers do the following things wrong:
- They make a non SSL connection direct to the target host, instead of making an SSL connection
- They attempt to make an CONNECT request, and if it succeeds (which it usually won't because they aren't using SSL and the host is an HTTPS host) they attempt to tunnel a second HTTP request as if they are using a proxy

This fix ensures that an HTTPS connection is used, and ensures that no CONNECT tunnelling is done in this situation.

Consequently it also affects HTTP nonProxyHost handling, in that requests matching a nonProxyHost made to HTTP hosts use a URI relative to the host, rather than an absolute http://hostname/path host.
