### PR TITLE
Fork Netty's Cookie Decoder, close #283

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -465,6 +465,7 @@
                         <exclude>**/NettyAsyncHttpProvider$*</exclude>
                         <exclude>**/NettyResponse</exclude>
                         <exclude>**/AsyncHttpProviderUtils</exclude>
+                        <exclude>**/Cookie</exclude>
                     </excludes>
                 </configuration>
                 <executions>

--- a/src/main/java/com/ning/http/client/Cookie.java
+++ b/src/main/java/com/ning/http/client/Cookie.java
@@ -20,7 +20,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.TreeSet;
 
-public class Cookie {
+public class Cookie implements Comparable<Cookie>{
     private final String domain;
     private final String name;
     private final String value;
@@ -28,27 +28,85 @@ public class Cookie {
     private final int maxAge;
     private final boolean secure;
     private final int version;
+    private final boolean httpOnly;
+    private final boolean discard;
+    private final String comment;
+    private final String commentUrl;
+
     private Set<Integer> ports = Collections.emptySet();
     private Set<Integer> unmodifiablePorts = ports;
 
+    @Deprecated
     public Cookie(String domain, String name, String value, String path, int maxAge, boolean secure) {
-        this.domain = domain;
-        this.name = name;
-        this.value = value;
-        this.path = path;
-        this.maxAge = maxAge;
-        this.secure = secure;
-        this.version = 1;
+        this(domain, name, value, path, maxAge, secure, 1);
     }
 
+    @Deprecated
     public Cookie(String domain, String name, String value, String path, int maxAge, boolean secure, int version) {
-        this.domain = domain;
+        this(domain, name, value, path, maxAge, secure, version, false, false, null, null, Collections.<Integer> emptySet());
+    }
+
+    public Cookie(String domain, String name, String value, String path, int maxAge, boolean secure, int version, boolean httpOnly, boolean discard, String comment, String commentUrl, Iterable<Integer> ports) {
+
+        if (name == null) {
+            throw new NullPointerException("name");
+        }
+        name = name.trim();
+        if (name.length() == 0) {
+            throw new IllegalArgumentException("empty name");
+        }
+
+        for (int i = 0; i < name.length(); i++) {
+            char c = name.charAt(i);
+            if (c > 127) {
+                throw new IllegalArgumentException("name contains non-ascii character: " + name);
+            }
+
+            // Check prohibited characters.
+            switch (c) {
+            case '\t':
+            case '\n':
+            case 0x0b:
+            case '\f':
+            case '\r':
+            case ' ':
+            case ',':
+            case ';':
+            case '=':
+                throw new IllegalArgumentException("name contains one of the following prohibited characters: " + "=,; \\t\\r\\n\\v\\f: " + name);
+            }
+        }
+
+        if (name.charAt(0) == '$') {
+            throw new IllegalArgumentException("name starting with '$' not allowed: " + name);
+        }
+
+        if (value == null) {
+            throw new NullPointerException("value");
+        }
+
         this.name = name;
         this.value = value;
-        this.path = path;
+        this.domain = validateValue("domain", domain);
+        this.path = validateValue("path", path);
         this.maxAge = maxAge;
         this.secure = secure;
         this.version = version;
+        this.httpOnly = httpOnly;
+
+        if (version > 0) {
+            this.comment = validateValue("comment", comment);
+        } else {
+            this.comment = null;
+        }
+        if (version > 1) {
+            this.discard = discard;
+            this.commentUrl = validateValue("commentUrl", commentUrl);
+            setPorts(ports);
+        } else {
+            this.discard = false;
+            this.commentUrl = null;
+        }
     }
 
     public String getDomain() {
@@ -79,6 +137,22 @@ public class Cookie {
         return version;
     }
 
+    public String getComment() {
+        return this.comment;
+    }
+
+    public String getCommentUrl() {
+        return this.commentUrl;
+    }
+
+    public boolean isHttpOnly() {
+        return httpOnly;
+    }
+
+    public boolean isDiscard() {
+        return discard;
+    }
+
     public Set<Integer> getPorts() {
         if (unmodifiablePorts == null) {
             unmodifiablePorts = Collections.unmodifiableSet(ports);
@@ -86,28 +160,7 @@ public class Cookie {
         return unmodifiablePorts;
     }
 
-    public void setPorts(int... ports) {
-        if (ports == null) {
-            throw new NullPointerException("ports");
-        }
-
-        int[] portsCopy = ports.clone();
-        if (portsCopy.length == 0) {
-            unmodifiablePorts = this.ports = Collections.emptySet();
-        } else {
-            Set<Integer> newPorts = new TreeSet<Integer>();
-            for (int p : portsCopy) {
-                if (p <= 0 || p > 65535) {
-                    throw new IllegalArgumentException("port out of range: " + p);
-                }
-                newPorts.add(Integer.valueOf(p));
-            }
-            this.ports = newPorts;
-            unmodifiablePorts = null;
-        }
-    }
-
-    public void setPorts(Iterable<Integer> ports) {
+    private void setPorts(Iterable<Integer> ports) {
         Set<Integer> newPorts = new TreeSet<Integer>();
         for (int p : ports) {
             if (p <= 0 || p > 65535) {
@@ -125,7 +178,89 @@ public class Cookie {
 
     @Override
     public String toString() {
-        return String.format("Cookie: domain=%s, name=%s, value=%s, path=%s, maxAge=%d, secure=%s",
-                domain, name, value, path, maxAge, secure);
+        StringBuilder buf = new StringBuilder();
+        buf.append(getName());
+        buf.append('=');
+        buf.append(getValue());
+        if (getDomain() != null) {
+            buf.append("; domain=");
+            buf.append(getDomain());
+        }
+        if (getPath() != null) {
+            buf.append("; path=");
+            buf.append(getPath());
+        }
+        if (getComment() != null) {
+            buf.append("; comment=");
+            buf.append(getComment());
+        }
+        if (getMaxAge() >= 0) {
+            buf.append("; maxAge=");
+            buf.append(getMaxAge());
+            buf.append('s');
+        }
+        if (isSecure()) {
+            buf.append("; secure");
+        }
+        if (isHttpOnly()) {
+            buf.append("; HTTPOnly");
+        }
+        return buf.toString();
+    }
+
+    private String validateValue(String name, String value) {
+        if (value == null) {
+            return null;
+        }
+        value = value.trim();
+        if (value.length() == 0) {
+            return null;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+            case '\r':
+            case '\n':
+            case '\f':
+            case 0x0b:
+            case ';':
+                throw new IllegalArgumentException(name + " contains one of the following prohibited characters: " + ";\\r\\n\\f\\v (" + value + ')');
+            }
+        }
+        return value;
+    }
+
+    public int compareTo(Cookie c) {
+        int v;
+        v = getName().compareToIgnoreCase(c.getName());
+        if (v != 0) {
+            return v;
+        }
+
+        if (getPath() == null) {
+            if (c.getPath() != null) {
+                return -1;
+            }
+        } else if (c.getPath() == null) {
+            return 1;
+        } else {
+            v = getPath().compareTo(c.getPath());
+            if (v != 0) {
+                return v;
+            }
+        }
+
+        if (getDomain() == null) {
+            if (c.getDomain() != null) {
+                return -1;
+            }
+        } else if (c.getDomain() == null) {
+            return 1;
+        } else {
+            v = getDomain().compareToIgnoreCase(c.getDomain());
+            return v;
+        }
+
+        return 0;
     }
 }

--- a/src/main/java/com/ning/http/client/providers/apache/ApacheResponse.java
+++ b/src/main/java/com/ning/http/client/providers/apache/ApacheResponse.java
@@ -14,6 +14,7 @@ package com.ning.http.client.providers.apache;
 
 import static com.ning.http.util.MiscUtil.isNonEmpty;
 
+import com.ning.org.jboss.netty.handler.codec.http.CookieDecoder;
 import com.ning.http.client.Cookie;
 import com.ning.http.client.FluentCaseInsensitiveStringsMap;
 import com.ning.http.client.HttpResponseBodyPart;
@@ -31,7 +32,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
+import java.util.Set;
 
 public class ApacheResponse implements Response {
     private final static String DEFAULT_CHARSET = "ISO-8859-1";
@@ -161,8 +162,8 @@ public class ApacheResponse implements Response {
                     // TODO: ask for parsed header
                     List<String> v = header.getValue();
                     for (String value : v) {
-                        Cookie cookie = AsyncHttpProviderUtils.parseCookie(value);
-                        localCookies.add(cookie);
+                        Set<Cookie> cookies = CookieDecoder.decode(value);
+                        localCookies.addAll(cookies);
                     }
                 }
             }

--- a/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyAsyncHttpProvider.java
@@ -15,13 +15,13 @@ package com.ning.http.client.providers.grizzly;
 
 import static com.ning.http.util.MiscUtil.isNonEmpty;
 
+import com.ning.org.jboss.netty.handler.codec.http.CookieDecoder;
 import com.ning.http.client.AsyncHandler;
 import com.ning.http.client.AsyncHttpClientConfig;
 import com.ning.http.client.AsyncHttpProvider;
 import com.ning.http.client.AsyncHttpProviderConfig;
 import com.ning.http.client.Body;
 import com.ning.http.client.BodyGenerator;
-import com.ning.http.client.ConnectionPoolKeyStrategy;
 import com.ning.http.client.ConnectionsPool;
 import com.ning.http.client.Cookie;
 import com.ning.http.client.FluentCaseInsensitiveStringsMap;
@@ -1667,8 +1667,9 @@ public class GrizzlyAsyncHttpProvider implements AsyncHttpProvider {
                 builder.setQueryParameters(null);
             }
             for (String cookieStr : response.getHeaders().values(Header.Cookie)) {
-                Cookie c = AsyncHttpProviderUtils.parseCookie(cookieStr);
-                builder.addOrReplaceCookie(c);
+                for (Cookie c : CookieDecoder.decode(cookieStr)) {
+                    builder.addOrReplaceCookie(c);
+                }
             }
             return builder.build();
 

--- a/src/main/java/com/ning/http/client/providers/jdk/JDKResponse.java
+++ b/src/main/java/com/ning/http/client/providers/jdk/JDKResponse.java
@@ -14,6 +14,7 @@ package com.ning.http.client.providers.jdk;
 
 import static com.ning.http.util.MiscUtil.isNonEmpty;
 
+import com.ning.org.jboss.netty.handler.codec.http.CookieDecoder;
 import com.ning.http.client.Cookie;
 import com.ning.http.client.FluentCaseInsensitiveStringsMap;
 import com.ning.http.client.HttpResponseBodyPart;
@@ -32,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 
@@ -175,8 +177,8 @@ public class JDKResponse implements Response {
                     // TODO: ask for parsed header
                     List<String> v = header.getValue();
                     for (String value : v) {
-                        Cookie cookie = AsyncHttpProviderUtils.parseCookie(value);
-                        localCookies.add(cookie);
+                        Set<Cookie> cookies = CookieDecoder.decode(value);
+                        localCookies.addAll(cookies);
                     }
                 }
             }

--- a/src/main/java/com/ning/http/client/providers/netty/NettyResponse.java
+++ b/src/main/java/com/ning/http/client/providers/netty/NettyResponse.java
@@ -17,6 +17,7 @@ package com.ning.http.client.providers.netty;
 
 import static com.ning.http.util.MiscUtil.isNonEmpty;
 
+import com.ning.org.jboss.netty.handler.codec.http.CookieDecoder;
 import com.ning.http.client.Cookie;
 import com.ning.http.client.FluentCaseInsensitiveStringsMap;
 import com.ning.http.client.HttpResponseBodyPart;
@@ -35,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBufferInputStream;
@@ -184,8 +186,8 @@ public class NettyResponse implements Response {
                     // TODO: ask for parsed header
                     List<String> v = header.getValue();
                     for (String value : v) {
-                        Cookie cookie = AsyncHttpProviderUtils.parseCookie(value);
-                        localCookies.add(cookie);
+                        Set<Cookie> cookies = CookieDecoder.decode(value);
+                        localCookies.addAll(cookies);
                     }
                 }
             }

--- a/src/main/java/com/ning/org/jboss/netty/handler/codec/http/CookieDecoder.java
+++ b/src/main/java/com/ning/org/jboss/netty/handler/codec/http/CookieDecoder.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (c) 2010-2012 Sonatype, Inc. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.ning.org.jboss.netty.handler.codec.http;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import com.ning.org.jboss.netty.util.internal.StringUtil;
+import com.ning.http.client.Cookie;
+import com.ning.http.util.AsyncHttpProviderUtils;
+
+/**
+ * Decodes an HTTP header value into {@link Cookie}s. This decoder can decode the HTTP cookie version 0, 1, and 2.
+ * 
+ * <pre>
+ * {@link HttpRequest} req = ...;
+ * String value = req.getHeader("Cookie");
+ * Set&lt;{@link Cookie}&gt; cookies = new {@link CookieDecoder}().decode(value);
+ * </pre>
+ * 
+ * @see CookieEncoder
+ * 
+ * @apiviz.stereotype utility
+ * @apiviz.has org.jboss.netty.handler.codec.http.Cookie oneway - - decodes
+ */
+public class CookieDecoder {
+
+    private static final char COMMA = ',';
+
+    /**
+     * Creates a new decoder.
+     */
+    private CookieDecoder() {
+    }
+
+    /**
+     * Decodes the specified HTTP header value into {@link Cookie}s.
+     * 
+     * @return the decoded {@link Cookie}s
+     */
+    public static Set<Cookie> decode(String header) {
+        List<String> names = new ArrayList<String>(8);
+        List<String> values = new ArrayList<String>(8);
+        extractKeyValuePairs(header, names, values);
+
+        if (names.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        int i;
+        int version = 0;
+
+        // $Version is the only attribute that can appear before the actual
+        // cookie name-value pair.
+        if (names.get(0).equalsIgnoreCase(CookieHeaderNames.VERSION)) {
+            try {
+                version = Integer.parseInt(values.get(0));
+            } catch (NumberFormatException e) {
+                // Ignore.
+            }
+            i = 1;
+        } else {
+            i = 0;
+        }
+
+        if (names.size() <= i) {
+            // There's a version attribute, but nothing more.
+            return Collections.emptySet();
+        }
+
+        Set<Cookie> cookies = new TreeSet<Cookie>();
+        for (; i < names.size(); i++) {
+            String name = names.get(i);
+            String value = values.get(i);
+            if (value == null) {
+                value = "";
+            }
+
+            String cookieName = name;
+            String cookieValue = value;
+            boolean discard = false;
+            boolean secure = false;
+            boolean httpOnly = false;
+            String comment = null;
+            String commentURL = null;
+            String domain = null;
+            String path = null;
+            int maxAge = Integer.MIN_VALUE;
+            List<Integer> ports = Collections.emptyList();
+
+            for (int j = i + 1; j < names.size(); j++, i++) {
+                name = names.get(j);
+                value = values.get(j);
+
+                if (CookieHeaderNames.DISCARD.equalsIgnoreCase(name)) {
+                    discard = true;
+                } else if (CookieHeaderNames.SECURE.equalsIgnoreCase(name)) {
+                    secure = true;
+                } else if (CookieHeaderNames.HTTPONLY.equalsIgnoreCase(name)) {
+                    httpOnly = true;
+                } else if (CookieHeaderNames.COMMENT.equalsIgnoreCase(name)) {
+                    comment = value;
+                } else if (CookieHeaderNames.COMMENTURL.equalsIgnoreCase(name)) {
+                    commentURL = value;
+                } else if (CookieHeaderNames.DOMAIN.equalsIgnoreCase(name)) {
+                    domain = value;
+                } else if (CookieHeaderNames.PATH.equalsIgnoreCase(name)) {
+                    path = value;
+                } else if (CookieHeaderNames.EXPIRES.equalsIgnoreCase(name)) {
+                    try {
+                        maxAge = AsyncHttpProviderUtils.convertExpireField(value);
+                    } catch (Exception e) {
+                        // original behavior, is this correct at all (expires field with max-age semantics)?
+                        try {
+                            maxAge = Math.max(Integer.valueOf(value), 0);
+                        } catch (NumberFormatException e1) {
+                            // ignore failure to parse -> treat as session cookie
+                        }
+                    }
+                } else if (CookieHeaderNames.MAX_AGE.equalsIgnoreCase(name)) {
+                    maxAge = Integer.parseInt(value);
+                } else if (CookieHeaderNames.VERSION.equalsIgnoreCase(name)) {
+                    version = Integer.parseInt(value);
+                } else if (CookieHeaderNames.PORT.equalsIgnoreCase(name)) {
+                    String[] portList = StringUtil.split(value, COMMA);
+                    ports = new ArrayList<Integer>(2);
+                    for (String s1 : portList) {
+                        try {
+                            ports.add(Integer.valueOf(s1));
+                        } catch (NumberFormatException e) {
+                            // Ignore.
+                        }
+                    }
+                } else {
+                    break;
+                }
+            }
+
+            Cookie c = new Cookie(domain, cookieName, cookieValue, path, maxAge, secure, version, httpOnly, discard, comment, commentURL, ports);
+            cookies.add(c);
+        }
+
+        return cookies;
+    }
+
+    private static void extractKeyValuePairs(final String header, final List<String> names, final List<String> values) {
+
+        final int headerLen = header.length();
+        loop: for (int i = 0;;) {
+
+            // Skip spaces and separators.
+            for (;;) {
+                if (i == headerLen) {
+                    break loop;
+                }
+                switch (header.charAt(i)) {
+                case '\t':
+                case '\n':
+                case 0x0b:
+                case '\f':
+                case '\r':
+                case ' ':
+                case ',':
+                case ';':
+                    i++;
+                    continue;
+                }
+                break;
+            }
+
+            // Skip '$'.
+            for (;;) {
+                if (i == headerLen) {
+                    break loop;
+                }
+                if (header.charAt(i) == '$') {
+                    i++;
+                    continue;
+                }
+                break;
+            }
+
+            String name;
+            String value;
+
+            if (i == headerLen) {
+                name = null;
+                value = null;
+            } else {
+                int newNameStart = i;
+                keyValLoop: for (;;) {
+                    switch (header.charAt(i)) {
+                    case ';':
+                        // NAME; (no value till ';')
+                        name = header.substring(newNameStart, i);
+                        value = null;
+                        break keyValLoop;
+                    case '=':
+                        // NAME=VALUE
+                        name = header.substring(newNameStart, i);
+                        i++;
+                        if (i == headerLen) {
+                            // NAME= (empty value, i.e. nothing after '=')
+                            value = "";
+                            break keyValLoop;
+                        }
+
+                        int newValueStart = i;
+                        char c = header.charAt(i);
+                        if (c == '"' || c == '\'') {
+                            // NAME="VALUE" or NAME='VALUE'
+                            StringBuilder newValueBuf = new StringBuilder(header.length() - i);
+                            final char q = c;
+                            boolean hadBackslash = false;
+                            i++;
+                            for (;;) {
+                                if (i == headerLen) {
+                                    value = newValueBuf.toString();
+                                    break keyValLoop;
+                                }
+                                if (hadBackslash) {
+                                    hadBackslash = false;
+                                    c = header.charAt(i++);
+                                    switch (c) {
+                                    case '\\':
+                                    case '"':
+                                    case '\'':
+                                        // Escape last backslash.
+                                        newValueBuf.setCharAt(newValueBuf.length() - 1, c);
+                                        break;
+                                    default:
+                                        // Do not escape last backslash.
+                                        newValueBuf.append(c);
+                                    }
+                                } else {
+                                    c = header.charAt(i++);
+                                    if (c == q) {
+                                        value = newValueBuf.toString();
+                                        break keyValLoop;
+                                    }
+                                    newValueBuf.append(c);
+                                    if (c == '\\') {
+                                        hadBackslash = true;
+                                    }
+                                }
+                            }
+                        } else {
+                            // NAME=VALUE;
+                            int semiPos = header.indexOf(';', i);
+                            if (semiPos > 0) {
+                                value = header.substring(newValueStart, semiPos);
+                                i = semiPos;
+                            } else {
+                                value = header.substring(newValueStart);
+                                i = headerLen;
+                            }
+                        }
+                        break keyValLoop;
+                    default:
+                        i++;
+                    }
+
+                    if (i == headerLen) {
+                        // NAME (no value till the end of string)
+                        name = header.substring(newNameStart);
+                        value = null;
+                        break;
+                    }
+                }
+            }
+
+            names.add(name);
+            values.add(value);
+        }
+    }
+}

--- a/src/main/java/com/ning/org/jboss/netty/handler/codec/http/CookieHeaderNames.java
+++ b/src/main/java/com/ning/org/jboss/netty/handler/codec/http/CookieHeaderNames.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (c) 2010-2012 Sonatype, Inc. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.ning.org.jboss.netty.handler.codec.http;
+
+final class CookieHeaderNames {
+    static final String PATH = "Path";
+
+    static final String EXPIRES = "Expires";
+
+    static final String MAX_AGE = "Max-Age";
+
+    static final String DOMAIN = "Domain";
+
+    static final String SECURE = "Secure";
+
+    static final String HTTPONLY = "HTTPOnly";
+
+    static final String COMMENT = "Comment";
+
+    static final String COMMENTURL = "CommentURL";
+
+    static final String DISCARD = "Discard";
+
+    static final String PORT = "Port";
+
+    static final String VERSION = "Version";
+
+    private CookieHeaderNames() {
+        // Unused.
+    }
+}
+

--- a/src/main/java/com/ning/org/jboss/netty/util/internal/StringUtil.java
+++ b/src/main/java/com/ning/org/jboss/netty/util/internal/StringUtil.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.org.jboss.netty.util.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * String utility class.
+ */
+public final class StringUtil {
+
+    private StringUtil() {
+        // Unused.
+    }
+
+    private static final String EMPTY_STRING = "";
+
+    /**
+     * Splits the specified {@link String} with the specified delimiter.  This operation is a simplified and optimized
+     * version of {@link String#split(String)}.
+     */
+    public static String[] split(String value, char delim) {
+        final int end = value.length();
+        final List<String> res = new ArrayList<String>();
+
+        int start = 0;
+        for (int i = 0; i < end; i ++) {
+            if (value.charAt(i) == delim) {
+                if (start == i) {
+                    res.add(EMPTY_STRING);
+                } else {
+                    res.add(value.substring(start, i));
+                }
+                start = i + 1;
+            }
+        }
+
+        if (start == 0) { // If no delimiter was found in the value
+            res.add(value);
+        } else {
+            if (start != end) {
+                // Add the last element if it's not empty.
+                res.add(value.substring(start, end));
+            } else {
+                // Truncate trailing empty elements.
+                for (int i = res.size() - 1; i >= 0; i --) {
+                    if (res.get(i).length() == 0) {
+                        res.remove(i);
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+
+        return res.toArray(new String[res.size()]);
+    }
+}
+

--- a/src/test/java/com/ning/org/jboss/netty/handler/codec/http/CookieDecoderTest.java
+++ b/src/test/java/com/ning/org/jboss/netty/handler/codec/http/CookieDecoderTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2010-2012 Sonatype, Inc. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.ning.org.jboss.netty.handler.codec.http;
+
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.ning.http.client.Cookie;
+
+public class CookieDecoderTest {
+    
+    @Test(groups = "fast")
+    public void testDecodeUnquoted() {
+        Set<Cookie> cookies = CookieDecoder.decode("foo=value; domain=/; path=/");
+        Assert.assertEquals(cookies.size(), 1);
+
+        Cookie first = cookies.iterator().next();
+        Assert.assertEquals(first.getValue(), "value");
+        Assert.assertEquals(first.getDomain(), "/");
+        Assert.assertEquals(first.getPath(), "/");
+    }
+
+    @Test(groups = "fast")
+    public void testDecodeQuoted() {
+        Set<Cookie> cookies = CookieDecoder.decode("ALPHA=\"VALUE1\"; Domain=docs.foo.com; Path=/accounts; Expires=Wed, 13-Jan-2021 22:23:01 GMT; Secure; HttpOnly");
+        Assert.assertEquals(cookies.size(), 1);
+
+        Cookie first = cookies.iterator().next();
+        Assert.assertEquals(first.getValue(), "VALUE1");
+    }
+
+    @Test(groups = "fast")
+    public void testDecodeQuotedContainingEscapedQuote() {
+        Set<Cookie> cookies = CookieDecoder.decode("ALPHA=\"VALUE1\\\"\"; Domain=docs.foo.com; Path=/accounts; Expires=Wed, 13-Jan-2021 22:23:01 GMT; Secure; HttpOnly");
+        Assert.assertEquals(cookies.size(), 1);
+
+        Cookie first = cookies.iterator().next();
+        Assert.assertEquals(first.getValue(), "VALUE1\"");
+    }
+}


### PR DESCRIPTION
@rlubke IMHO, you should extract GrizzlyResponse.convertCookies so that GrizzlyAsyncHttpProvider.newRequest can use the same GrizzlyCookie <-> AHCCookie conversion logic, based on CookiesBuilder.ServerCookiesBuilder.
