### PR TITLE
Fixed nonProxyHosts handling for SSL hosts

### DIFF
--- a/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyAsyncHttpProvider.java
@@ -855,7 +855,8 @@ public class GrizzlyAsyncHttpProvider implements AsyncHttpProvider {
                 }
             }
             final ProxyServer proxy = getProxyServer(request);
-            final boolean useProxy = (proxy != null);
+            boolean avoidProxy = ProxyUtils.avoidProxy(proxy, request);
+            final boolean useProxy = !(avoidProxy || proxy == null);
             if (useProxy) {
                 if ((secure || httpCtx.isWSRequest) && !httpCtx.isTunnelEstablished(ctx.getConnection())) {
                     secure = false;
@@ -903,16 +904,13 @@ public class GrizzlyAsyncHttpProvider implements AsyncHttpProvider {
             addCookies(request, requestPacket);
 
             if (useProxy) {
-                boolean avoidProxy = ProxyUtils.avoidProxy(proxy, request);
-                if (!avoidProxy) {
-                    if (!requestPacket.getHeaders().contains(Header.ProxyConnection)) {
-                        requestPacket.setHeader(Header.ProxyConnection, "keep-alive");
-                    }
+                if (!requestPacket.getHeaders().contains(Header.ProxyConnection)) {
+                    requestPacket.setHeader(Header.ProxyConnection, "keep-alive");
+                }
 
-                    if (proxy.getPrincipal() != null) {
-                        requestPacket.setHeader(Header.ProxyAuthorization,
-                                AuthenticatorUtils.computeBasicAuthentication(proxy));
-                    }
+                if (proxy.getPrincipal() != null) {
+                    requestPacket.setHeader(Header.ProxyAuthorization,
+                            AuthenticatorUtils.computeBasicAuthentication(proxy));
                 }
             }
             final AsyncHandler h = httpCtx.handler;

--- a/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -578,7 +578,15 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
     }
 
     private static boolean isProxyServer(AsyncHttpClientConfig config, Request request) {
-        return request.getProxyServer() != null || config.getProxyServer() != null;
+        ProxyServer proxyServer = request.getProxyServer();
+        if (proxyServer == null) {
+            proxyServer = config.getProxyServer();
+        }
+        if (proxyServer == null) {
+            return false;
+        } else {
+            return !ProxyUtils.avoidProxy(proxyServer, request);
+        }
     }
 
     protected final static HttpRequest buildRequest(AsyncHttpClientConfig config, Request request, URI uri,
@@ -951,7 +959,10 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
             bufferedBytes = f.getNettyRequest().getContent();
         }
 
-        boolean useSSl = isSecure(uri) && proxyServer == null;
+        boolean avoidProxy = ProxyUtils.avoidProxy(proxyServer, uri.getHost());
+        boolean useProxy = !(avoidProxy || proxyServer == null);
+
+        boolean useSSl = isSecure(uri) && !useProxy;
         if (channel != null && channel.isOpen() && channel.isConnected()) {
             HttpRequest nettyRequest = buildRequest(config, request, uri, f == null ? false : f.isConnectAllowed(), bufferedBytes);
 
@@ -1018,7 +1029,6 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
         }
 
         NettyConnectListener<T> c = new NettyConnectListener.Builder<T>(config, request, asyncHandler, f, this, bufferedBytes).build(uri);
-        boolean avoidProxy = ProxyUtils.avoidProxy(proxyServer, uri.getHost());
 
         if (useSSl) {
             constructSSLPipeline(c);
@@ -1037,7 +1047,7 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
             InetSocketAddress remoteAddress;
             if (request.getInetAddress() != null) {
                 remoteAddress = new InetSocketAddress(request.getInetAddress(), AsyncHttpProviderUtils.getPort(uri));
-            } else if (proxyServer == null || avoidProxy) {
+            } else if (!useProxy) {
                 remoteAddress = new InetSocketAddress(AsyncHttpProviderUtils.getHost(uri), AsyncHttpProviderUtils.getPort(uri));
             } else {
                 remoteAddress = new InetSocketAddress(proxyServer.getHost(), proxyServer.getPort());

--- a/src/test/java/com/ning/http/client/async/ProxyyTunnellingTest.java
+++ b/src/test/java/com/ning/http/client/async/ProxyyTunnellingTest.java
@@ -28,11 +28,13 @@ import org.eclipse.jetty.server.ssl.SslSocketConnector;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.testng.Assert.assertEquals;
@@ -163,6 +165,21 @@ public abstract class ProxyyTunnellingTest extends AbstractBasicTest {
 
         assertEquals(r.getStatusCode(), 200);
         assertEquals(r.getHeader("X-Proxy-Connection"), "keep-alive");
+
+        client.close();
+    }
+
+    @Test(groups = { "standalone", "default_provider" })
+    public void testNonProxyHostsSsl() throws IOException, ExecutionException, TimeoutException, InterruptedException {
+        AsyncHttpClient client = getAsyncHttpClient(null);
+
+        Response resp = client.prepareGet(getTargetUrl2()).setProxyServer(new ProxyServer("127.0.0.1", port1 - 1)
+                .addNonProxyHost("127.0.0.1"))
+                .execute().get(3, TimeUnit.SECONDS);
+
+        assertNotNull(resp);
+        assertEquals(resp.getStatusCode(), HttpServletResponse.SC_OK);
+        assertEquals(resp.getHeader("X-pathInfo"), "/foo/test");
 
         client.close();
     }


### PR DESCRIPTION
This fixes the case when an https host matches a nonProxyHost, ensuring that a direct https request is made correctly.
