### PR TITLE
Make sure no bytes are lost during the handshake

### DIFF
--- a/providers/netty/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/providers/netty/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -277,8 +277,8 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
             /* @Override */
             public ChannelPipeline getPipeline() throws Exception {
                 ChannelPipeline pipeline = pipeline();
-                pipeline.addLast("ws-decoder", new HttpResponseDecoder());
-                pipeline.addLast("ws-encoder", new HttpRequestEncoder());
+                pipeline.addLast("http-decoder", new HttpResponseDecoder());
+                pipeline.addLast("http-encoder", new HttpRequestEncoder());
                 pipeline.addLast("httpProcessor", NettyAsyncHttpProvider.this);
                 return pipeline;
             }
@@ -354,8 +354,8 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
                     abort(cl.future(), ex);
                 }
 
-                pipeline.addLast("ws-decoder", new HttpResponseDecoder());
-                pipeline.addLast("ws-encoder", new HttpRequestEncoder());
+                pipeline.addLast("http-decoder", new HttpResponseDecoder());
+                pipeline.addLast("http-encoder", new HttpRequestEncoder());
                 pipeline.addLast("httpProcessor", NettyAsyncHttpProvider.this);
 
                 return pipeline;
@@ -2390,8 +2390,8 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
                     throw new IOException(String.format("Invalid challenge. Actual: %s. Expected: %s", accept, key));
                 }
 
-                ctx.getPipeline().replace("ws-decoder", "ws-decoder", new WebSocket08FrameDecoder(false, false));
-                ctx.getPipeline().replace("ws-encoder", "ws-encoder", new WebSocket08FrameEncoder(true));
+                ctx.getPipeline().get(HttpResponseDecoder.class).replace("ws-decoder", new WebSocket08FrameDecoder(false, false));
+                ctx.getPipeline().replace("http-encoder", "ws-encoder", new WebSocket08FrameEncoder(true));
                 if (h.onHeadersReceived(responseHeaders) == STATE.CONTINUE) {
                     h.onSuccess(new NettyWebSocket(ctx.getChannel()));
                 }


### PR DESCRIPTION
This fix the problem @jfarcand reported on the netty issue tracker:
https://github.com/netty/netty/issues/1331

I wonder why you not used the WebSocketClientHandshakerFactory as it would have returned the WebSocketClientHandshaker08 which handles all of this correctly already.
