### PR TITLE
Allows to configure Netty NioClientSocketChannelFactory for 1.7-AHC

### DIFF
--- a/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProviderConfig.java
+++ b/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProviderConfig.java
@@ -71,6 +71,11 @@ public class NettyAsyncHttpProviderConfig implements AsyncHttpProviderConfig<Str
     public final static String HTTPS_CLIENT_CODEC_MAX_HEADER_SIZE = "httpsClientCodecMaxHeaderSize";
     public final static String HTTPS_CLIENT_CODEC_MAX_CHUNK_SIZE = "httpsClientCodecMaxChunkSize";
 
+    /**
+     * Allow configuring the Netty's socket channel factory.
+     */
+    public final static String SOCKET_CHANNEL_FACTORY = "socketChannelFactory";
+
     private final ConcurrentHashMap<String, Object> properties = new ConcurrentHashMap<String, Object>();
 
     public NettyAsyncHttpProviderConfig() {


### PR DESCRIPTION
Allow to configure NioClientSocketChannelFactory to NettyAsyncHttpProvider via property in NettyAsyncHttpProviderConfig for 1.7-AHC
