### PR TITLE
Fix proxy authentication in ApacheAsyncHttpProvider

### DIFF
--- a/providers/apache/src/main/java/com/ning/http/client/providers/apache/ApacheAsyncHttpProvider.java
+++ b/providers/apache/src/main/java/com/ning/http/client/providers/apache/ApacheAsyncHttpProvider.java
@@ -345,7 +345,7 @@ public class ApacheAsyncHttpProvider implements AsyncHttpProvider {
 
             if (proxyServer.getPrincipal() != null) {
                 Credentials defaultcreds = new UsernamePasswordCredentials(proxyServer.getPrincipal(), proxyServer.getPassword());
-                client.getState().setCredentials(new AuthScope(null, -1, AuthScope.ANY_REALM), defaultcreds);
+                client.getState().setProxyCredentials(new AuthScope(null, -1, AuthScope.ANY_REALM), defaultcreds);
             }
 
             ProxyHost proxyHost = proxyServer == null ? null : new ProxyHost(proxyServer.getHost(), proxyServer.getPort());


### PR DESCRIPTION
Ran into an issue where proxy authentication was not working. Turns out the provider was setting the host credentials instead of the proxy credentials.
