### PR TITLE
Optimize URI.create/String round trips, fix #139

### DIFF
--- a/src/main/java/com/ning/http/client/Request.java
+++ b/src/main/java/com/ning/http/client/Request.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
+import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 
@@ -65,6 +66,10 @@ public interface Request {
      * @return the decoded url
      */
     public String getUrl();
+
+    public URI getOriginalURI();
+    public URI getURI();
+    public URI getRawURI();
 
     /**
      * Return the InetAddress to override

--- a/src/main/java/com/ning/http/client/RequestBuilderBase.java
+++ b/src/main/java/com/ning/http/client/RequestBuilderBase.java
@@ -18,6 +18,7 @@ package com.ning.http.client;
 import static com.ning.http.util.MiscUtil.isNonEmpty;
 
 import com.ning.http.client.Request.EntityWriter;
+import com.ning.http.util.AsyncHttpProviderUtils;
 import com.ning.http.util.UTF8UrlEncoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,15 +39,19 @@ import java.util.Map.Entry;
 
 /**
  * Builder for {@link Request}
- *
+ * 
  * @param <T>
  */
 public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
     private final static Logger logger = LoggerFactory.getLogger(RequestBuilderBase.class);
 
+    private static final URI DEFAULT_REQUEST_URL = URI.create("http://localhost");
+
     private static final class RequestImpl implements Request {
         private String method;
-        private String url = null;
+        private URI originalUri = null;
+        private URI uri = null;
+        private URI rawUri = null;
         private InetAddress address = null;
         private InetAddress localAddress = null;
         private FluentCaseInsensitiveStringsMap headers = new FluentCaseInsensitiveStringsMap();
@@ -78,9 +83,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
         public RequestImpl(Request prototype) {
             if (prototype != null) {
                 this.method = prototype.getMethod();
-                String prototypeUrl = prototype.getUrl();
-                int pos = prototypeUrl.indexOf("?");
-                this.url = pos > 0 ? prototypeUrl.substring(0, pos) : prototypeUrl;
+                this.originalUri = prototype.getOriginalURI();
                 this.address = prototype.getInetAddress();
                 this.localAddress = prototype.getLocalAddress();
                 this.headers = new FluentCaseInsensitiveStringsMap(prototype.getHeaders());
@@ -117,12 +120,6 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
             return method;
         }
 
-        /* @Override */
-
-        public String getUrl() {
-            return toUrl(true);
-        }
-
         public InetAddress getInetAddress() {
             return address;
         }
@@ -131,34 +128,66 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
             return localAddress;
         }
 
-        private String toUrl(boolean encode) {
+        private String removeTrailingSlash(URI uri) {
+            String uriString = uri.toString();
+            if (uriString.endsWith("/")) {
+                return uriString.substring(0, uriString.length() - 1);
+            } else {
+                return uriString;
+            }
+        }
 
-            if (url == null) {
+        /* @Override */
+        public String getUrl() {
+            return removeTrailingSlash(getURI());
+        }
+
+        /* @Override */
+        public String getRawUrl() {
+            return removeTrailingSlash(getRawURI());
+        }
+
+        public URI getOriginalURI() {
+            return originalUri;
+        }
+
+        public URI getURI() {
+            if (uri == null)
+                uri = toURI(true);
+            return uri;
+        }
+
+        public URI getRawURI() {
+            if (rawUri == null)
+                rawUri = toURI(false);
+            return rawUri;
+        }
+
+        private URI toURI(boolean encode) {
+
+            if (originalUri == null) {
                 logger.debug("setUrl hasn't been invoked. Using http://localhost");
-                url = "http://localhost";
+                originalUri = DEFAULT_REQUEST_URL;
             }
 
-            String uri = url;
-            if (!uri.startsWith("ws")) {
-                try {
-                    uri = URI.create(url).toURL().toString();
-                } catch (Throwable e) {
-                    throw new IllegalArgumentException("Illegal URL: " + url, e);
-                }
+            AsyncHttpProviderUtils.validateSupportedScheme(originalUri);
+
+            StringBuilder builder = new StringBuilder();
+            builder.append(originalUri.getScheme()).append("://").append(originalUri.getAuthority());
+            if (isNonEmpty(originalUri.getRawPath())) {
+                builder.append(originalUri.getRawPath());
+            } else {
+                builder.append("/");
             }
 
             if (isNonEmpty(queryParams)) {
 
-                StringBuilder builder = new StringBuilder();
-                if (!url.substring(8).contains("/")) { // no other "/" than http[s]:// -> http://localhost:1234
-                    builder.append("/");
-                }
                 builder.append("?");
 
-                for (Iterator<Entry<String, List<String>>> i = queryParams.iterator(); i.hasNext(); ) {
+                for (Iterator<Entry<String, List<String>>> i = queryParams.iterator(); i.hasNext();) {
                     Map.Entry<String, List<String>> param = i.next();
                     String name = param.getKey();
-                    for (Iterator<String> j = param.getValue().iterator(); j.hasNext(); ) {
+                    for (Iterator<String> j = param.getValue().iterator(); j.hasNext();) {
                         String value = j.next();
                         if (encode) {
                             UTF8UrlEncoder.appendEncoded(builder, name);
@@ -181,14 +210,9 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
                         builder.append('&');
                     }
                 }
-                uri += builder.toString();
             }
-            return uri;
-        }
 
-        /* @Override */
-        public String getRawUrl() {
-            return toUrl(false);
+            return URI.create(builder.toString());
         }
 
         /* @Override */
@@ -292,12 +316,12 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
         }
 
         public ConnectionPoolKeyStrategy getConnectionPoolKeyStrategy() {
-        	return connectionPoolKeyStrategy;
-       }
-        
+            return connectionPoolKeyStrategy;
+        }
+
         @Override
         public String toString() {
-            StringBuilder sb = new StringBuilder(url);
+            StringBuilder sb = new StringBuilder(getURI().toString());
 
             sb.append("\t");
             sb.append(method);
@@ -346,7 +370,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
     }
 
     public T setUrl(String url) {
-        request.url = buildUrl(url);
+        request.originalUri = buildURI(url);
         return derived.cast(this);
     }
 
@@ -360,7 +384,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
         return derived.cast(this);
     }
 
-    private String buildUrl(String url) {
+    private URI buildURI(String url) {
         URI uri = URI.create(url);
         StringBuilder buildedUrl = new StringBuilder();
 
@@ -380,7 +404,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
             if (url.indexOf("://") == -1) {
                 String s = buildedUrl.toString();
                 url = s + url.substring(uri.getScheme().length() + 1);
-                return buildUrl(url);
+                return buildURI(url);
             } else {
                 throw new IllegalArgumentException("Invalid url " + uri.toString());
             }
@@ -395,7 +419,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
                     addQueryParameter(query, null);
                 } else {
                     try {
-                        if (this.useRawUrl) {
+                        if (useRawUrl) {
                             addQueryParameter(query.substring(0, pos), query.substring(pos + 1));
                         } else {
                             addQueryParameter(URLDecoder.decode(query.substring(0, pos), "UTF-8"), URLDecoder.decode(query.substring(pos + 1), "UTF-8"));
@@ -406,9 +430,8 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
                 }
             }
         }
-        return buildedUrl.toString();
+        return uri;
     }
-
 
     public T setVirtualHost(String virtualHost) {
         request.virtualHost = virtualHost;
@@ -612,8 +635,8 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
     }
 
     public T setConnectionPoolKeyStrategy(ConnectionPoolKeyStrategy connectionPoolKeyStrategy) {
-    	request.connectionPoolKeyStrategy = connectionPoolKeyStrategy;
-    	return derived.cast(this);
+        request.connectionPoolKeyStrategy = connectionPoolKeyStrategy;
+        return derived.cast(this);
     }
 
     public Request build() {
@@ -633,13 +656,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
     }
 
     private boolean allowBody(String method) {
-        if (method.equalsIgnoreCase("GET") || method.equalsIgnoreCase("OPTIONS")
-                && method.equalsIgnoreCase("TRACE")
-                && method.equalsIgnoreCase("HEAD")) {
-            return false;
-        } else {
-            return true;
-        }
+        return !(method.equalsIgnoreCase("GET") || method.equalsIgnoreCase("OPTIONS") || method.equalsIgnoreCase("TRACE") || method.equalsIgnoreCase("HEAD"));
     }
 
     public T addOrReplaceCookie(Cookie cookie) {

--- a/src/main/java/com/ning/http/client/providers/netty/NettyResponse.java
+++ b/src/main/java/com/ning/http/client/providers/netty/NettyResponse.java
@@ -46,7 +46,6 @@ import org.jboss.netty.buffer.ChannelBuffers;
 public class NettyResponse implements Response {
     private final static Charset DEFAULT_CHARSET = Charset.forName("ISO-8859-1");
 
-    private final URI uri;
     private final List<HttpResponseBodyPart> bodyParts;
     private final HttpResponseHeaders headers;
     private final HttpResponseStatus status;
@@ -59,7 +58,6 @@ public class NettyResponse implements Response {
         this.status = status;
         this.headers = headers;
         this.bodyParts = bodyParts;
-        uri = status.getUrl();
     }
 
     /* @Override */
@@ -140,7 +138,7 @@ public class NettyResponse implements Response {
     /* @Override */
 
     public URI getUri() throws MalformedURLException {
-        return uri;
+        return status.getUrl();
     }
 
     /* @Override */

--- a/src/main/java/com/ning/http/util/AsyncHttpProviderUtils.java
+++ b/src/main/java/com/ning/http/util/AsyncHttpProviderUtils.java
@@ -137,15 +137,19 @@ public class AsyncHttpProviderUtils {
     static final String VERSION = "Version";
 
     static final byte[] EMPTY_BYTE_ARRAY = "".getBytes();
-
-    public final static URI createUri(String u) {
-        URI uri = URI.create(u);
+    
+    public static final void validateSupportedScheme(URI uri) {
         final String scheme = uri.getScheme();
         if (scheme == null || !scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https") && !scheme.equalsIgnoreCase("ws")
                 && !scheme.equalsIgnoreCase("wss")) {
-            throw new IllegalArgumentException("The URI scheme, of the URI " + u
+            throw new IllegalArgumentException("The URI scheme, of the URI " + uri
                     + ", must be equal (ignoring case) to 'http', 'https', 'ws', or 'wss'");
         }
+    }
+
+    public final static URI createUri(String u) {
+        URI uri = URI.create(u);
+        validateSupportedScheme(uri);
 
         String path = uri.getPath();
         if (path == null) {

--- a/src/main/java/com/ning/http/util/ProxyUtils.java
+++ b/src/main/java/com/ning/http/util/ProxyUtils.java
@@ -16,7 +16,6 @@ import com.ning.http.client.ProxyServer;
 import com.ning.http.client.ProxyServer.Protocol;
 import com.ning.http.client.Request;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Properties;
 
@@ -70,7 +69,7 @@ public class ProxyUtils {
      * @return true if we have to avoid proxy use (obeying non-proxy hosts settings), false otherwise.
      */
     public static boolean avoidProxy(final ProxyServer proxyServer, final Request request) {
-        return avoidProxy(proxyServer, AsyncHttpProviderUtils.getHost(URI.create(request.getUrl())));
+        return avoidProxy(proxyServer, AsyncHttpProviderUtils.getHost(request.getOriginalURI()));
     }
 
     /**


### PR DESCRIPTION
I introduced new methods on Request so that it can now expose URIs.
With this, Netty and Grizzly providers and ProxyUtils no longer have to recreate URIs from Strings.

@jfarcand and @rlubke If this is OK with you, I can port it on master.
