### PR TITLE
Don't leave a trailing equal sign in the URL

### DIFF
--- a/api/src/main/java/org/asynchttpclient/RequestBuilderBase.java
+++ b/api/src/main/java/org/asynchttpclient/RequestBuilderBase.java
@@ -190,7 +190,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
                         } else {
                             builder.append(name);
                         }
-                        if (value != null) {
+                        if (isNonEmpty(value)) {
                             builder.append('=');
                             if (encode) {
                                 UTF8UrlEncoder.appendEncoded(builder, value);

--- a/api/src/test/java/org/asynchttpclient/async/RequestBuilderTest.java
+++ b/api/src/test/java/org/asynchttpclient/async/RequestBuilderTest.java
@@ -90,11 +90,12 @@ public class RequestBuilderTest {
         Request request = new RequestBuilder("GET")
                 .setUrl("http://foo.com/?param1=value1")
                 .addQueryParameter("param2", "value2")
+                .addQueryParameter("param3", "")
                 .build();
 
-        assertEquals(request.getUrl(), "http://foo.com/?param1=value1&param2=value2");
+        assertEquals(request.getUrl(), "http://foo.com/?param1=value1&param2=value2&param3");
         FluentStringsMap params = request.getQueryParams();
-        assertEquals(params.size(), 2);
+        assertEquals(params.size(), 3);
         assertEquals(params.get("param1").get(0), "value1");
         assertEquals(params.get("param2").get(0), "value2");
     }


### PR DESCRIPTION
Don't leave a trailing equal sign in the URL if a queryParam has an empty value
