### PR TITLE
making the  proxy with digest work

### DIFF
--- a/api/src/main/java/com/ning/http/client/ProxyServer.java
+++ b/api/src/main/java/com/ning/http/client/ProxyServer.java
@@ -53,7 +53,17 @@ public class ProxyServer {
     private int port;
     private String ntlmDomain = System.getProperty("http.auth.ntlm.domain", "");
 
-    public ProxyServer(final Protocol protocol, final String host, final int port, String principal, String password) {
+    private boolean isBasic = true;
+    
+    public boolean isBasic() {
+		return isBasic;
+	}
+
+	public void setBasic(boolean isBasic) {
+		this.isBasic = isBasic;
+	}
+
+	public ProxyServer(final Protocol protocol, final String host, final int port, String principal, String password) {
         this.protocol = protocol;
         this.host = host;
         this.port = port;

--- a/api/src/main/java/com/ning/http/client/Realm.java
+++ b/api/src/main/java/com/ning/http/client/Realm.java
@@ -439,6 +439,19 @@ public class Realm {
             return this;
         }
 
+        public RealmBuilder parseProxyAuthenticateHeader(String headerLine) {
+            setRealmName(match(headerLine, "realm"));
+            setNonce(match(headerLine, "nonce"));
+            setOpaque(match(headerLine, "opaque"));
+            setQop(match(headerLine, "qop"));
+            if (getNonce() != null && !getNonce().equalsIgnoreCase("")) {
+                setScheme(AuthScheme.DIGEST);
+            } else {
+                setScheme(AuthScheme.BASIC);
+            }
+            return this;
+        }
+        
         public RealmBuilder setNtlmMessageType2Received(boolean messageType2Received) {
             this.messageType2Received = messageType2Received;
             return this;

--- a/api/src/main/java/com/ning/http/util/AuthenticatorUtils.java
+++ b/api/src/main/java/com/ning/http/util/AuthenticatorUtils.java
@@ -49,6 +49,18 @@ public final class AuthenticatorUtils {
         return new String(builder.toString().getBytes("ISO_8859_1"));
     }
 
+	public static String computeDigestAuthentication(ProxyServer proxy) {
+		try{
+	        StringBuilder builder = new StringBuilder().append("Digest ");
+	        construct(builder, "username", proxy.getPrincipal(),true);
+	        return new String(builder.toString().getBytes("ISO_8859_1"));
+		}
+		catch (Exception e){
+			e.printStackTrace();
+		}
+		return null;
+	}
+
     private static StringBuilder construct(StringBuilder builder, String name, String value) {
         return construct(builder, name, value, false);
     }


### PR DESCRIPTION
in case the digest auth on proxy

based on a flag in proxy, sending the realm etc.. info on challenge and retuning on onHttpHeadersParsed in case we don;t find protocolHandler. so that antoher grizly request goes after the auth.
