### PR TITLE
bump netty 4.0.13.Final -> 4.0.14.Final

### DIFF
--- a/providers/netty/pom.xml
+++ b/providers/netty/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.0.13.Final</version>
+            <version>4.0.14.Final</version>
         </dependency>
         <dependency>
             <groupId>org.javassist</groupId>


### PR DESCRIPTION
a new release netty version was published. note the [5.*](http://netty.io/wiki/new-and-noteworthy-in-5.x.html) series is also around the corner.
