### PR TITLE
Updated Grizzly to 2.3.4-SNAPSHOT

### DIFF
--- a/providers/grizzly/pom.xml
+++ b/providers/grizzly/pom.xml
@@ -14,7 +14,7 @@
     </description>
 
     <properties>
-        <grizzly.version>2.3.3-SNAPSHOT</grizzly.version>
+        <grizzly.version>2.3.4-SNAPSHOT</grizzly.version>
         <grizzly.npn.version>1.0</grizzly.npn.version>
     </properties>
 


### PR DESCRIPTION
Unable to build before because Grizzly 2.3.3-SNAPSHOT doesn't exist.
