### PR TITLE
Netty provider: Support multi-valued headers in Request

### DIFF
--- a/providers/netty/src/main/java/org/asynchttpclient/providers/netty/request/NettyRequests.java
+++ b/providers/netty/src/main/java/org/asynchttpclient/providers/netty/request/NettyRequests.java
@@ -114,7 +114,6 @@ public class NettyRequests {
                     }
                 }
             }
-            headers.replaceAll(h);
 
             if (config.isCompressionEnabled()) {
                 headers.replace(HttpHeaders.Names.ACCEPT_ENCODING, HttpHeaders.Values.GZIP);


### PR DESCRIPTION
In one step of the request process, the headers are saved in a regular map, instead of a multi-value map like everywhere else. This pull request fixes that.
