### PR TITLE
-fix: Change the delay of the reaperFuture to be the minimum of the requ...

### DIFF
--- a/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -564,7 +564,7 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
 
         try {
             future.touch();
-            int delay = requestTimeout(config, future.getRequest().getPerRequestConfig());
+            int delay = Math.min(config.getIdleConnectionTimeoutInMs(), requestTimeout(config, future.getRequest().getPerRequestConfig()));
             if (delay != -1 && !future.isDone() && !future.isCancelled()) {
                 ReaperFuture reaperFuture = new ReaperFuture(future);
                 Future scheduledFuture = config.reaper().scheduleAtFixedRate(reaperFuture, 0, delay, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Requests executed using NettyAsyncHttpProvider are not timing out if the idleConnectionTimeout is exceeded.
The reason is that the ReaperFuture is scheduled at a rate of "requestTimeout".
My change is scheduling it at a rate of Min(idleConnectionTimeout, requestTimeout)
