### PR TITLE
Respect Rawl URL Setting for Grizzly Provider in 1.7.x branch

### DIFF
--- a/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyAsyncHttpProvider.java
@@ -814,7 +814,8 @@ public class GrizzlyAsyncHttpProvider implements AsyncHttpProvider {
                 httpCtx.isWSRequest = true;
                 convertToUpgradeRequest(httpCtx);
             }
-            final URI uri = httpCtx.request.getURI();
+            final Request req = httpCtx.request;
+            final URI uri = req.isUseRawUrl() ? req.getRawURI() : req.getURI();
             final HttpRequestPacket.Builder builder = HttpRequestPacket.builder();
             boolean secure = "https".equals(uri.getScheme());
             builder.method(request.getMethod());


### PR DESCRIPTION
A backport of my prior pull request #437 to 1.7.x
