### PR TITLE
Respecting raw URL for paths, and responses, too (Grizzly Provider)

### DIFF
--- a/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyAsyncHttpProvider.java
@@ -844,7 +844,7 @@ public class GrizzlyAsyncHttpProvider implements AsyncHttpProvider {
                     builder.uri(uri.toString());
                 }
             } else {
-                builder.uri(uri.getPath());
+                builder.uri(uri.getRawPath());
             }
             if (requestHasEntityBody(request)) {
                 final long contentLength = request.getContentLength();
@@ -1163,9 +1163,11 @@ public class GrizzlyAsyncHttpProvider implements AsyncHttpProvider {
                     }
                 }
             }
+            final Request req = context.request;
+            final URI req_uri = req.isUseRawUrl() ? req.getRawURI() : req.getURI();
             final GrizzlyResponseStatus responseStatus =
                     new GrizzlyResponseStatus((HttpResponsePacket) httpHeader,
-                            context.request.getURI(),
+                            req_uri,
                             provider);
             context.responseStatus = responseStatus;
             if (context.statusHandler != null) {


### PR DESCRIPTION
Setting raw URL still has some glitches with Grizzly. Namely the path is still escaped twice (e.g. http://example.com/white%20space becomes http://example.com/white%2520space), and the URI of the Response instance also is escaped twice.

This fixes it. Tests all pass.
