### PR TITLE
Fix useRelativeURIsWithSSLProxies initialization in AsyncHttpClientConfi...

### DIFF
--- a/src/main/java/com/ning/http/client/AsyncHttpClientConfig.java
+++ b/src/main/java/com/ning/http/client/AsyncHttpClientConfig.java
@@ -154,6 +154,7 @@ public class AsyncHttpClientConfig {
         this.hostnameVerifier = hostnameVerifier;
         this.ioThreadMultiplier = ioThreadMultiplier;
         this.strict302Handling = strict302Handling;
+        this.useRelativeURIsWithSSLProxies = useRelativeURIsWithSSLProxies;
         this.rfc6265CookieEncoding = rfc6265CookieEncoding;
 
         if (applicationThreadPool == null) {


### PR DESCRIPTION
It is a blocking issue when using SSL with a proxy, so it would be really useful if you could release a 1.7.18 with this fix ! Is it possible ?
