### PR TITLE
Introduce ConnectionPoolKeyStrategy

### DIFF
--- a/api/src/main/java/com/ning/http/client/ConnectionPoolKeyStrategy.java
+++ b/api/src/main/java/com/ning/http/client/ConnectionPoolKeyStrategy.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2010 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.http.client;
+
+import java.net.URI;
+
+public interface ConnectionPoolKeyStrategy {
+
+	String getKey(URI uri);
+}

--- a/api/src/main/java/com/ning/http/client/DefaultConnectionPoolStrategy.java
+++ b/api/src/main/java/com/ning/http/client/DefaultConnectionPoolStrategy.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2010 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.http.client;
+
+import java.net.URI;
+
+import com.ning.http.util.AsyncHttpProviderUtils;
+
+public enum DefaultConnectionPoolStrategy implements ConnectionPoolKeyStrategy {
+
+	INSTANCE;
+	
+	@Override
+	public String getKey(URI uri) {
+		return AsyncHttpProviderUtils.getBaseUrl(uri);
+	}
+}

--- a/api/src/main/java/com/ning/http/client/Request.java
+++ b/api/src/main/java/com/ning/http/client/Request.java
@@ -232,4 +232,5 @@ public interface Request {
 
     public boolean isUseRawUrl();
 
+    ConnectionPoolKeyStrategy getConnectionPoolKeyStrategy();
 }

--- a/api/src/main/java/com/ning/http/client/RequestBuilderBase.java
+++ b/api/src/main/java/com/ning/http/client/RequestBuilderBase.java
@@ -67,6 +67,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
         private long rangeOffset = 0;
         public String charset;
         private boolean useRawUrl = false;
+        private ConnectionPoolKeyStrategy connectionPoolKeyStrategy = DefaultConnectionPoolStrategy.INSTANCE;
 
         public RequestImpl(boolean useRawUrl) {
             this.useRawUrl = useRawUrl;
@@ -100,6 +101,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
                 this.rangeOffset = prototype.getRangeOffset();
                 this.charset = prototype.getBodyEncoding();
                 this.useRawUrl = prototype.isUseRawUrl();
+                this.connectionPoolKeyStrategy = prototype.getConnectionPoolKeyStrategy();
             }
         }
 
@@ -285,6 +287,10 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
 
         public String getBodyEncoding() {
             return charset;
+        }
+
+        public ConnectionPoolKeyStrategy getConnectionPoolKeyStrategy() {
+        	return connectionPoolKeyStrategy;
         }
 
         @Override
@@ -601,6 +607,11 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
     public T setBodyEncoding(String charset) {
         request.charset = charset;
         return derived.cast(this);
+    }
+
+    public T setConnectionPoolKeyStrategy(ConnectionPoolKeyStrategy connectionPoolKeyStrategy) {
+    	request.connectionPoolKeyStrategy = connectionPoolKeyStrategy;
+    	return derived.cast(this);
     }
 
     public Request build() {

--- a/providers/netty/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/providers/netty/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -21,6 +21,7 @@ import com.ning.http.client.AsyncHttpClientConfig;
 import com.ning.http.client.AsyncHttpProvider;
 import com.ning.http.client.Body;
 import com.ning.http.client.BodyGenerator;
+import com.ning.http.client.ConnectionPoolKeyStrategy;
 import com.ning.http.client.ConnectionsPool;
 import com.ning.http.client.Cookie;
 import com.ning.http.client.FluentCaseInsensitiveStringsMap;
@@ -345,8 +346,9 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
         }
     }
 
-    private Channel lookupInCache(URI uri) {
-        final Channel channel = connectionsPool.poll(AsyncHttpProviderUtils.getBaseUrl(uri));
+    private Channel lookupInCache(URI uri, ConnectionPoolKeyStrategy connectionPoolKeyStrategy) {
+
+    	final Channel channel = connectionsPool.poll(connectionPoolKeyStrategy.getKey(uri));
 
         if (channel != null) {
             log.debug("Using cached Channel {}\n for uri {}\n", channel, uri);
@@ -910,7 +912,7 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
             if (f != null && f.reuseChannel() && f.channel() != null) {
                 channel = f.channel();
             } else {
-                channel = lookupInCache(uri);
+                channel = lookupInCache(uri, request.getConnectionPoolKeyStrategy());
             }
         }
 
@@ -1271,7 +1273,8 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
     private void drainChannel(final ChannelHandlerContext ctx, final NettyResponseFuture<?> future, final boolean keepAlive, final URI uri) {
         ctx.setAttachment(new AsyncCallable(future) {
             public Object call() throws Exception {
-                if (keepAlive && ctx.getChannel().isReadable() && connectionsPool.offer(AsyncHttpProviderUtils.getBaseUrl(uri), ctx.getChannel())) {
+            	// TODO POOL
+                if (keepAlive && ctx.getChannel().isReadable() && connectionsPool.offer(future.getConnectionPoolKeyStrategy().getKey(uri), ctx.getChannel())) {
                     return null;
                 }
 
@@ -1467,8 +1470,9 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
         if (lastValidChunk && future.getKeepAlive()) {
             drainChannel(ctx, future, future.getKeepAlive(), future.getURI());
         } else {
+        	// TODO POOL
             if (future.getKeepAlive() && ctx.getChannel().isReadable() &&
-                    connectionsPool.offer(AsyncHttpProviderUtils.getBaseUrl(future.getURI()), ctx.getChannel())) {
+                    connectionsPool.offer(future.getConnectionPoolKeyStrategy().getKey(future.getURI()), ctx.getChannel())) {
                 markAsDone(future, ctx);
                 return;
             }
@@ -1666,7 +1670,7 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
                                                        NettyAsyncHttpProvider provider) {
 
         NettyResponseFuture<T> f = new NettyResponseFuture<T>(uri, request, asyncHandler, nettyRequest,
-                requestTimeout(config, request.getPerRequestConfig()), config.getIdleConnectionTimeoutInMs(), provider);
+                requestTimeout(config, request.getPerRequestConfig()), config.getIdleConnectionTimeoutInMs(), provider, request.getConnectionPoolKeyStrategy());
 
         if (request.getHeaders().getFirstValue("Expect") != null
                 && request.getHeaders().getFirstValue("Expect").equalsIgnoreCase("100-Continue")) {
@@ -2036,10 +2040,11 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
                         nBuilder.addOrReplaceCookie(c);
                     }
 
+                    final String connectionPoolKey = future.getConnectionPoolKeyStrategy().getKey(initialConnectionUri);
                     AsyncCallable ac = new AsyncCallable(future) {
                         public Object call() throws Exception {
                             if (initialConnectionKeepAlive && ctx.getChannel().isReadable() &&
-                                    connectionsPool.offer(AsyncHttpProviderUtils.getBaseUrl(initialConnectionUri), ctx.getChannel())) {
+                                    connectionsPool.offer(connectionPoolKey, ctx.getChannel())) {
                                 return null;
                             }
                             finishChannel(ctx);

--- a/providers/netty/src/main/java/com/ning/http/client/providers/netty/NettyResponseFuture.java
+++ b/providers/netty/src/main/java/com/ning/http/client/providers/netty/NettyResponseFuture.java
@@ -16,6 +16,7 @@
 package com.ning.http.client.providers.netty;
 
 import com.ning.http.client.AsyncHandler;
+import com.ning.http.client.ConnectionPoolKeyStrategy;
 import com.ning.http.client.Request;
 import com.ning.http.client.listenable.AbstractListenableFuture;
 import org.jboss.netty.channel.Channel;
@@ -85,14 +86,16 @@ public final class NettyResponseFuture<V> extends AbstractListenableFuture<V> {
     private boolean writeBody;
     private final AtomicBoolean throwableCalled = new AtomicBoolean(false);
     private boolean allowConnect = false;
-
+    private final ConnectionPoolKeyStrategy connectionPoolKeyStrategy;
+    
     public NettyResponseFuture(URI uri,
                                Request request,
                                AsyncHandler<V> asyncHandler,
                                HttpRequest nettyRequest,
                                int responseTimeoutInMs,
                                int idleConnectionTimeoutInMs,
-                               NettyAsyncHttpProvider asyncHttpProvider) {
+                               NettyAsyncHttpProvider asyncHttpProvider,
+                               ConnectionPoolKeyStrategy connectionPoolKeyStrategy) {
 
         this.asyncHandler = asyncHandler;
         this.responseTimeoutInMs = responseTimeoutInMs;
@@ -101,6 +104,7 @@ public final class NettyResponseFuture<V> extends AbstractListenableFuture<V> {
         this.nettyRequest = nettyRequest;
         this.uri = uri;
         this.asyncHttpProvider = asyncHttpProvider;
+        this.connectionPoolKeyStrategy = connectionPoolKeyStrategy;
 
         if (System.getProperty(MAX_RETRY) != null) {
             maxRetry = Integer.valueOf(System.getProperty(MAX_RETRY));
@@ -118,6 +122,10 @@ public final class NettyResponseFuture<V> extends AbstractListenableFuture<V> {
     protected void setURI(URI uri) {
         this.uri = uri;
     }
+
+	public ConnectionPoolKeyStrategy getConnectionPoolKeyStrategy() {
+		return connectionPoolKeyStrategy;
+	}
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
The general idea is to be able to control at request level the connection used to sent it.
This is implemented with an optional `ConnectionPoolKeyStrategy` passed on the Request object.

For example, one can pass a `ConnectionPoolKeyStrategy` that combines a user UUID the default `DefaultConnectionPoolStrategy`.

Currently only works for Netty provider.
