### PR TITLE
Support DEFLATE compression for Netty provider

### DIFF
--- a/providers/netty/src/main/java/org/asynchttpclient/providers/netty/request/NettyRequests.java
+++ b/providers/netty/src/main/java/org/asynchttpclient/providers/netty/request/NettyRequests.java
@@ -107,7 +107,7 @@ public class NettyRequests {
 
         if (method != HttpMethod.CONNECT) {
             if (config.isCompressionEnabled()) {
-                headers.put(HttpHeaders.Names.ACCEPT_ENCODING, HttpHeaders.Values.GZIP);
+                headers.put(HttpHeaders.Names.ACCEPT_ENCODING, HttpHeaders.Values.GZIP + "," + HttpHeaders.Values.DEFLATE);
             }
         } else {
             List<String> auth = request.getHeaders().get(HttpHeaders.Names.PROXY_AUTHORIZATION);


### PR DESCRIPTION
Since Netty itself supports both gzip and deflate compression, allow both in the request, too. At strucr.com we noticed, there are quite some sites out there that do only support deflate, but no gzip.
