### PR TITLE
Bugfix for JDK API, using proxies

### DIFF
--- a/api/src/main/java/org/asynchttpclient/providers/jdk/JDKAsyncHttpProvider.java
+++ b/api/src/main/java/org/asynchttpclient/providers/jdk/JDKAsyncHttpProvider.java
@@ -173,12 +173,8 @@ public class JDKAsyncHttpProvider implements AsyncHttpProvider {
             }
         }
 
-        HttpURLConnection urlConnection = null;
-        if (proxy == null) {
-            urlConnection = (HttpURLConnection) request.getURI().toURL().openConnection(Proxy.NO_PROXY);
-        } else {
-            urlConnection = (HttpURLConnection) proxyServer.getURI().toURL().openConnection(proxy);
-        }
+        HttpURLConnection urlConnection = (HttpURLConnection)
+            request.getURI().toURL().openConnection(proxy == null ? Proxy.NO_PROXY : proxy);
 
         if (request.getUrl().startsWith("https")) {
             HttpsURLConnection secure = (HttpsURLConnection) urlConnection;


### PR DESCRIPTION
A bug caused the connection to be set up to the proxy URI rather than the request URI.
