### PR TITLE
Following HTTP RFC, GET can contain a BODY

### DIFF
--- a/api/src/main/java/com/ning/http/client/RequestBuilderBase.java
+++ b/api/src/main/java/com/ning/http/client/RequestBuilderBase.java
@@ -459,8 +459,8 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
     }
 
     private void checkIfBodyAllowed() {
-        if ("GET".equals(request.method) || "HEAD".equals(request.method)) {
-            throw new IllegalArgumentException("Can NOT set Body on HTTP Request Method GET nor HEAD.");
+        if ("HEAD".equals(request.method)) {
+            throw new IllegalArgumentException("Can NOT set Body on HTTP Request Method HEAD.");
         }
     }
 


### PR DESCRIPTION
Hey,

[RFC 2616](http://tools.ietf.org/html/rfc2616#section-4.3) does not forbide using BODY in GET requests.

See also this [thread](http://tech.groups.yahoo.com/group/rest-discuss/message/9962)

So here comes this pull request.

Hope this helps
