### PR TITLE
Refactor non proxy hosts handling, fix #202 in 1.7.x

### DIFF
--- a/src/main/java/com/ning/http/client/providers/apache/ApacheAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/apache/ApacheAsyncHttpProvider.java
@@ -340,9 +340,8 @@ public class ApacheAsyncHttpProvider implements AsyncHttpProvider {
             throw new IllegalStateException(String.format("Invalid Method", methodName));
         }
 
-        ProxyServer proxyServer = request.getProxyServer() != null ? request.getProxyServer() : config.getProxyServer();
-        boolean avoidProxy = ProxyUtils.avoidProxy(proxyServer, request);
-        if (!avoidProxy) {
+        ProxyServer proxyServer = ProxyUtils.getProxyServer(config, request);
+        if (proxyServer != null) {
 
             if (proxyServer.getPrincipal() != null) {
                 Credentials defaultcreds = new UsernamePasswordCredentials(proxyServer.getPrincipal(), proxyServer.getPassword());

--- a/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyResponseFuture.java
+++ b/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyResponseFuture.java
@@ -14,6 +14,7 @@
 package com.ning.http.client.providers.grizzly;
 
 import com.ning.http.client.AsyncHandler;
+import com.ning.http.client.ProxyServer;
 import com.ning.http.client.Request;
 import com.ning.http.client.listenable.AbstractListenableFuture;
 
@@ -42,7 +43,7 @@ public class GrizzlyResponseFuture<V> extends AbstractListenableFuture<V> {
     private final AsyncHandler handler;
     private final GrizzlyAsyncHttpProvider provider;
     private final Request request;
-
+    private final ProxyServer proxy;
     private Connection connection;
 
     FutureImpl<V> delegate;
@@ -53,12 +54,13 @@ public class GrizzlyResponseFuture<V> extends AbstractListenableFuture<V> {
 
     GrizzlyResponseFuture(final GrizzlyAsyncHttpProvider provider,
                           final Request request,
-                          final AsyncHandler handler) {
+                          final AsyncHandler handler,
+                          final ProxyServer proxy) {
 
         this.provider = provider;
         this.request = request;
         this.handler = handler;
-
+        this.proxy = proxy;
     }
 
 
@@ -208,4 +210,7 @@ public class GrizzlyResponseFuture<V> extends AbstractListenableFuture<V> {
 
     }
 
+    public ProxyServer getProxy() {
+        return proxy;
+    }
 }

--- a/src/main/java/com/ning/http/client/providers/jdk/JDKAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/jdk/JDKAsyncHttpProvider.java
@@ -131,11 +131,10 @@ public class JDKAsyncHttpProvider implements AsyncHttpProvider {
             throw new IOException(String.format("Too many connections %s", config.getMaxTotalConnections()));
         }
 
-        ProxyServer proxyServer = request.getProxyServer() != null ? request.getProxyServer() : config.getProxyServer();
+        ProxyServer proxyServer = ProxyUtils.getProxyServer(config, request);
         Realm realm = request.getRealm() != null ? request.getRealm() : config.getRealm();
-        boolean avoidProxy = ProxyUtils.avoidProxy(proxyServer, request);
         Proxy proxy = null;
-        if (!avoidProxy && (proxyServer != null || realm != null)) {
+        if (proxyServer != null || realm != null) {
             try {
                 proxy = configureProxyAndAuth(proxyServer, realm);
             } catch (AuthenticationException e) {
@@ -497,7 +496,7 @@ public class JDKAsyncHttpProvider implements AsyncHttpProvider {
 
             String ka = config.getAllowPoolingConnection() ? "keep-alive" : "close";
             urlConnection.setRequestProperty("Connection", ka);
-            ProxyServer proxyServer = request.getProxyServer() != null ? request.getProxyServer() : config.getProxyServer();
+            ProxyServer proxyServer = ProxyUtils.getProxyServer(config, request);
             boolean avoidProxy = ProxyUtils.avoidProxy(proxyServer, uri.getHost());
             if (!avoidProxy) {
                 urlConnection.setRequestProperty("Proxy-Connection", ka);

--- a/src/main/java/com/ning/http/client/providers/netty/NettyConnectListener.java
+++ b/src/main/java/com/ning/http/client/providers/netty/NettyConnectListener.java
@@ -18,8 +18,11 @@ package com.ning.http.client.providers.netty;
 
 import com.ning.http.client.AsyncHandler;
 import com.ning.http.client.AsyncHttpClientConfig;
+import com.ning.http.client.ProxyServer;
 import com.ning.http.client.Request;
 import com.ning.http.util.AllowAllHostnameVerifier;
+import com.ning.http.util.ProxyUtils;
+
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelFuture;
@@ -137,9 +140,10 @@ final class NettyConnectListener<T> implements ChannelFutureListener {
         }
 
         public NettyConnectListener<T> build(final URI uri) throws IOException {
-            HttpRequest nettyRequest = NettyAsyncHttpProvider.buildRequest(config, request, uri, true, buffer);
+            ProxyServer proxyServer = ProxyUtils.getProxyServer(config, request);
+            HttpRequest nettyRequest = NettyAsyncHttpProvider.buildRequest(config, request, uri, true, buffer, proxyServer);
             if (future == null) {
-                future = NettyAsyncHttpProvider.newFuture(uri, request, asyncHandler, nettyRequest, config, provider);
+                future = NettyAsyncHttpProvider.newFuture(uri, request, asyncHandler, nettyRequest, config, provider, proxyServer);
             } else {
                 future.setNettyRequest(nettyRequest);
                 future.setRequest(request);

--- a/src/main/java/com/ning/http/client/providers/netty/NettyResponseFuture.java
+++ b/src/main/java/com/ning/http/client/providers/netty/NettyResponseFuture.java
@@ -17,6 +17,7 @@ package com.ning.http.client.providers.netty;
 
 import com.ning.http.client.AsyncHandler;
 import com.ning.http.client.ConnectionPoolKeyStrategy;
+import com.ning.http.client.ProxyServer;
 import com.ning.http.client.Request;
 import com.ning.http.client.listenable.AbstractListenableFuture;
 import org.jboss.netty.channel.Channel;
@@ -87,6 +88,7 @@ public final class NettyResponseFuture<V> extends AbstractListenableFuture<V> {
     private final AtomicBoolean throwableCalled = new AtomicBoolean(false);
     private boolean allowConnect = false;
     private final ConnectionPoolKeyStrategy connectionPoolKeyStrategy;
+    private final ProxyServer proxyServer;
 
     public NettyResponseFuture(URI uri,
                                Request request,
@@ -95,7 +97,8 @@ public final class NettyResponseFuture<V> extends AbstractListenableFuture<V> {
                                int responseTimeoutInMs,
                                int idleConnectionTimeoutInMs,
                                NettyAsyncHttpProvider asyncHttpProvider,
-                                  ConnectionPoolKeyStrategy connectionPoolKeyStrategy) {
+                               ConnectionPoolKeyStrategy connectionPoolKeyStrategy,
+                               ProxyServer proxyServer) {
 
         this.asyncHandler = asyncHandler;
         this.responseTimeoutInMs = responseTimeoutInMs;
@@ -105,6 +108,7 @@ public final class NettyResponseFuture<V> extends AbstractListenableFuture<V> {
         this.uri = uri;
         this.asyncHttpProvider = asyncHttpProvider;
         this.connectionPoolKeyStrategy = connectionPoolKeyStrategy;
+        this.proxyServer = proxyServer;
 
         if (System.getProperty(MAX_RETRY) != null) {
             maxRetry = Integer.valueOf(System.getProperty(MAX_RETRY));
@@ -125,6 +129,10 @@ public final class NettyResponseFuture<V> extends AbstractListenableFuture<V> {
 
     public ConnectionPoolKeyStrategy getConnectionPoolKeyStrategy() {
         return connectionPoolKeyStrategy;
+    }
+
+    public ProxyServer getProxyServer() {
+        return proxyServer;
     }
 
     /**

--- a/src/main/java/com/ning/http/util/ProxyUtils.java
+++ b/src/main/java/com/ning/http/util/ProxyUtils.java
@@ -12,6 +12,7 @@
  */
 package com.ning.http.util;
 
+import com.ning.http.client.AsyncHttpClientConfig;
 import com.ning.http.client.ProxyServer;
 import com.ning.http.client.ProxyServer.Protocol;
 import com.ning.http.client.Request;
@@ -58,6 +59,19 @@ public class ProxyUtils {
      */
     public static final String PROXY_PASSWORD = PROPERTY_PREFIX + "password";
 
+    /**
+     * @param config the global config
+     * @param request the request
+     * @return the proxy server to be used for this request (can be null)
+     */
+    public static ProxyServer getProxyServer(AsyncHttpClientConfig config, Request request) {
+        ProxyServer proxyServer = request.getProxyServer();
+        if (proxyServer == null) {
+            proxyServer = config.getProxyServer();
+        }
+        return ProxyUtils.avoidProxy(proxyServer, request) ? null : proxyServer;
+    }
+    
     /**
      * Checks whether proxy should be used according to nonProxyHosts settings of it, or we want to go directly to
      * target host. If <code>null</code> proxy is passed in, this method returns true -- since there is NO proxy, we

--- a/src/test/java/com/ning/http/client/async/ProxyTest.java
+++ b/src/test/java/com/ning/http/client/async/ProxyTest.java
@@ -126,6 +126,21 @@ public abstract class ProxyTest extends AbstractBasicTest {
     }
 
     @Test(groups = { "standalone", "default_provider" })
+    public void testNonProxyHostIssue202() throws IOException, ExecutionException, TimeoutException, InterruptedException {
+        AsyncHttpClient client = getAsyncHttpClient(null);
+        try {
+            String target = "http://127.0.0.1:" + port1 + "/";
+            Future<Response> f = client.prepareGet(target).setProxyServer(new ProxyServer("127.0.0.1", port1 - 1).addNonProxyHost("127.0.0.1")).execute();
+            Response resp = f.get(3, TimeUnit.SECONDS);
+            assertNotNull(resp);
+            assertEquals(resp.getStatusCode(), HttpServletResponse.SC_OK);
+            assertEquals(resp.getHeader("target"), "/");
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test(groups = { "standalone", "default_provider" })
     public void testProxyProperties() throws IOException, ExecutionException, TimeoutException, InterruptedException {
         Properties originalProps = System.getProperties();
         try {


### PR DESCRIPTION
This homogenizes non proxy hosts handling across providers in 1.7.x. It also makes ProxyServer computation more efficient (not compute it over and over again for the same request).

The same work has to be done in master.
