### PR TITLE
Added support for java.net.ProxySelector

### DIFF
--- a/api/src/main/java/org/asynchttpclient/AsyncHttpClientConfig.java
+++ b/api/src/main/java/org/asynchttpclient/AsyncHttpClientConfig.java
@@ -92,7 +92,7 @@ public class AsyncHttpClientConfig {
     protected boolean allowPoolingConnection;
     protected ScheduledExecutorService reaper;
     protected ExecutorService applicationThreadPool;
-    protected ProxyServer proxyServer;
+    protected ProxyServerSelector proxyServerSelector;
     protected SSLContext sslContext;
     protected SSLEngineFactory sslEngineFactory;
     protected AsyncHttpProviderConfig<?, ?> providerConfig;
@@ -136,7 +136,7 @@ public class AsyncHttpClientConfig {
                                   boolean keepAlive,
                                   ScheduledExecutorService reaper,
                                   ExecutorService applicationThreadPool,
-                                  ProxyServer proxyServer,
+                                  ProxyServerSelector proxyServerSelector,
                                   SSLContext sslContext,
                                   SSLEngineFactory sslEngineFactory,
                                   AsyncHttpProviderConfig<?, ?> providerConfig,
@@ -196,7 +196,7 @@ public class AsyncHttpClientConfig {
         } else {
             this.applicationThreadPool = applicationThreadPool;
         }
-        this.proxyServer = proxyServer;
+        this.proxyServerSelector = proxyServerSelector;
         this.useRawUrl = useRawUrl;
         this.spdyEnabled = spdyEnabled;
         this.spdyInitialWindowSize = spdyInitialWindowSize;
@@ -362,8 +362,8 @@ public class AsyncHttpClientConfig {
      *
      * @return instance of {@link ProxyServer}
      */
-    public ProxyServer getProxyServer() {
-        return proxyServer;
+    public ProxyServerSelector getProxyServerSelector() {
+        return proxyServerSelector;
     }
 
     /**
@@ -613,11 +613,12 @@ public class AsyncHttpClientConfig {
         private boolean compressionEnabled = Boolean.getBoolean(ASYNC_CLIENT + "compressionEnabled");
         private String userAgent = System.getProperty(ASYNC_CLIENT + "userAgent", "AsyncHttpClient/" + AHC_VERSION);
         private boolean useProxyProperties = Boolean.getBoolean(ASYNC_CLIENT + "useProxyProperties");
+        private boolean useProxySelector = Boolean.getBoolean(ASYNC_CLIENT + "useProxySelector");
         private boolean allowPoolingConnection = true;
         private boolean useRelativeURIsWithSSLProxies = Boolean.getBoolean(ASYNC_CLIENT + "useRelativeURIsWithSSLProxies");
         private ScheduledExecutorService reaper;
         private ExecutorService applicationThreadPool;
-        private ProxyServer proxyServer = null;
+        private ProxyServerSelector proxyServerSelector = null;
         private SSLContext sslContext;
         private SSLEngineFactory sslEngineFactory;
         private AsyncHttpProviderConfig<?, ?> providerConfig;
@@ -817,13 +818,24 @@ public class AsyncHttpClientConfig {
         }
 
         /**
+         * Set an instance of {@link ProxyServerSelector} used by an {@link AsyncHttpClient}
+         *
+         * @param proxyServerSelector instance of {@link ProxyServerSelector}
+         * @return a {@link Builder}
+         */
+        public Builder setProxyServerSelector(ProxyServerSelector proxyServerSelector) {
+            this.proxyServerSelector = proxyServerSelector;
+            return this;
+        }
+
+        /**
          * Set an instance of {@link ProxyServer} used by an {@link AsyncHttpClient}
          *
          * @param proxyServer instance of {@link ProxyServer}
          * @return a {@link Builder}
          */
         public Builder setProxyServer(ProxyServer proxyServer) {
-            this.proxyServer = proxyServer;
+            this.proxyServerSelector = ProxyUtils.createProxyServerSelector(proxyServer);
             return this;
         }
 
@@ -1025,11 +1037,26 @@ public class AsyncHttpClientConfig {
         }
 
         /**
-         * Sets whether AHC should use the default http.proxy* system properties
-         * to obtain proxy information.
+         * Sets whether AHC should use the default JDK ProxySelector to select a proxy server.
          * <p/>
-         * If useProxyProperties is set to <code>true</code> but {@link #setProxyServer(ProxyServer)} was used
-         * to explicitly set a proxy server, the latter is preferred.
+         * If useProxySelector is set to <code>true</code> but {@link #setProxyServer(ProxyServer)}
+         * was used to explicitly set a proxy server, the latter is preferred.
+         * <p/>
+         * See http://docs.oracle.com/javase/7/docs/api/java/net/ProxySelector.html
+         */
+        public Builder setUseProxySelector(boolean useProxySelector) {
+            this.useProxySelector = useProxySelector;
+            return this;
+        }
+
+        /**
+         * Sets whether AHC should use the default http.proxy* system properties
+         * to obtain proxy information.  This differs from {@link #setUseProxySelector(boolean)}
+         * in that AsyncHttpClient will use its own logic to handle the system properties,
+         * potentially supporting other protocols that the the JDK ProxySelector doesn't.
+         * <p/>
+         * If useProxyProperties is set to <code>true</code> but {@link #setUseProxySelector(boolean)}
+         * was also set to true, the latter is preferred.
          * <p/>
          * See http://download.oracle.com/javase/1.4.2/docs/guide/net/properties.html
          */
@@ -1182,7 +1209,7 @@ public class AsyncHttpClientConfig {
             defaultMaxConnectionLifeTimeInMs = prototype.getMaxConnectionLifeTimeInMs();
             maxDefaultRedirects = prototype.getMaxRedirects();
             defaultMaxTotalConnections = prototype.getMaxTotalConnections();
-            proxyServer = prototype.getProxyServer();
+            proxyServerSelector = prototype.getProxyServerSelector();
             realm = prototype.getRealm();
             defaultRequestTimeoutInMs = prototype.getRequestTimeoutInMs();
             sslContext = prototype.getSSLContext();
@@ -1248,8 +1275,16 @@ public class AsyncHttpClientConfig {
                 throw new IllegalStateException("ExecutorServices closed");
             }
 
-            if (proxyServer == null && useProxyProperties) {
-                proxyServer = ProxyUtils.createProxy(System.getProperties());
+            if (proxyServerSelector == null && useProxySelector) {
+                proxyServerSelector = ProxyUtils.getJdkDefaultProxyServerSelector();
+            }
+
+            if (proxyServerSelector == null && useProxyProperties) {
+                proxyServerSelector = ProxyUtils.createProxyServerSelector(System.getProperties());
+            }
+
+            if (proxyServerSelector == null) {
+                proxyServerSelector = ProxyServerSelector.NO_PROXY_SELECTOR;
             }
 
             return new AsyncHttpClientConfig(defaultMaxTotalConnections,
@@ -1267,7 +1302,7 @@ public class AsyncHttpClientConfig {
                     allowPoolingConnection,
                     reaper,
                     applicationThreadPool,
-                    proxyServer,
+                    proxyServerSelector,
                     sslContext,
                     sslEngineFactory,
                     providerConfig,

--- a/api/src/main/java/org/asynchttpclient/AsyncHttpClientConfigBean.java
+++ b/api/src/main/java/org/asynchttpclient/AsyncHttpClientConfigBean.java
@@ -55,9 +55,12 @@ public class AsyncHttpClientConfigBean extends AsyncHttpClientConfig {
         compressionEnabled = Boolean.getBoolean(ASYNC_CLIENT + "compressionEnabled");
         userAgent = System.getProperty(ASYNC_CLIENT + "userAgent", "AsyncHttpClient/" + AHC_VERSION);
 
+        boolean useProxySelector = Boolean.getBoolean(ASYNC_CLIENT + "useProxySelector");
         boolean useProxyProperties = Boolean.getBoolean(ASYNC_CLIENT + "useProxyProperties");
-        if (useProxyProperties) {
-            proxyServer = ProxyUtils.createProxy(System.getProperties());
+        if (useProxySelector) {
+            proxyServerSelector = ProxyUtils.getJdkDefaultProxyServerSelector();
+        } else if (useProxyProperties) {
+            proxyServerSelector = ProxyUtils.createProxyServerSelector(System.getProperties());
         }
 
         allowPoolingConnection = true;
@@ -163,7 +166,12 @@ public class AsyncHttpClientConfigBean extends AsyncHttpClientConfig {
     }
 
     public AsyncHttpClientConfigBean setProxyServer(ProxyServer proxyServer) {
-        this.proxyServer = proxyServer;
+        this.proxyServerSelector = ProxyUtils.createProxyServerSelector(proxyServer);
+        return this;
+    }
+
+    public AsyncHttpClientConfigBean setProxyServerSelector(ProxyServerSelector proxyServerSelector) {
+        this.proxyServerSelector = proxyServerSelector;
         return this;
     }
 

--- a/api/src/main/java/org/asynchttpclient/ProxyServerSelector.java
+++ b/api/src/main/java/org/asynchttpclient/ProxyServerSelector.java
@@ -1,0 +1,27 @@
+package org.asynchttpclient;
+
+import java.net.URI;
+
+/**
+ * Selector for a proxy server
+ */
+public interface ProxyServerSelector {
+
+    /**
+     * Select a proxy server to use for the given URI.
+     *
+     * @param uri The URI to select a proxy server for.
+     * @return The proxy server to use, if any.  May return null.
+     */
+    ProxyServer select(URI uri);
+
+    /**
+     * A selector that always selects no proxy.
+     */
+    static final ProxyServerSelector NO_PROXY_SELECTOR = new ProxyServerSelector() {
+        @Override
+        public ProxyServer select(URI uri) {
+            return null;
+        }
+    };
+}

--- a/providers/grizzly/src/main/java/org/asynchttpclient/providers/grizzly/statushandler/ProxyAuthorizationHandler.java
+++ b/providers/grizzly/src/main/java/org/asynchttpclient/providers/grizzly/statushandler/ProxyAuthorizationHandler.java
@@ -65,7 +65,8 @@ public final class ProxyAuthorizationHandler implements StatusHandler {
         final Request req = httpTransactionContext.getRequest();
         ProxyServer proxyServer = httpTransactionContext.getProvider()
                 .getClientConfig()
-                .getProxyServer();
+                .getProxyServerSelector()
+                .select(req.getOriginalURI());
         String principal = proxyServer.getPrincipal();
         String password = proxyServer.getPassword();
         Realm realm = new Realm.RealmBuilder().setPrincipal(principal)

--- a/site/src/site/apt/proxy.apt
+++ b/site/src/site/apt/proxy.apt
@@ -61,3 +61,26 @@ Response r = responseFuture.get();
 
   You can also set the <<<ProxyServer>>> at the <<<AsyncHttpClientConfig>>> level. In that case, all request will share
   the same proxy information.
+
+Using Java System Properties
+
+  The AsyncHttpClient library supports the standard
+  {{{http://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html#Proxies}Java Proxy System Properties}}.
+  You can configure this at a global level using the <<<setUseProxyProperties(true)>>> method on the
+  <<<AsyncHttpClientConfig.Builder>>>, or by setting the <<<org.asynchttpclient.AsyncHttpClientConfig.useProxyProperties>>>
+  system property to true.
+
+Using JDK ProxySelectors
+
+  The AsyncHttpClient library also supports using the default
+  {{{http://docs.oracle.com/javase/7/docs/api/java/net/ProxySelector.html}JDK ProxySelector}}.  This allows for more
+  fine grained control over which proxies to use, for example, it can be used in combination with
+  {{{https://code.google.com/p/proxy-vole/}Proxy Vole}} to use OS configured proxies or to use a proxy.pac file.
+
+  You configure this at a global level using the <<<setUseProxySelector(true)>>> method on the
+  <<<AsyncHttpClientConfig.Builder>>>, or by setting the
+   <<<org.asynchttpclient.AsyncHttpClientConfig.useProxySelector>>> system property to true.
+
+  If you don't change the default JDK <<<ProxySelector>>>, this setting is very similar to the <<<useProxyProperties>>>
+  setting, though the <<<useProxyProperties>>> setting does allow more flexibility, such as the ability to use an
+  HTTPS proxy.


### PR DESCRIPTION
Fixes #360.

Summary:
- Instead of AsyncHttpClientConfig having a ProxyServer, it now has a ProxyServerSelector.
- Methods that configure a ProxyServer now take the passed in ProxyServer and configure a selector that always returns that ProxyServer.
- Although I could have moved the nonProxyHosts handling into the ProxyServerSelector implementation, I didn't because users might still configure a ProxyServer per request that has nonProxyHosts configuration, and so this handling needs to go through the current avoidHosts methods.
- Added an option called useProxySelector that tells async-http-client to use an implementation of ProxyServerSelector that wraps the JDK default ProxySelector. This allows for much more complex proxy selection, such as a proxy.pac based implementation from the Proxy Vole project.
- Kept the useProxyProperties option and its current implementation, because it offers some things that ProxySelector can't provide, for example, using HTTPS and other protocols to connect to the proxy.
- Fixed a bug in useProxyProperties nonProxyHosts handling, where only wildcards at the front of the nonProxyHosts config were being honoured, but the JDK docs indicate that wildcards are permitted both at the front and at the end.
- Fixed a turkish i bug in nonProxyHosts matching.
- Fixed a bug in the ProxyUtils.createProxy method where it was ignoring the passed in Properties, and going directly to System.getProperty.
- Documented both useProxyProperties and useProxySelector.
