### PR TITLE
GrizzlyResponse#getResponseBodyAsBytes should return original byte array (backporting from master)

### DIFF
--- a/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyResponse.java
+++ b/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyResponse.java
@@ -172,9 +172,11 @@ public class GrizzlyResponse implements Response {
      * {@inheritDoc}
      */
     public byte[] getResponseBodyAsBytes() throws IOException {
-
-        return getResponseBody().getBytes();
-
+        final byte[] responseBodyBytes = new byte[responseBody.remaining()];
+        final int origPos = responseBody.position();
+        responseBody.get(responseBodyBytes);
+        responseBody.position(origPos);
+        return responseBodyBytes;
     }
 
     public ByteBuffer getResponseBodyAsByteBuffer() throws IOException {


### PR DESCRIPTION
GrizzlyResponse#getResponseBodyAsBytes returns bytes as text content. So when downloading binary contents like images, the byte array is not original content. The method should return byte array directly in the same way as Netty provider.
