### PR TITLE
Allow Netty provider subclass to modify pipeline

### DIFF
--- a/providers/netty/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/providers/netty/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -244,26 +244,7 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
             }
         }
 
-        plainBootstrap.setPipelineFactory(new ChannelPipelineFactory() {
-
-            /* @Override */
-            public ChannelPipeline getPipeline() throws Exception {
-                ChannelPipeline pipeline = pipeline();
-
-                pipeline.addLast(HTTP_HANDLER, new HttpClientCodec());
-
-                if (config.getRequestCompressionLevel() > 0) {
-                    pipeline.addLast("deflater", new HttpContentCompressor(config.getRequestCompressionLevel()));
-                }
-
-                if (config.isCompressionEnabled()) {
-                    pipeline.addLast("inflater", new HttpContentDecompressor());
-                }
-                pipeline.addLast("chunkedWriter", new ChunkedWriteHandler());
-                pipeline.addLast("httpProcessor", NettyAsyncHttpProvider.this);
-                return pipeline;
-            }
-        });
+        plainBootstrap.setPipelineFactory(createPlainPipelineFactory());
         DefaultChannelFuture.setUseDeadLockChecker(false);
 
         if (asyncHttpProviderConfig != null) {
@@ -286,6 +267,29 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
                 return pipeline;
             }
         });
+    }
+
+    protected ChannelPipelineFactory createPlainPipelineFactory() {
+    	return new ChannelPipelineFactory() {
+
+            /* @Override */
+            public ChannelPipeline getPipeline() throws Exception {
+                ChannelPipeline pipeline = pipeline();
+
+                pipeline.addLast(HTTP_HANDLER, new HttpClientCodec());
+
+                if (config.getRequestCompressionLevel() > 0) {
+                    pipeline.addLast("deflater", new HttpContentCompressor(config.getRequestCompressionLevel()));
+                }
+
+                if (config.isCompressionEnabled()) {
+                    pipeline.addLast("inflater", new HttpContentDecompressor());
+                }
+                pipeline.addLast("chunkedWriter", new ChunkedWriteHandler());
+                pipeline.addLast("httpProcessor", NettyAsyncHttpProvider.this);
+                return pipeline;
+            }
+        };
     }
 
     void constructSSLPipeline(final NettyConnectListener<?> cl) {

--- a/providers/netty/src/test/java/com/ning/http/client/providers/netty/NettyAsyncProviderPipelineTest.java
+++ b/providers/netty/src/test/java/com/ning/http/client/providers/netty/NettyAsyncProviderPipelineTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2010-2012 Sonatype, Inc. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+package com.ning.http.client.providers.netty;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelPipeline;
+import org.jboss.netty.channel.ChannelPipelineFactory;
+import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.channel.SimpleChannelHandler;
+import org.jboss.netty.handler.codec.http.HttpMessage;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.AsyncHttpClientConfig;
+import com.ning.http.client.Request;
+import com.ning.http.client.RequestBuilder;
+import com.ning.http.client.Response;
+import com.ning.http.client.async.AbstractBasicTest;
+
+public class NettyAsyncProviderPipelineTest extends AbstractBasicTest {
+
+    @Override
+    public AsyncHttpClient getAsyncHttpClient(AsyncHttpClientConfig config) {
+        return new AsyncHttpClient(new CopyEncodingNettyAsyncHttpProvider(config), config);
+    }
+
+    @Test(groups = {"standalone", "netty_provider"})
+    public void asyncPipelineTest() throws Throwable {
+        AsyncHttpClient p = getAsyncHttpClient(new AsyncHttpClientConfig.Builder()
+                .setCompressionEnabled(true).build());
+
+        final CountDownLatch l = new CountDownLatch(1);
+        Request request = new RequestBuilder("GET").setUrl(getTargetUrl()).build();
+        p.executeRequest(request, new AsyncCompletionHandlerAdapter() {
+            @Override
+            public Response onCompleted(Response response) throws Exception {
+                try {
+                    assertEquals(response.getStatusCode(), 200);
+                    assertEquals(response.getHeader("X-Original-Content-Encoding"), "<original encoding>");
+                } finally {
+                    l.countDown();
+                }
+                return response;
+            }
+        }).get();
+        if (!l.await(TIMEOUT, TimeUnit.SECONDS)) {
+            Assert.fail("Timeout out");
+        }
+        p.close();
+    }
+
+    private static class CopyEncodingNettyAsyncHttpProvider extends NettyAsyncHttpProvider {
+        public CopyEncodingNettyAsyncHttpProvider(AsyncHttpClientConfig config) {
+            super(config);
+        }
+        protected ChannelPipelineFactory createPlainPipelineFactory() {
+            final ChannelPipelineFactory pipelineFactory = super.createPlainPipelineFactory();
+            return new ChannelPipelineFactory() {
+                public ChannelPipeline getPipeline() throws Exception {
+                    ChannelPipeline pipeline = pipelineFactory.getPipeline();
+                    pipeline.addBefore("inflater", "copyEncodingHeader", new CopyEncodingHandler());
+                    return pipeline;
+                }
+            };
+        }
+    }
+
+    private static class CopyEncodingHandler extends SimpleChannelHandler {
+        @Override
+        public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) {
+            Object msg = e.getMessage();
+            if (msg instanceof HttpMessage) {
+                HttpMessage m = (HttpMessage) msg;
+                // for test there is no Content-Encoding header so just hard coding value
+                // for verification
+                m.setHeader("X-Original-Content-Encoding", "<original encoding>");
+            }
+            ctx.sendUpstream(e);
+        }
+    }
+}


### PR DESCRIPTION
As part of a unit test, I want to verify that an http response was gzipped, however Netty's HttpContentDecoder removes the Content-Encoding header during decompression, which makes sense, but is thwarting my attempt to verify whether the response was indeed gzipped.

To work around this, I'd like to insert a ChannelHandler in the Netty pipeline before the "inflater" ChannelHandler, e.g.

```
    pipeline.addBefore("inflater", "gzipDetection", new GzipDetectionHandler());
```

so I can copy the original Content-Encoding header over to another http header before the HttpContentDecoder clears that header.

I mocked up a change to NettyAsyncHttpProvider to expose enough so the Netty pipeline can be modified, and included a unit test to show an example of how this could be used.

I'm curious if this is something you would consider.
