### PR TITLE
Fix bug in netty websockets that treated a close frame as text.

### DIFF
--- a/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -2366,7 +2366,7 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
                     if (webSocket != null) {
                         if (pendingOpcode == OPCODE_BINARY) {
                             webSocket.onBinaryFragment(rp.getBodyPartBytes(), frame.isFinalFragment());
-                        } else {
+                        } else if (pendingOpcode == OPCODE_TEXT) {
                             webSocket.onTextFragment(frame.getBinaryData().toString(UTF8), frame.isFinalFragment());
                         }
 


### PR DESCRIPTION
When the remote server closes a websocket connection, the close frame is
treated as a text frame and junk bytes are sent to onTextFragment.
