### PR TITLE
Resepect Raw URL setting for query string, too (Grizzly, 1.7.x)

### DIFF
--- a/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyAsyncHttpProvider.java
@@ -874,7 +874,8 @@ public class GrizzlyAsyncHttpProvider implements AsyncHttpProvider {
             ctx.notifyDownstream(new SwitchingSSLFilter.SSLSwitchingEvent(secure, ctx.getConnection()));
 
             if (!useProxy && !httpCtx.isWSRequest) {
-                addQueryString(request, requestPacket);
+                requestPacket.setQueryString(uri.getRawQuery());
+                //addQueryString(request, requestPacket);
             }
             addHeaders(request, requestPacket);
             addCookies(request, requestPacket);


### PR DESCRIPTION
Even with my prior pull request #439 applied, the query string was still escaped twice, when using raw URL. This change fixes it. 

The function addQueryString() - that I commented out - seems to do nothing that has not already be done when building the URI in the Request. Except it does not care for the isUseRawUrl() setting. If there's a subtle difference I did not notice, isUseRawUrl() should be added inside the body of that function.

All of async-http-client tests still pass. com.ning.http.client.async.QueryParametersTest has no tests for raw URLs, though. But our tests now show the same behavior for both Netty and Grizzly.
