### PR TITLE
use createHttpClientCodec to use user defined parameters

### DIFF
--- a/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -1405,14 +1405,14 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
 
         if (isSecure(scheme)) {
             if (p.get(SSL_HANDLER) == null) {
-                p.addFirst(HTTP_HANDLER, createHttpClientCodec);
+                p.addFirst(HTTP_HANDLER, createHttpClientCodec());
                 p.addFirst(SSL_HANDLER, new SslHandler(createSSLEngine()));
             } else {
-                p.addAfter(SSL_HANDLER, HTTP_HANDLER, createHttpClientCodec);
+                p.addAfter(SSL_HANDLER, HTTP_HANDLER, createHttpClientCodec());
             }
 
         } else {
-            p.addFirst(HTTP_HANDLER, createHttpClientCodec);
+            p.addFirst(HTTP_HANDLER, createHttpClientCodec());
         }
     }
 


### PR DESCRIPTION
The private method upgradeProtocol was not using user defined parameters when creating a new HttpClientCodec for netty.
