### PR TITLE
Netty ssl parts

### DIFF
--- a/src/main/java/com/ning/http/multipart/MultipartRequestEntity.java
+++ b/src/main/java/com/ning/http/multipart/MultipartRequestEntity.java
@@ -125,20 +125,10 @@ public class MultipartRequestEntity implements RequestEntity {
         return true;
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.apache.commons.httpclient.methods.RequestEntity#writeRequest(java.io.OutputStream)
-     */
     public void writeRequest(OutputStream out) throws IOException {
         Part.sendParts(out, parts, multipartBoundary);
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.apache.commons.httpclient.methods.RequestEntity#getContentLength()
-     */
     public long getContentLength() {
         try {
             return Part.getLengthOfParts(parts, multipartBoundary);
@@ -148,13 +138,7 @@ public class MultipartRequestEntity implements RequestEntity {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.apache.commons.httpclient.methods.RequestEntity#getContentType()
-     */
     public String getContentType() {
         return contentType;
     }
 }
-


### PR DESCRIPTION
Parts were being sent twice when using HTTPS:
- once when setting the headers: https://github.com/AsyncHttpClient/async-http-client/blob/async-http-client-1.7.18/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java#L826
- once again when sending the request: https://github.com/AsyncHttpClient/async-http-client/blob/async-http-client-1.7.18/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java#L546

@jfarcand WDYT?
