### PR TITLE
Move prepareResponse from Provider to HttpStatus

### DIFF
--- a/api/src/main/java/org/asynchttpclient/AsyncHttpProvider.java
+++ b/api/src/main/java/org/asynchttpclient/AsyncHttpProvider.java
@@ -17,7 +17,6 @@ package org.asynchttpclient;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.List;
 
 /**
  * Interface to be used when implementing custom asynchronous I/O HTTP client.
@@ -39,16 +38,4 @@ public interface AsyncHttpProvider extends Closeable {
      * Close the current underlying TCP/HTTP connection.
      */
     public void close();
-
-    /**
-     * Prepare a {@link Response}
-     *
-     * @param status    {@link HttpResponseStatus}
-     * @param headers   {@link HttpResponseHeaders}
-     * @param bodyParts list of {@link HttpResponseBodyPart}
-     * @return a {@link Response}
-     */
-    public Response prepareResponse(HttpResponseStatus status,
-                                    HttpResponseHeaders headers,
-                                    List<HttpResponseBodyPart> bodyParts);
 }

--- a/api/src/main/java/org/asynchttpclient/HttpContent.java
+++ b/api/src/main/java/org/asynchttpclient/HttpContent.java
@@ -21,21 +21,10 @@ import java.net.URI;
  * Base class for callback class used by {@link AsyncHandler}
  */
 public class HttpContent {
-    protected final AsyncHttpProvider provider;
     protected final URI uri;
 
-    protected HttpContent(URI url, AsyncHttpProvider provider) {
-        this.provider = provider;
+    protected HttpContent(URI url) {
         this.uri = url;
-    }
-
-    /**
-     * Return the current {@link AsyncHttpProvider}
-     *
-     * @return the current {@link AsyncHttpProvider}
-     */
-    public final AsyncHttpProvider provider() {
-        return provider;
     }
 
     /**

--- a/api/src/main/java/org/asynchttpclient/HttpResponseBodyPart.java
+++ b/api/src/main/java/org/asynchttpclient/HttpResponseBodyPart.java
@@ -26,8 +26,8 @@ import java.nio.ByteBuffer;
  */
 public abstract class HttpResponseBodyPart extends HttpContent {
 
-    public HttpResponseBodyPart(URI uri, AsyncHttpProvider provider) {
-        super(uri, provider);
+    public HttpResponseBodyPart(URI uri) {
+        super(uri);
     }
 
     /**

--- a/api/src/main/java/org/asynchttpclient/HttpResponseHeaders.java
+++ b/api/src/main/java/org/asynchttpclient/HttpResponseHeaders.java
@@ -24,13 +24,13 @@ public abstract class HttpResponseHeaders extends HttpContent {
 
     private final boolean traillingHeaders;
 
-    public HttpResponseHeaders(URI uri, AsyncHttpProvider provider) {
-        super(uri, provider);
+    public HttpResponseHeaders(URI uri) {
+        super(uri);
         this.traillingHeaders = false;
     }
 
-    public HttpResponseHeaders(URI uri, AsyncHttpProvider provider, boolean traillingHeaders) {
-        super(uri, provider);
+    public HttpResponseHeaders(URI uri, boolean traillingHeaders) {
+        super(uri);
         this.traillingHeaders = traillingHeaders;
     }
 

--- a/api/src/main/java/org/asynchttpclient/HttpResponseStatus.java
+++ b/api/src/main/java/org/asynchttpclient/HttpResponseStatus.java
@@ -17,55 +17,66 @@
 package org.asynchttpclient;
 
 import java.net.URI;
+import java.util.List;
 
 /**
  * A class that represent the HTTP response' status line (code + text)
  */
 public abstract class HttpResponseStatus extends HttpContent {
 
-    public HttpResponseStatus(URI uri, AsyncHttpProvider provider) {
-        super(uri, provider);
+    public HttpResponseStatus(URI uri) {
+        super(uri);
     }
+
+    /**
+     * Prepare a {@link Response}
+     *
+     * @param headers   {@link HttpResponseHeaders}
+     * @param bodyParts list of {@link HttpResponseBodyPart}
+     * @return a {@link Response}
+     */
+    public abstract Response prepareResponse(HttpResponseHeaders headers,
+                                    List<HttpResponseBodyPart> bodyParts);
 
     /**
      * Return the response status code
      *
      * @return the response status code
      */
-    abstract public int getStatusCode();
+    public abstract int getStatusCode();
 
     /**
      * Return the response status text
      *
      * @return the response status text
      */
-    abstract public String getStatusText();
+    public abstract String getStatusText();
 
     /**
      * Protocol name from status line.
      *
      * @return Protocol name.
      */
-    abstract public String getProtocolName();
+    public abstract String getProtocolName();
 
     /**
      * Protocol major version.
      *
      * @return Major version.
      */
-    abstract public int getProtocolMajorVersion();
+    public abstract int getProtocolMajorVersion();
 
     /**
      * Protocol minor version.
      *
      * @return Minor version.
      */
-    abstract public int getProtocolMinorVersion();
+    public abstract int getProtocolMinorVersion();
 
     /**
      * Full protocol name + version
      *
      * @return protocol name + version
      */
-    abstract public String getProtocolText();
+    public abstract String getProtocolText();
 }

--- a/api/src/main/java/org/asynchttpclient/Response.java
+++ b/api/src/main/java/org/asynchttpclient/Response.java
@@ -213,7 +213,7 @@ public interface Response {
          * @return a {@link Response} instance
          */
         public Response build() {
-            return status == null ? null : status.provider().prepareResponse(status, headers, bodies);
+            return status == null ? null : status.prepareResponse(headers, bodies);
         }
 
         /**

--- a/api/src/main/java/org/asynchttpclient/providers/jdk/ResponseBodyPart.java
+++ b/api/src/main/java/org/asynchttpclient/providers/jdk/ResponseBodyPart.java
@@ -12,7 +12,6 @@
  */
 package org.asynchttpclient.providers.jdk;
 
-import org.asynchttpclient.AsyncHttpProvider;
 import org.asynchttpclient.HttpResponseBodyPart;
 
 import java.io.ByteArrayInputStream;
@@ -31,8 +30,8 @@ public class ResponseBodyPart extends HttpResponseBodyPart {
     private final boolean isLast;
     private boolean closeConnection;
 
-    public ResponseBodyPart(URI uri, byte[] chunk, AsyncHttpProvider provider, boolean last) {
-        super(uri, provider);
+    public ResponseBodyPart(URI uri, byte[] chunk, boolean last) {
+        super(uri);
         this.chunk = chunk;
         isLast = last;
     }

--- a/api/src/main/java/org/asynchttpclient/providers/jdk/ResponseHeaders.java
+++ b/api/src/main/java/org/asynchttpclient/providers/jdk/ResponseHeaders.java
@@ -12,7 +12,6 @@
  */
 package org.asynchttpclient.providers.jdk;
 
-import org.asynchttpclient.AsyncHttpProvider;
 import org.asynchttpclient.FluentCaseInsensitiveStringsMap;
 import org.asynchttpclient.HttpResponseHeaders;
 
@@ -29,8 +28,8 @@ public class ResponseHeaders extends HttpResponseHeaders {
     private final HttpURLConnection urlConnection;
     private final FluentCaseInsensitiveStringsMap headers;
 
-    public ResponseHeaders(URI uri, HttpURLConnection urlConnection, AsyncHttpProvider provider) {
-        super(uri, provider, false);
+    public ResponseHeaders(URI uri, HttpURLConnection urlConnection) {
+        super(uri, false);
         this.urlConnection = urlConnection;
         headers = computerHeaders();
     }

--- a/api/src/main/java/org/asynchttpclient/providers/jdk/ResponseStatus.java
+++ b/api/src/main/java/org/asynchttpclient/providers/jdk/ResponseStatus.java
@@ -12,12 +12,15 @@
  */
 package org.asynchttpclient.providers.jdk;
 
-import org.asynchttpclient.AsyncHttpProvider;
+import org.asynchttpclient.HttpResponseBodyPart;
+import org.asynchttpclient.HttpResponseHeaders;
 import org.asynchttpclient.HttpResponseStatus;
+import org.asynchttpclient.Response;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.util.List;
 
 /**
  * A class that represent the HTTP response' status line (code + text)
@@ -26,9 +29,13 @@ public class ResponseStatus extends HttpResponseStatus {
 
     private final HttpURLConnection urlConnection;
 
-    public ResponseStatus(URI uri, HttpURLConnection urlConnection, AsyncHttpProvider provider) {
-        super(uri, provider);
+    public ResponseStatus(URI uri, HttpURLConnection urlConnection) {
+        super(uri);
         this.urlConnection = urlConnection;
+    }
+
+    public Response prepareResponse(HttpResponseHeaders headers, List<HttpResponseBodyPart> bodyParts) {
+        return new JDKResponse(this, headers, bodyParts);
     }
 
     /**

--- a/api/src/main/java/org/asynchttpclient/webdav/WebDavCompletionHandlerBase.java
+++ b/api/src/main/java/org/asynchttpclient/webdav/WebDavCompletionHandlerBase.java
@@ -81,12 +81,12 @@ public abstract class WebDavCompletionHandlerBase<T> implements AsyncHandler<T> 
     /* @Override */
     public final T onCompleted() throws Exception {
         if (status != null) {
-            Response response = status.provider().prepareResponse(status, headers, bodies);
+            Response response = status.prepareResponse(headers, bodies);
             Document document = null;
             if (status.getStatusCode() == 207) {
                 document = readXMLResponse(response.getResponseBodyAsStream());
             }
-            return onCompleted(new WebDavResponse(status.provider().prepareResponse(status, headers, bodies), document));
+            return onCompleted(new WebDavResponse(status.prepareResponse(headers, bodies), document));
         } else {
             throw new IllegalStateException("Status is null");
         }
@@ -118,10 +118,15 @@ public abstract class WebDavCompletionHandlerBase<T> implements AsyncHandler<T> 
         private final int statusCode;
 
         public HttpStatusWrapper(HttpResponseStatus wrapper, String statusText, int statusCode) {
-            super(wrapper.getUrl(), wrapper.provider());
+            super(wrapper.getUrl());
             this.wrapper = wrapper;
             this.statusText = statusText;
             this.statusCode = statusCode;
+        }
+
+        public Response prepareResponse(HttpResponseHeaders headers,
+                List<HttpResponseBodyPart> bodyParts) {
+            return wrapper.prepareResponse(headers, bodyParts);
         }
 
         @Override

--- a/providers/grizzly/src/main/java/org/asynchttpclient/providers/grizzly/EventHandler.java
+++ b/providers/grizzly/src/main/java/org/asynchttpclient/providers/grizzly/EventHandler.java
@@ -108,8 +108,7 @@ public final class EventHandler {
                 context.setCurrentState(handler.onBodyPartReceived(
                         new GrizzlyResponseBodyPart(content,
                                                     context.getRequest().getURI(),
-                                                    ctx.getConnection(),
-                                                    provider)));
+                                                    ctx.getConnection())));
             } catch (Exception e) {
                 handler.onThrowable(e);
             }
@@ -194,7 +193,7 @@ public final class EventHandler {
         final GrizzlyResponseStatus responseStatus =
                 new GrizzlyResponseStatus((HttpResponsePacket) httpHeader,
                         context.getRequest().getURI(),
-                        provider);
+                        provider.getClientConfig().isRfc6265CookieEncoding());
         context.setResponseStatus(responseStatus);
         if (context.getStatusHandler() != null) {
             return;
@@ -248,8 +247,7 @@ public final class EventHandler {
         final AsyncHandler handler = context.getHandler();
         final GrizzlyResponseHeaders responseHeaders =
                 new GrizzlyResponseHeaders((HttpResponsePacket) httpHeader,
-                                           context.getRequest().getURI(),
-                                           provider);
+                                           context.getRequest().getURI());
         if (context.getProvider().getClientConfig().hasResponseFilters()) {
             final List<ResponseFilter> filters = context.getProvider()
                     .getClientConfig().getResponseFilters();

--- a/providers/grizzly/src/main/java/org/asynchttpclient/providers/grizzly/GrizzlyAsyncHttpProvider.java
+++ b/providers/grizzly/src/main/java/org/asynchttpclient/providers/grizzly/GrizzlyAsyncHttpProvider.java
@@ -16,13 +16,9 @@ package org.asynchttpclient.providers.grizzly;
 import org.asynchttpclient.AsyncHandler;
 import org.asynchttpclient.AsyncHttpClientConfig;
 import org.asynchttpclient.AsyncHttpProvider;
-import org.asynchttpclient.HttpResponseBodyPart;
-import org.asynchttpclient.HttpResponseHeaders;
-import org.asynchttpclient.HttpResponseStatus;
 import org.asynchttpclient.ListenableFuture;
 import org.asynchttpclient.ProxyServer;
 import org.asynchttpclient.Request;
-import org.asynchttpclient.Response;
 import org.asynchttpclient.ntlm.NTLMEngine;
 import org.asynchttpclient.providers.grizzly.bodyhandler.BodyHandler;
 import org.asynchttpclient.providers.grizzly.bodyhandler.BodyHandlerFactory;
@@ -78,7 +74,6 @@ import javax.net.ssl.SSLEngine;
 import java.io.File;
 import java.io.IOException;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -196,22 +191,6 @@ public class GrizzlyAsyncHttpProvider implements AsyncHttpProvider {
         } catch (IOException ignored) { }
 
     }
-
-
-    /**
-     * {@inheritDoc}
-     */
-    public Response prepareResponse(HttpResponseStatus status,
-                                    HttpResponseHeaders headers,
-                                    List<HttpResponseBodyPart> bodyParts) {
-
-        return new GrizzlyResponse(status,
-                                   headers,
-                                   bodyParts,
-                                   clientConfig.isRfc6265CookieEncoding());
-
-    }
-
 
     // ---------------------------------------------------------- Public Methods
 

--- a/providers/grizzly/src/main/java/org/asynchttpclient/providers/grizzly/GrizzlyResponseBodyPart.java
+++ b/providers/grizzly/src/main/java/org/asynchttpclient/providers/grizzly/GrizzlyResponseBodyPart.java
@@ -13,7 +13,6 @@
 
 package org.asynchttpclient.providers.grizzly;
 
-import org.asynchttpclient.AsyncHttpProvider;
 import org.asynchttpclient.HttpResponseBodyPart;
 
 import org.glassfish.grizzly.Buffer;
@@ -48,9 +47,8 @@ class GrizzlyResponseBodyPart extends HttpResponseBodyPart {
 
     public GrizzlyResponseBodyPart(final HttpContent content,
                                    final URI uri,
-                                   final Connection<?> connection,
-                                   final AsyncHttpProvider provider) {
-        super(uri, provider);
+                                   final Connection<?> connection) {
+        super(uri);
         this.content = content;
         this.connection = connection;
 

--- a/providers/grizzly/src/main/java/org/asynchttpclient/providers/grizzly/GrizzlyResponseHeaders.java
+++ b/providers/grizzly/src/main/java/org/asynchttpclient/providers/grizzly/GrizzlyResponseHeaders.java
@@ -13,7 +13,6 @@
 
 package org.asynchttpclient.providers.grizzly;
 
-import org.asynchttpclient.AsyncHttpProvider;
 import org.asynchttpclient.FluentCaseInsensitiveStringsMap;
 import org.asynchttpclient.HttpResponseHeaders;
 
@@ -40,10 +39,9 @@ class GrizzlyResponseHeaders extends HttpResponseHeaders {
 
 
     public GrizzlyResponseHeaders(final HttpResponsePacket response,
-                                  final URI uri,
-                                  final AsyncHttpProvider provider) {
+                                  final URI uri) {
 
-        super(uri, provider);
+        super(uri);
         grizzlyHeaders = new MimeHeaders();
         grizzlyHeaders.copyFrom(response.getHeaders());
 

--- a/providers/grizzly/src/main/java/org/asynchttpclient/providers/grizzly/GrizzlyResponseStatus.java
+++ b/providers/grizzly/src/main/java/org/asynchttpclient/providers/grizzly/GrizzlyResponseStatus.java
@@ -13,12 +13,14 @@
 
 package org.asynchttpclient.providers.grizzly;
 
-import org.asynchttpclient.AsyncHttpProvider;
+import org.asynchttpclient.HttpResponseBodyPart;
+import org.asynchttpclient.HttpResponseHeaders;
 import org.asynchttpclient.HttpResponseStatus;
-
+import org.asynchttpclient.Response;
 import org.glassfish.grizzly.http.HttpResponsePacket;
 
 import java.net.URI;
+import java.util.List;
 
 /**
  * {@link HttpResponseStatus} implementation using the Grizzly 2.0 HTTP client
@@ -35,6 +37,7 @@ public class GrizzlyResponseStatus extends HttpResponseStatus {
     private final int majorVersion;
     private final int minorVersion;
     private final String protocolText;
+    private final boolean isRfc6265CookieEncoding;
 
 
 
@@ -43,20 +46,32 @@ public class GrizzlyResponseStatus extends HttpResponseStatus {
 
     public GrizzlyResponseStatus(final HttpResponsePacket response,
                                  final URI uri,
-                                 final AsyncHttpProvider provider) {
+                                 final boolean isRfc6265CookieEncoding) {
 
-        super(uri, provider);
+        super(uri);
         statusCode = response.getStatus();
         statusText = response.getReasonPhrase();
         majorVersion = response.getProtocol().getMajorVersion();
         minorVersion = response.getProtocol().getMinorVersion();
         protocolText = response.getProtocolString();
-
+        this.isRfc6265CookieEncoding = isRfc6265CookieEncoding;
     }
 
 
     // ----------------------------------------- Methods from HttpResponseStatus
 
+    /**
+     * {@inheritDoc}
+     */
+    public Response prepareResponse(HttpResponseHeaders headers,
+                                    List<HttpResponseBodyPart> bodyParts) {
+
+        return new GrizzlyResponse(this,
+                                   headers,
+                                   bodyParts,
+                                   isRfc6265CookieEncoding);
+
+    }
 
     /**
      * {@inheritDoc}

--- a/providers/netty/src/main/java/org/asynchttpclient/providers/netty/ResponseBodyPart.java
+++ b/providers/netty/src/main/java/org/asynchttpclient/providers/netty/ResponseBodyPart.java
@@ -27,7 +27,6 @@ import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.handler.codec.http.HttpChunk;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 
-import org.asynchttpclient.AsyncHttpProvider;
 import org.asynchttpclient.HttpResponseBodyPart;
 import org.asynchttpclient.providers.netty.util.ChannelBufferUtil;
 
@@ -45,12 +44,12 @@ public class ResponseBodyPart extends HttpResponseBodyPart {
     /**
      * Constructor used for non-chunked GET requests and HEAD requests.
      */
-    public ResponseBodyPart(URI uri, HttpResponse response, AsyncHttpProvider provider, boolean last) {
-        this(uri, response, provider, null, last);
+    public ResponseBodyPart(URI uri, HttpResponse response, boolean last) {
+        this(uri, response, null, last);
     }
 
-    public ResponseBodyPart(URI uri, HttpResponse response, AsyncHttpProvider provider, HttpChunk chunk, boolean last) {
-        super(uri, provider);
+    public ResponseBodyPart(URI uri, HttpResponse response, HttpChunk chunk, boolean last) {
+        super(uri);
         this.chunk = chunk;
         this.response = response;
         isLast = last;

--- a/providers/netty/src/main/java/org/asynchttpclient/providers/netty/ResponseHeaders.java
+++ b/providers/netty/src/main/java/org/asynchttpclient/providers/netty/ResponseHeaders.java
@@ -15,7 +15,6 @@
  */
 package org.asynchttpclient.providers.netty;
 
-import org.asynchttpclient.AsyncHttpProvider;
 import org.asynchttpclient.FluentCaseInsensitiveStringsMap;
 import org.asynchttpclient.HttpResponseHeaders;
 import org.jboss.netty.handler.codec.http.HttpChunkTrailer;
@@ -33,15 +32,15 @@ public class ResponseHeaders extends HttpResponseHeaders {
     private final HttpResponse response;
     private final FluentCaseInsensitiveStringsMap headers;
 
-    public ResponseHeaders(URI uri, HttpResponse response, AsyncHttpProvider provider) {
-        super(uri, provider, false);
+    public ResponseHeaders(URI uri, HttpResponse response) {
+        super(uri, false);
         this.trailingHeaders = null;
         this.response = response;
         headers = computerHeaders();
     }
 
-    public ResponseHeaders(URI uri, HttpResponse response, AsyncHttpProvider provider, HttpChunkTrailer traillingHeaders) {
-        super(uri, provider, true);
+    public ResponseHeaders(URI uri, HttpResponse response, HttpChunkTrailer traillingHeaders) {
+        super(uri, true);
         this.trailingHeaders = traillingHeaders;
         this.response = response;
         headers = computerHeaders();

--- a/providers/netty/src/main/java/org/asynchttpclient/providers/netty/ResponseStatus.java
+++ b/providers/netty/src/main/java/org/asynchttpclient/providers/netty/ResponseStatus.java
@@ -16,11 +16,14 @@
  */
 package org.asynchttpclient.providers.netty;
 
-import org.asynchttpclient.AsyncHttpProvider;
+import org.asynchttpclient.HttpResponseBodyPart;
+import org.asynchttpclient.HttpResponseHeaders;
 import org.asynchttpclient.HttpResponseStatus;
+import org.asynchttpclient.Response;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 
 import java.net.URI;
+import java.util.List;
 
 /**
  * A class that represent the HTTP response' status line (code + text)
@@ -29,9 +32,13 @@ public class ResponseStatus extends HttpResponseStatus {
 
     private final HttpResponse response;
 
-    public ResponseStatus(URI uri, HttpResponse response, AsyncHttpProvider provider) {
-        super(uri, provider);
+    public ResponseStatus(URI uri, HttpResponse response) {
+        super(uri);
         this.response = response;
+    }
+
+    public Response prepareResponse(HttpResponseHeaders headers, List<HttpResponseBodyPart> bodyParts) {
+        return new NettyResponse(this, headers, bodyParts);
     }
 
     /**

--- a/providers/netty/src/test/java/org/asynchttpclient/providers/netty/NettyAsyncResponseTest.java
+++ b/providers/netty/src/test/java/org/asynchttpclient/providers/netty/NettyAsyncResponseTest.java
@@ -44,7 +44,7 @@ public class NettyAsyncResponseTest {
         final String cookieDef = String.format("efmembercheck=true; expires=%s; path=/; domain=.eclipse.org", sdf.format(date));
 
         NettyResponse
-                response = new NettyResponse(new ResponseStatus(null, null, null), new HttpResponseHeaders(null, null, false) {
+                response = new NettyResponse(new ResponseStatus(null, null), new HttpResponseHeaders(null, false) {
             @Override
             public FluentCaseInsensitiveStringsMap getHeaders() {
                 return new FluentCaseInsensitiveStringsMap().add("Set-Cookie", cookieDef);
@@ -61,7 +61,7 @@ public class NettyAsyncResponseTest {
     @Test(groups = "standalone")
     public void testCookieParseMaxAge() {
         final String cookieDef = "efmembercheck=true; max-age=60; path=/; domain=.eclipse.org";
-        NettyResponse response = new NettyResponse(new ResponseStatus(null, null, null), new HttpResponseHeaders(null, null, false) {
+        NettyResponse response = new NettyResponse(new ResponseStatus(null, null), new HttpResponseHeaders(null, false) {
             @Override
             public FluentCaseInsensitiveStringsMap getHeaders() {
                 return new FluentCaseInsensitiveStringsMap().add("Set-Cookie", cookieDef);
@@ -77,7 +77,7 @@ public class NettyAsyncResponseTest {
     @Test(groups = "standalone")
     public void testCookieParseWeirdExpiresValue() {
         final String cookieDef = "efmembercheck=true; expires=60; path=/; domain=.eclipse.org";
-        NettyResponse response = new NettyResponse(new ResponseStatus(null, null, null), new HttpResponseHeaders(null, null, false) {
+        NettyResponse response = new NettyResponse(new ResponseStatus(null, null), new HttpResponseHeaders(null, false) {
             @Override
             public FluentCaseInsensitiveStringsMap getHeaders() {
                 return new FluentCaseInsensitiveStringsMap().add("Set-Cookie", cookieDef);

--- a/providers/netty4/src/main/java/org/asynchttpclient/providers/netty4/NettyAsyncHttpProvider.java
+++ b/providers/netty4/src/main/java/org/asynchttpclient/providers/netty4/NettyAsyncHttpProvider.java
@@ -16,18 +16,13 @@
 package org.asynchttpclient.providers.netty4;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.asynchttpclient.AsyncHandler;
 import org.asynchttpclient.AsyncHttpClientConfig;
 import org.asynchttpclient.AsyncHttpProvider;
-import org.asynchttpclient.HttpResponseBodyPart;
-import org.asynchttpclient.HttpResponseHeaders;
-import org.asynchttpclient.HttpResponseStatus;
 import org.asynchttpclient.ListenableFuture;
 import org.asynchttpclient.Request;
-import org.asynchttpclient.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,11 +75,6 @@ public class NettyAsyncHttpProvider implements AsyncHttpProvider {
         } catch (Throwable t) {
             LOGGER.warn("Unexpected error on close", t);
         }
-    }
-
-    @Override
-    public Response prepareResponse(final HttpResponseStatus status, final HttpResponseHeaders headers, final List<HttpResponseBodyPart> bodyParts) {
-        throw new UnsupportedOperationException("Mocked, should be refactored");
     }
 
     @Override

--- a/providers/netty4/src/main/java/org/asynchttpclient/providers/netty4/ResponseBodyPart.java
+++ b/providers/netty4/src/main/java/org/asynchttpclient/providers/netty4/ResponseBodyPart.java
@@ -37,9 +37,8 @@ public class ResponseBodyPart extends HttpResponseBodyPart {
     private final boolean isLast;
     private boolean closeConnection = false;
 
-    // FIXME unused AsyncHttpProvider provider
     public ResponseBodyPart(URI uri, HttpContent chunk) {
-        super(uri, null);
+        super(uri);
         bytes = ByteBufUtil.byteBuf2bytes(chunk.content());
         isLast = chunk instanceof LastHttpContent;
     }

--- a/providers/netty4/src/main/java/org/asynchttpclient/providers/netty4/ResponseHeaders.java
+++ b/providers/netty4/src/main/java/org/asynchttpclient/providers/netty4/ResponseHeaders.java
@@ -32,14 +32,12 @@ public class ResponseHeaders extends HttpResponseHeaders {
     private final HttpHeaders trailingHeaders;
     private final FluentCaseInsensitiveStringsMap headers;
 
-    // FIXME unused AsyncHttpProvider provider
     public ResponseHeaders(URI uri, HttpHeaders responseHeaders) {
         this(uri, responseHeaders, null);
     }
 
-    // FIXME unused AsyncHttpProvider provider
     public ResponseHeaders(URI uri,HttpHeaders responseHeaders, HttpHeaders traillingHeaders) {
-        super(uri, null, traillingHeaders != null);
+        super(uri, traillingHeaders != null);
         this.responseHeaders = responseHeaders;
         this.trailingHeaders = traillingHeaders;
         headers = computerHeaders();

--- a/providers/netty4/src/main/java/org/asynchttpclient/providers/netty4/ResponseStatus.java
+++ b/providers/netty4/src/main/java/org/asynchttpclient/providers/netty4/ResponseStatus.java
@@ -16,18 +16,13 @@
  */
 package org.asynchttpclient.providers.netty4;
 
-import org.asynchttpclient.AsyncHandler;
-import org.asynchttpclient.AsyncHttpProvider;
 import org.asynchttpclient.HttpResponseBodyPart;
 import org.asynchttpclient.HttpResponseHeaders;
 import org.asynchttpclient.HttpResponseStatus;
-import org.asynchttpclient.ListenableFuture;
-import org.asynchttpclient.Request;
 import org.asynchttpclient.Response;
 
 import io.netty.handler.codec.http.HttpResponse;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 
@@ -36,44 +31,24 @@ import java.util.List;
  */
 public class ResponseStatus extends HttpResponseStatus {
     
-    private static final AsyncHttpProvider fakeProvider = new AsyncHttpProvider() {
-        public <T> ListenableFuture<T> execute(Request request, AsyncHandler<T> handler) throws IOException {
-            throw new UnsupportedOperationException("Mocked, should be refactored");
-        }
-
-        public void close() {
-            throw new UnsupportedOperationException("Mocked, should be refactored");
-        }
-
-        public Response prepareResponse(HttpResponseStatus status,
-                                        HttpResponseHeaders headers,
-                                        List<HttpResponseBodyPart> bodyParts) {
-            return new NettyResponse(status, headers, bodyParts);
-        }
-    };
-
     private final HttpResponse response;
 
-    // FIXME ResponseStatus should have an abstract prepareResponse(headers, bodyParts) method instead of being passed the provider!
     public ResponseStatus(URI uri, HttpResponse response) {
-        super(uri, fakeProvider);
+        super(uri);
         this.response = response;
     }
 
-    /**
-     * Return the response status code
-     *
-     * @return the response status code
-     */
+    @Override
+    public Response prepareResponse(HttpResponseHeaders headers, List<HttpResponseBodyPart> bodyParts) {
+        return new NettyResponse(this, headers, bodyParts);
+    }
+
+    @Override
     public int getStatusCode() {
         return response.getStatus().code();
     }
 
-    /**
-     * Return the response status text
-     *
-     * @return the response status text
-     */
+    @Override
     public String getStatusText() {
         return response.getStatus().reasonPhrase();
     }

--- a/providers/netty4/src/test/java/org/asynchttpclient/providers/netty4/NettyAsyncResponseTest.java
+++ b/providers/netty4/src/test/java/org/asynchttpclient/providers/netty4/NettyAsyncResponseTest.java
@@ -44,7 +44,7 @@ public class NettyAsyncResponseTest {
         final String cookieDef = String.format("efmembercheck=true; expires=%s; path=/; domain=.eclipse.org", sdf.format(date));
 
         NettyResponse
-                response = new NettyResponse(new ResponseStatus(null, null), new HttpResponseHeaders(null, null, false) {
+                response = new NettyResponse(new ResponseStatus(null, null), new HttpResponseHeaders(null, false) {
             @Override
             public FluentCaseInsensitiveStringsMap getHeaders() {
                 return new FluentCaseInsensitiveStringsMap().add("Set-Cookie", cookieDef);
@@ -61,7 +61,7 @@ public class NettyAsyncResponseTest {
     @Test(groups = "standalone")
     public void testCookieParseMaxAge() {
         final String cookieDef = "efmembercheck=true; max-age=60; path=/; domain=.eclipse.org";
-        NettyResponse response = new NettyResponse(new ResponseStatus(null, null), new HttpResponseHeaders(null, null, false) {
+        NettyResponse response = new NettyResponse(new ResponseStatus(null, null), new HttpResponseHeaders(null, false) {
             @Override
             public FluentCaseInsensitiveStringsMap getHeaders() {
                 return new FluentCaseInsensitiveStringsMap().add("Set-Cookie", cookieDef);
@@ -77,7 +77,7 @@ public class NettyAsyncResponseTest {
     @Test(groups = "standalone")
     public void testCookieParseWeirdExpiresValue() {
         final String cookieDef = "efmembercheck=true; expires=60; path=/; domain=.eclipse.org";
-        NettyResponse response = new NettyResponse(new ResponseStatus(null, null), new HttpResponseHeaders(null, null, false) {
+        NettyResponse response = new NettyResponse(new ResponseStatus(null, null), new HttpResponseHeaders(null, false) {
             @Override
             public FluentCaseInsensitiveStringsMap getHeaders() {
                 return new FluentCaseInsensitiveStringsMap().add("Set-Cookie", cookieDef);


### PR DESCRIPTION
Small API change: `HttpContent` no longer exposes the provider in order to be able to `prepareResponse`. This method is now only available on `HttpResponseStatus`, as it's how all the providers call it anyway.

@jfarcand @rlubke Is this OK for you?
