### PR TITLE
Reuse the socket on a 401

### DIFF
--- a/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -2093,7 +2093,6 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
                         }
 
                         final Realm nr = new Realm.RealmBuilder().clone(newRealm).setUri(request.getUrl()).build();
-                        future.setReuseChannel(true);
                         log.debug("Sending authentication to {}", request.getUrl());
                         AsyncCallable ac = new AsyncCallable(future) {
                             public Object call() throws Exception {
@@ -2103,6 +2102,9 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
                             }
                         };
 
+                        if (future.getKeepAlive()) {
+                            future.setReuseChannel(true);
+                        }
                         if (future.getKeepAlive() && response.isChunked()) {
                             // We must make sure there is no bytes left before executing the next request.
                             ctx.setAttachment(ac);


### PR DESCRIPTION
On a 401, the client was opening a new socket, regardless of the keeplive status. The client was sending keepAlive and the remote server was honoring it.

This patch sets reuseChannel if the keepalive was honored by the remote server.
