### PR TITLE
Fix NPE in NettyConnectionsPool

### DIFF
--- a/providers/netty/src/main/java/org/asynchttpclient/providers/netty/NettyConnectionsPool.java
+++ b/providers/netty/src/main/java/org/asynchttpclient/providers/netty/NettyConnectionsPool.java
@@ -54,8 +54,8 @@ public class NettyConnectionsPool implements ConnectionsPool<String, Channel> {
         this.sslConnectionPoolEnabled = sslConnectionPoolEnabled;
         this.maxIdleTime = maxIdleTime;
         this.maxConnectionLifeTimeInMs = maxConnectionLifeTimeInMs;
-        this.idleConnectionDetector.schedule(new IdleChannelDetector(), maxIdleTime, maxIdleTime);
         this.idleConnectionDetector = idleConnectionDetector;
+        this.idleConnectionDetector.schedule(new IdleChannelDetector(), maxIdleTime, maxIdleTime);
     }
 
     private static class IdleChannel {


### PR DESCRIPTION
`idleConnectionDetector` was used before it is on the next line, leading to a NPE.
