### PR TITLE
Fast RFC2616 Date parser

### DIFF
--- a/api/src/main/java/org/asynchttpclient/AsyncHttpClientConfig.java
+++ b/api/src/main/java/org/asynchttpclient/AsyncHttpClientConfig.java
@@ -15,6 +15,7 @@
  */
 package org.asynchttpclient;
 
+import org.asynchttpclient.date.TimeConverter;
 import org.asynchttpclient.filter.IOExceptionFilter;
 import org.asynchttpclient.filter.RequestFilter;
 import org.asynchttpclient.filter.ResponseFilter;
@@ -24,6 +25,7 @@ import org.asynchttpclient.util.ProxyUtils;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
@@ -111,47 +113,49 @@ public class AsyncHttpClientConfig {
     protected int spdyInitialWindowSize;
     protected int spdyMaxConcurrentStreams;
     protected boolean asyncConnectMode;
+    protected TimeConverter timeConverter;
 
     protected AsyncHttpClientConfig() {
     }
 
-    private AsyncHttpClientConfig(int maxTotalConnections,
-                                  int maxConnectionPerHost,
-                                  int connectionTimeOutInMs,
-                                  int webSocketTimeoutInMs,
-                                  int idleConnectionInPoolTimeoutInMs,
-                                  int idleConnectionTimeoutInMs,
-                                  int requestTimeoutInMs,
-                                  int connectionMaxLifeTimeInMs,
-                                  boolean redirectEnabled,
-                                  int maxDefaultRedirects,
-                                  boolean compressionEnabled,
-                                  String userAgent,
-                                  boolean keepAlive,
-                                  ScheduledExecutorService reaper,
-                                  ExecutorService applicationThreadPool,
-                                  ProxyServerSelector proxyServerSelector,
-                                  SSLContext sslContext,
-                                  SSLEngineFactory sslEngineFactory,
-                                  AsyncHttpProviderConfig<?, ?> providerConfig,
-                                  Realm realm,
-                                  List<RequestFilter> requestFilters,
-                                  List<ResponseFilter> responseFilters,
-                                  List<IOExceptionFilter> ioExceptionFilters,
-                                  int requestCompressionLevel,
-                                  int maxRequestRetry,
-                                  boolean allowSslConnectionCaching,
-                                  boolean useRawUrl,
-                                  boolean removeQueryParamOnRedirect,
-                                  HostnameVerifier hostnameVerifier,
-                                  int ioThreadMultiplier,
-                                  boolean strict302Handling,
-                                  boolean useRelativeURIsWithSSLProxies,
-                                  boolean spdyEnabled,
-                                  int spdyInitialWindowSize,
-                                  int spdyMaxConcurrentStreams,
-                                  boolean rfc6265CookieEncoding,
-                                  boolean asyncConnectMode) {
+    private AsyncHttpClientConfig(int maxTotalConnections, //
+            int maxConnectionPerHost, //
+            int connectionTimeOutInMs, //
+            int webSocketTimeoutInMs, //
+            int idleConnectionInPoolTimeoutInMs, //
+            int idleConnectionTimeoutInMs, //
+            int requestTimeoutInMs, //
+            int connectionMaxLifeTimeInMs, //
+            boolean redirectEnabled, //
+            int maxDefaultRedirects, //
+            boolean compressionEnabled, //
+            String userAgent, //
+            boolean keepAlive, //
+            ScheduledExecutorService reaper, //
+            ExecutorService applicationThreadPool, //
+            ProxyServerSelector proxyServerSelector, //
+            SSLContext sslContext, //
+            SSLEngineFactory sslEngineFactory, //
+            AsyncHttpProviderConfig<?, ?> providerConfig, //
+            Realm realm, //
+            List<RequestFilter> requestFilters, //
+            List<ResponseFilter> responseFilters, //
+            List<IOExceptionFilter> ioExceptionFilters, //
+            int requestCompressionLevel, //
+            int maxRequestRetry, //
+            boolean allowSslConnectionCaching, //
+            boolean useRawUrl, //
+            boolean removeQueryParamOnRedirect, //
+            HostnameVerifier hostnameVerifier, //
+            int ioThreadMultiplier, //
+            boolean strict302Handling, //
+            boolean useRelativeURIsWithSSLProxies, //
+            boolean spdyEnabled, //
+            int spdyInitialWindowSize, //
+            int spdyMaxConcurrentStreams, //
+            boolean rfc6265CookieEncoding, //
+            boolean asyncConnectMode, //
+            TimeConverter timeConverter) {
 
         this.maxTotalConnections = maxTotalConnections;
         this.maxConnectionPerHost = maxConnectionPerHost;
@@ -188,6 +192,7 @@ public class AsyncHttpClientConfig {
         this.spdyInitialWindowSize = spdyInitialWindowSize;
         this.spdyMaxConcurrentStreams = spdyMaxConcurrentStreams;
         this.asyncConnectMode = asyncConnectMode;
+        this.timeConverter = timeConverter;
     }
 
     /**
@@ -440,7 +445,6 @@ public class AsyncHttpClientConfig {
         return allowSslConnectionPool;
     }
 
-
     /**
      * @return the useRawUrl
      */
@@ -558,6 +562,15 @@ public class AsyncHttpClientConfig {
     }
 
     /**
+     * @return the TimeConverter used for converting RFC2616Dates into time
+     *
+     * @since 2.0.0
+     */
+    public TimeConverter getTimeConverter() {
+        return timeConverter;
+    }
+
+    /**
      * Builder for an {@link AsyncHttpClient}
      */
     public static class Builder {
@@ -600,6 +613,7 @@ public class AsyncHttpClientConfig {
         private int spdyMaxConcurrentStreams = 100;
         private boolean rfc6265CookieEncoding = true;
         private boolean asyncConnectMode;
+        private TimeConverter timeConverter;
 
         public Builder() {
         }
@@ -1035,8 +1049,8 @@ public class AsyncHttpClientConfig {
          * @return a {@link Builder}
          */
         public Builder setMaxConnectionLifeTimeInMs(int maxConnectionLifeTimeInMs) {
-           this.defaultMaxConnectionLifeTimeInMs = maxConnectionLifeTimeInMs;
-           return this;
+            this.defaultMaxConnectionLifeTimeInMs = maxConnectionLifeTimeInMs;
+            return this;
         }
 
         /**
@@ -1125,6 +1139,11 @@ public class AsyncHttpClientConfig {
             return this;
         }
 
+        public Builder setTimeConverter(TimeConverter timeConverter) {
+            this.timeConverter = timeConverter;
+            return this;
+        }
+
         /**
          * Create a config builder with values taken from the given prototype configuration.
          *
@@ -1168,6 +1187,7 @@ public class AsyncHttpClientConfig {
             strict302Handling = prototype.isStrict302Handling();
             useRelativeURIsWithSSLProxies = prototype.isUseRelativeURIsWithSSLProxies();
             asyncConnectMode = prototype.isAsyncConnectMode();
+            timeConverter = prototype.getTimeConverter();
         }
 
         /**
@@ -1176,7 +1196,7 @@ public class AsyncHttpClientConfig {
          * @return an {@link AsyncHttpClientConfig}
          */
         public AsyncHttpClientConfig build() {
-            
+
             if (reaper == null) {
                 reaper = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors(), new ThreadFactory() {
                     public Thread newThread(Runnable r) {
@@ -1199,44 +1219,44 @@ public class AsyncHttpClientConfig {
                 proxyServerSelector = ProxyServerSelector.NO_PROXY_SELECTOR;
             }
 
-            return new AsyncHttpClientConfig(defaultMaxTotalConnections,
-                    defaultMaxConnectionPerHost,
-                    defaultConnectionTimeOutInMs,
-                    defaultWebsocketIdleTimeoutInMs,
-                    defaultIdleConnectionInPoolTimeoutInMs,
-                    defaultIdleConnectionTimeoutInMs,
-                    defaultRequestTimeoutInMs,
-                    defaultMaxConnectionLifeTimeInMs,
-                    redirectEnabled,
-                    maxDefaultRedirects,
-                    compressionEnabled,
-                    userAgent,
-                    allowPoolingConnection,
-                    reaper,
-                    applicationThreadPool,
-                    proxyServerSelector,
-                    sslContext,
-                    sslEngineFactory,
-                    providerConfig,
-                    realm,
-                    requestFilters,
-                    responseFilters,
-                    ioExceptionFilters,
-                    requestCompressionLevel,
-                    maxRequestRetry,
-                    allowSslConnectionPool,
-                    useRawUrl,
-                    removeQueryParamOnRedirect,
-                    hostnameVerifier,
-                    ioThreadMultiplier,
-                    strict302Handling,
-                    useRelativeURIsWithSSLProxies,
-                    spdyEnabled,
-                    spdyInitialWindowSize,
-                    spdyMaxConcurrentStreams,
-                    rfc6265CookieEncoding,
-                    asyncConnectMode);
+            return new AsyncHttpClientConfig(defaultMaxTotalConnections, //
+                    defaultMaxConnectionPerHost, //
+                    defaultConnectionTimeOutInMs, //
+                    defaultWebsocketIdleTimeoutInMs, //
+                    defaultIdleConnectionInPoolTimeoutInMs, //
+                    defaultIdleConnectionTimeoutInMs, //
+                    defaultRequestTimeoutInMs, //
+                    defaultMaxConnectionLifeTimeInMs, //
+                    redirectEnabled, //
+                    maxDefaultRedirects, //
+                    compressionEnabled, //
+                    userAgent, //
+                    allowPoolingConnection, //
+                    reaper, //
+                    applicationThreadPool, //
+                    proxyServerSelector, //
+                    sslContext, //
+                    sslEngineFactory, //
+                    providerConfig, //
+                    realm, //
+                    requestFilters, //
+                    responseFilters, //
+                    ioExceptionFilters, //
+                    requestCompressionLevel, //
+                    maxRequestRetry, //
+                    allowSslConnectionPool, //
+                    useRawUrl, //
+                    removeQueryParamOnRedirect, //
+                    hostnameVerifier, //
+                    ioThreadMultiplier, //
+                    strict302Handling, //
+                    useRelativeURIsWithSSLProxies, //
+                    spdyEnabled, //
+                    spdyInitialWindowSize, //
+                    spdyMaxConcurrentStreams, //
+                    rfc6265CookieEncoding, //
+                    asyncConnectMode, //
+                    timeConverter);
         }
     }
 }
-

--- a/api/src/main/java/org/asynchttpclient/cookie/Cookie.java
+++ b/api/src/main/java/org/asynchttpclient/cookie/Cookie.java
@@ -14,11 +14,7 @@ package org.asynchttpclient.cookie;
 
 public class Cookie {
 
-    public static Cookie newValidCookie(String domain, String name, String value, String path, int maxAge, boolean secure) {
-        return newValidCookie(domain, name, value, value, path, maxAge, secure, false);
-    }
-
-    public static Cookie newValidCookie(String domain, String name, String value, String rawValue, String path, int maxAge, boolean secure, boolean httpOnly) {
+    public static Cookie newValidCookie(String domain, String name, String value, String rawValue, String path, long expires, int maxAge, boolean secure, boolean httpOnly) {
 
         if (name == null) {
             throw new NullPointerException("name");
@@ -60,7 +56,7 @@ public class Cookie {
         domain = validateValue("domain", domain);
         path = validateValue("path", path);
 
-        return new Cookie(domain, name, value, rawValue, path, maxAge, secure, httpOnly);
+        return new Cookie(domain, name, value, rawValue, path, expires, maxAge, secure, httpOnly);
     }
 
     private static String validateValue(String name, String value) {
@@ -91,16 +87,18 @@ public class Cookie {
     private final String value;
     private final String rawValue;
     private final String path;
+    private long expires;
     private final int maxAge;
     private final boolean secure;
     private final boolean httpOnly;
 
-    public Cookie(String domain, String name, String value, String rawValue, String path, int maxAge, boolean secure, boolean httpOnly) {
+    public Cookie(String domain, String name, String value, String rawValue, String path, long expires, int maxAge, boolean secure, boolean httpOnly) {
         this.domain = domain;
         this.name = name;
         this.value = value;
         this.rawValue = rawValue;
         this.path = path;
+        this.expires = expires;
         this.maxAge = maxAge;
         this.secure = secure;
         this.httpOnly = httpOnly;
@@ -126,6 +124,10 @@ public class Cookie {
         return path;
     }
 
+    public long getExpires() {
+        return expires;
+    }
+    
     public int getMaxAge() {
         return maxAge;
     }
@@ -144,15 +146,19 @@ public class Cookie {
         buf.append(name);
         buf.append("=");
         buf.append(rawValue);
-        if (getDomain() != null) {
+        if (domain != null) {
             buf.append("; domain=");
             buf.append(domain);
         }
-        if (getPath() != null) {
+        if (path != null) {
             buf.append("; path=");
             buf.append(path);
         }
-        if (getMaxAge() >= 0) {
+        if (expires >= 0) {
+            buf.append("; expires=");
+            buf.append(expires);
+        }
+        if (maxAge >= 0) {
             buf.append("; maxAge=");
             buf.append(maxAge);
             buf.append("s");

--- a/api/src/main/java/org/asynchttpclient/cookie/CookieEncoder.java
+++ b/api/src/main/java/org/asynchttpclient/cookie/CookieEncoder.java
@@ -19,7 +19,7 @@ public final class CookieEncoder {
     private CookieEncoder() {
     }
 
-    public static String encodeClientSide(Collection<Cookie> cookies) {
+    public static String encode(Collection<Cookie> cookies) {
         StringBuilder sb = new StringBuilder();
 
         for (Cookie cookie : cookies) {

--- a/api/src/main/java/org/asynchttpclient/date/CalendarTimeConverter.java
+++ b/api/src/main/java/org/asynchttpclient/date/CalendarTimeConverter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2014 Sonatype, Inc. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.date;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+/**
+ * Calendar based TimeConverter.
+ * Note that a Joda-Time or DateTime based implementation would be more efficient, but AHC doesn't have a dependency to JodaTime.
+ * 
+ * @author slandelle
+ */
+public class CalendarTimeConverter implements TimeConverter {
+
+    public static final TimeZone GMT = TimeZone.getTimeZone("GMT");
+
+    @Override
+    public long toTime(RFC2616Date dateElements) {
+
+        Calendar calendar = new GregorianCalendar(//
+                dateElements.year(), //
+                dateElements.month() - 1, // beware, Calendar use months from 0 to 11
+                dateElements.dayOfMonth(), //
+                dateElements.hour(), //
+                dateElements.minute(), //
+                dateElements.second());
+        calendar.setTimeZone(GMT);
+        return calendar.getTimeInMillis();
+    }
+}

--- a/api/src/main/java/org/asynchttpclient/date/RFC2616Date.java
+++ b/api/src/main/java/org/asynchttpclient/date/RFC2616Date.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2010-2014 Sonatype, Inc. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.date;
+
+/**
+ * A placeholder for RFC2616 date elements
+ * 
+ * @author slandelle
+ */
+public final class RFC2616Date {
+
+    private final int year;
+    // 1 to 12
+    private final int month;
+    private final int dayOfMonth;
+    private final int hour;
+    private final int minute;
+    private final int second;
+
+    public RFC2616Date(int year, int month, int dayOfMonth, int hour, int minute, int second) {
+        this.year = year;
+        this.month = month;
+        this.dayOfMonth = dayOfMonth;
+        this.hour = hour;
+        this.minute = minute;
+        this.second = second;
+    }
+
+    public int year() {
+        return year;
+    }
+
+    public int month() {
+        return month;
+    }
+
+    public int dayOfMonth() {
+        return dayOfMonth;
+    }
+
+    public int hour() {
+        return hour;
+    }
+
+    public int minute() {
+        return minute;
+    }
+
+    public int second() {
+        return second;
+    }
+
+    public static final class Builder {
+
+        private int dayOfMonth;
+        private int month;
+        private int year;
+        private int hour;
+        private int minute;
+        private int second;
+
+        public void setDayOfMonth(int dayOfMonth) {
+            this.dayOfMonth = dayOfMonth;
+        }
+
+        public void setJanuary() {
+            month = 1;
+        }
+
+        public void setFebruary() {
+            month = 2;
+        }
+
+        public void setMarch() {
+            month = 3;
+        }
+
+        public void setApril() {
+            month = 4;
+        }
+
+        public void setMay() {
+            month = 5;
+        }
+
+        public void setJune() {
+            month = 6;
+        }
+
+        public void setJuly() {
+            month = 7;
+        }
+
+        public void setAugust() {
+            month = 8;
+        }
+
+        public void setSeptember() {
+            month = 9;
+        }
+
+        public void setOctobre() {
+            month = 10;
+        }
+
+        public void setNovembre() {
+            month = 11;
+        }
+
+        public void setDecember() {
+            month = 12;
+        }
+
+        public void setYear(int year) {
+            this.year = year;
+        }
+
+        public void setHour(int hour) {
+            this.hour = hour;
+        }
+
+        public void setMinute(int minute) {
+            this.minute = minute;
+        }
+
+        public void setSecond(int second) {
+            this.second = second;
+        }
+
+        public RFC2616Date build() {
+            return new RFC2616Date(year, month, dayOfMonth, hour, minute, second);
+        }
+    }
+}

--- a/api/src/main/java/org/asynchttpclient/date/RFC2616DateParser.java
+++ b/api/src/main/java/org/asynchttpclient/date/RFC2616DateParser.java
@@ -1,0 +1,434 @@
+/*
+ * Copyright (c) 2014 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.date;
+
+import org.asynchttpclient.date.RFC2616Date.Builder;
+
+/**
+ * A parser for <a href="http://tools.ietf.org/html/rfc2616#section-3.3">RFC2616
+ * Date format</a>.
+ * 
+ * @author slandelle
+ */
+public class RFC2616DateParser {
+
+    private final String string;
+    private final int offset;
+    private final int length;
+
+    /**
+     * @param string a string that will be fully parsed
+     */
+    public RFC2616DateParser(String string) {
+        this(string, 0, string.length());
+    }
+
+    /**
+     * @param string the string to be parsed
+     * @param offset the offset where to start parsing
+     * @param length the number of chars to parse
+     */
+    public RFC2616DateParser(String string, int offset, int length) {
+
+        if (string.length() + offset < length)
+            throw new IllegalArgumentException("String length doesn't match offset and length");
+
+        this.string = string;
+        this.offset = offset;
+        this.length = length;
+    }
+
+    private static class Tokens {
+        public final int[] starts;
+        public final int[] ends;
+        public final int length;
+
+        public Tokens(int[] starts, int[] ends, int length) {
+            this.starts = starts;
+            this.ends = ends;
+            this.length = length;
+        }
+    }
+
+    private Tokens tokenize() {
+
+        int[] starts = new int[8];
+        int[] ends = new int[8];
+        boolean inToken = false;
+        int tokenCount = 0;
+
+        int end = offset + length;
+        for (int i = offset; i < end; i++) {
+
+            char c = string.charAt(i);
+            if (c == ' ' || c == ',' || c == '-' || c == ':') {
+                if (inToken) {
+                    ends[tokenCount++] = i;
+                    inToken = false;
+                }
+            } else if (!inToken) {
+                starts[tokenCount] = i;
+                inToken = true;
+            }
+        }
+
+        // finish lastToken
+        if (inToken = true)
+            ends[tokenCount++] = end;
+
+        return new Tokens(starts, ends, tokenCount);
+    }
+
+    /**
+     * @param validate if validation is to be enabled of non-critical elements,
+     *            such as day of week and timezone
+     * @return null is the string is not a valid RFC2616 date
+     */
+    public RFC2616Date parse() {
+
+        Tokens tokens = tokenize();
+
+        if (tokens.length != 7 && tokens.length != 8)
+            return null;
+
+        // 1st token is ignored: ignore day of week
+        // 8th token is ignored: supposed to always be GMT
+
+        if (isDigit(string.charAt(tokens.starts[1])))
+            return buildDate(tokens);
+        else
+            return buildANSICDate(tokens);
+    }
+
+    private RFC2616Date buildDate(Tokens tokens) {
+
+        // Sun, 06 Nov 1994 08:49:37 GMT
+
+        Builder dateBuilder = new Builder();
+
+        if (isValidDayOfMonth(tokens.starts[1], tokens.ends[1], dateBuilder) && //
+                isValidMonth(tokens.starts[2], tokens.ends[2], dateBuilder) && //
+                isValidYear(tokens.starts[3], tokens.ends[3], dateBuilder) && //
+                isValidHour(tokens.starts[4], tokens.ends[4], dateBuilder) && //
+                isValidMinuteSecond(tokens.starts[5], tokens.ends[5], dateBuilder, true) && //
+                isValidMinuteSecond(tokens.starts[6], tokens.ends[6], dateBuilder, false)) {
+            return dateBuilder.build();
+        }
+
+        return null;
+    }
+
+    private RFC2616Date buildANSICDate(Tokens tokens) {
+
+        // Sun Nov 6 08:49:37 1994
+
+        Builder dateBuilder = new Builder();
+
+        if (isValidMonth(tokens.starts[1], tokens.ends[1], dateBuilder) && //
+                isValidDayOfMonth(tokens.starts[2], tokens.ends[2], dateBuilder) && //
+                isValidHour(tokens.starts[3], tokens.ends[3], dateBuilder) && //
+                isValidMinuteSecond(tokens.starts[4], tokens.ends[4], dateBuilder, true) && //
+                isValidMinuteSecond(tokens.starts[5], tokens.ends[5], dateBuilder, false) && //
+                isValidYear(tokens.starts[6], tokens.ends[6], dateBuilder)) {
+            return dateBuilder.build();
+        }
+
+        return null;
+    }
+
+    private boolean isValid1DigitDayOfMonth(char c0, Builder dateBuilder) {
+        if (isDigit(c0)) {
+            dateBuilder.setDayOfMonth(getNumericValue(c0));
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isValid2DigitsDayOfMonth(char c0, char c1, Builder dateBuilder) {
+        if (isDigit(c0) && isDigit(c1)) {
+            int i0 = getNumericValue(c0);
+            int i1 = getNumericValue(c1);
+            int day = i0 * 10 + i1;
+            if (day <= 31) {
+                dateBuilder.setDayOfMonth(day);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isValidDayOfMonth(int start, int end, Builder dateBuilder) {
+
+        int tokenLength = end - start;
+
+        if (tokenLength == 1) {
+            char c0 = string.charAt(start);
+            return isValid1DigitDayOfMonth(c0, dateBuilder);
+
+        } else if (tokenLength == 2) {
+            char c0 = string.charAt(start);
+            char c1 = string.charAt(start + 1);
+            return isValid2DigitsDayOfMonth(c0, c1, dateBuilder);
+        }
+        return false;
+    }
+
+    private boolean isValidJanuaryJuneJuly(char c0, char c1, char c2, Builder dateBuilder) {
+        if (c0 == 'J' || c0 == 'j')
+            if (c1 == 'a' || c1 == 'A') {
+                if (c2 == 'n' || c2 == 'N') {
+                    dateBuilder.setJanuary();
+                    return true;
+                }
+            } else if (c1 == 'u' || c1 == 'U') {
+                if (c2 == 'n' || c2 == 'N') {
+                    dateBuilder.setJune();
+                    return true;
+                } else if (c2 == 'l' || c2 == 'L') {
+                    dateBuilder.setJuly();
+                    return true;
+                }
+            }
+        return false;
+    }
+
+    private boolean isValidFebruary(char c0, char c1, char c2, Builder dateBuilder) {
+        if ((c0 == 'F' || c0 == 'f') && (c1 == 'e' || c1 == 'E') && (c2 == 'b' || c2 == 'B')) {
+            dateBuilder.setFebruary();
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isValidMarchMay(char c0, char c1, char c2, Builder dateBuilder) {
+        if ((c0 == 'M' || c0 == 'm') && (c1 == 'a' || c1 == 'A')) {
+            if (c2 == 'r' || c2 == 'R') {
+                dateBuilder.setMarch();
+                return true;
+            } else if (c2 == 'y' || c2 == 'M') {
+                dateBuilder.setMay();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isValidAprilAugust(char c0, char c1, char c2, Builder dateBuilder) {
+        if (c0 == 'A' || c0 == 'a')
+            if ((c1 == 'p' || c1 == 'P') && (c2 == 'r' || c2 == 'R')) {
+                dateBuilder.setApril();
+                return true;
+            } else if ((c1 == 'u' || c1 == 'U') && (c2 == 'g' || c2 == 'G')) {
+                dateBuilder.setAugust();
+                return true;
+            }
+        return false;
+    }
+
+    private boolean isValidSeptember(char c0, char c1, char c2, Builder dateBuilder) {
+        if ((c0 == 'S' || c0 == 's') && (c1 == 'e' || c1 == 'E') && (c2 == 'p' || c2 == 'P')) {
+            dateBuilder.setSeptember();
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isValidOctober(char c0, char c1, char c2, Builder dateBuilder) {
+        if ((c0 == 'O' || c0 == 'o') && (c1 == 'c' || c1 == 'C') && (c2 == 't' || c2 == 'T')) {
+            dateBuilder.setOctobre();
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isValidNovember(char c0, char c1, char c2, Builder dateBuilder) {
+        if ((c0 == 'N' || c0 == 'n') && (c1 == 'o' || c1 == 'O') && (c2 == 'v' || c2 == 'V')) {
+            dateBuilder.setNovembre();
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isValidDecember(char c0, char c1, char c2, Builder dateBuilder) {
+        if (c0 == 'D' || c0 == 'd')
+            if (c1 == 'e' || c1 == 'E') {
+                if (c2 == 'c' || c2 == 'C') {
+                    dateBuilder.setDecember();
+                    return true;
+                }
+            }
+        return false;
+    }
+
+    private boolean isValidMonth(int start, int end, Builder dateBuilder) {
+
+        if (end - start != 3)
+            return false;
+
+        char c0 = string.charAt(start);
+        char c1 = string.charAt(start + 1);
+        char c2 = string.charAt(start + 2);
+
+        return isValidJanuaryJuneJuly(c0, c1, c2, dateBuilder) || //
+                isValidFebruary(c0, c1, c2, dateBuilder) || //
+                isValidMarchMay(c0, c1, c2, dateBuilder) || //
+                isValidAprilAugust(c0, c1, c2, dateBuilder) || //
+                isValidSeptember(c0, c1, c2, dateBuilder) || //
+                isValidOctober(c0, c1, c2, dateBuilder) || //
+                isValidNovember(c0, c1, c2, dateBuilder) || //
+                isValidDecember(c0, c1, c2, dateBuilder);
+    }
+
+    private boolean isValid2DigitsYear(char c0, char c1, Builder dateBuilder) {
+        if (isDigit(c0) && isDigit(c1)) {
+            int i0 = getNumericValue(c0);
+            int i1 = getNumericValue(c1);
+            int year = i0 * 10 + i1;
+            year = year < 70 ? year + 2000 : year + 1900;
+
+            return setValidYear(year, dateBuilder);
+        }
+        return false;
+    }
+
+    private boolean isValid4DigitsYear(char c0, char c1, char c2, char c3, Builder dateBuilder) {
+        if (isDigit(c0) && isDigit(c1) && isDigit(c2) && isDigit(c3)) {
+            int i0 = getNumericValue(c0);
+            int i1 = getNumericValue(c1);
+            int i2 = getNumericValue(c2);
+            int i3 = getNumericValue(c3);
+            int year = i0 * 1000 + i1 * 100 + i2 * 10 + i3;
+
+            return setValidYear(year, dateBuilder);
+        }
+        return false;
+    }
+
+    private boolean setValidYear(int year, Builder dateBuilder) {
+        if (year >= 1601) {
+            dateBuilder.setYear(year);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isValidYear(int start, int end, Builder dateBuilder) {
+
+        int length = end - start;
+
+        if (length == 2) {
+            char c0 = string.charAt(start);
+            char c1 = string.charAt(start + 1);
+            return isValid2DigitsYear(c0, c1, dateBuilder);
+
+        } else if (length == 4) {
+            char c0 = string.charAt(start);
+            char c1 = string.charAt(start + 1);
+            char c2 = string.charAt(start + 2);
+            char c3 = string.charAt(start + 3);
+            return isValid4DigitsYear(c0, c1, c2, c3, dateBuilder);
+        }
+
+        return false;
+    }
+
+    private boolean isValid1DigitHour(char c0, Builder dateBuilder) {
+        if (isDigit(c0)) {
+            int hour = getNumericValue(c0);
+            dateBuilder.setHour(hour);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isValid2DigitsHour(char c0, char c1, Builder dateBuilder) {
+        if (isDigit(c0) && isDigit(c1)) {
+            int i0 = getNumericValue(c0);
+            int i1 = getNumericValue(c1);
+            int hour = i0 * 10 + i1;
+            if (hour <= 24) {
+                dateBuilder.setHour(hour);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isValidHour(int start, int end, Builder dateBuilder) {
+
+        int length = end - start;
+
+        if (length == 1) {
+            char c0 = string.charAt(start);
+            return isValid1DigitHour(c0, dateBuilder);
+
+        } else if (length == 2) {
+            char c0 = string.charAt(start);
+            char c1 = string.charAt(start + 1);
+            return isValid2DigitsHour(c0, c1, dateBuilder);
+        }
+        return false;
+    }
+
+    private boolean isValid1DigitMinuteSecond(char c0, Builder dateBuilder, boolean minuteOrSecond) {
+        if (isDigit(c0)) {
+            int value = getNumericValue(c0);
+            if (minuteOrSecond)
+                dateBuilder.setMinute(value);
+            else
+                dateBuilder.setSecond(value);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isValid2DigitsMinuteSecond(char c0, char c1, Builder dateBuilder, boolean minuteOrSecond) {
+        if (isDigit(c0) && isDigit(c1)) {
+            int i0 = getNumericValue(c0);
+            int i1 = getNumericValue(c1);
+            int value = i0 * 10 + i1;
+            if (value <= 60) {
+                if (minuteOrSecond)
+                    dateBuilder.setMinute(value);
+                else
+                    dateBuilder.setSecond(value);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isValidMinuteSecond(int start, int end, Builder dateBuilder, boolean minuteOrSecond) {
+
+        int length = end - start;
+
+        if (length == 1) {
+            char c0 = string.charAt(start);
+            return isValid1DigitMinuteSecond(c0, dateBuilder, minuteOrSecond);
+
+        } else if (length == 2) {
+            char c0 = string.charAt(start);
+            char c1 = string.charAt(start + 1);
+            return isValid2DigitsMinuteSecond(c0, c1, dateBuilder, minuteOrSecond);
+        }
+        return false;
+    }
+
+    private boolean isDigit(char c) {
+        return c >= '0' && c <= '9';
+    }
+
+    private int getNumericValue(char c) {
+        return (int) c - 48;
+    }
+}

--- a/api/src/main/java/org/asynchttpclient/date/TimeConverter.java
+++ b/api/src/main/java/org/asynchttpclient/date/TimeConverter.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2010-2014 Sonatype, Inc. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.date;
+
+/**
+ * Converts a RFC2616Date to time in millis
+ * 
+ * @author slandelle
+ */
+public interface TimeConverter {
+
+    long toTime(RFC2616Date dateElements);
+}

--- a/api/src/main/java/org/asynchttpclient/util/AsyncHttpProviderUtils.java
+++ b/api/src/main/java/org/asynchttpclient/util/AsyncHttpProviderUtils.java
@@ -20,11 +20,9 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
-import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Vector;
@@ -287,54 +285,11 @@ public class AsyncHttpProviderUtils {
         return null;
     }
 
-    public static Integer convertExpireField(String timestring) {
-        String trimmedTimeString = timestring.trim();
-
-        for (SimpleDateFormat sdf : simpleDateFormat.get()) {
-            Date date = sdf.parse(trimmedTimeString, new ParsePosition(0));
-            if (date != null) {
-                long now = System.currentTimeMillis();
-                long maxAgeMillis = date.getTime() - now;
-                return (int) (maxAgeMillis / 1000) + (maxAgeMillis % 1000 != 0 ? 1 : 0);
-            }
-        }
-
-        return null;
+    public static int secondsFromNow(long timeMillis) {
+        long maxAgeMillis = timeMillis - System.currentTimeMillis();
+        return (int) (maxAgeMillis / 1000) + (maxAgeMillis % 1000 != 0 ? 1 : 0);
     }
-
-    public final static String removeQuotes(String s) {
-        if (MiscUtil.isNonEmpty(s)) {
-            int start = 0;
-            int end = s.length();
-            boolean changed = false;
-
-            if (s.charAt(0) == '"') {
-                changed = true;
-                start++;
-            }
-
-            if (s.charAt(s.length() - 1) == '"') {
-                changed = true;
-                end--;
-            }
-
-            if (changed)
-                s = s.substring(start, end);
-        }
-        return s;
-    }
-
-    public static void checkBodyParts(int statusCode, Collection<HttpResponseBodyPart> bodyParts) {
-        if (bodyParts == null || bodyParts.size() == 0) {
-
-            // We allow empty body on 204
-            if (statusCode == 204)
-                return;
-
-            throw new IllegalStateException(BODY_NOT_COMPUTED);
-        }
-    }
-
+    
     public static String keepAliveHeaderValue(AsyncHttpClientConfig config) {
         return config.getAllowPoolingConnection() ? "keep-alive" : "close";
     }

--- a/api/src/test/java/org/asynchttpclient/async/AsyncProvidersBasicTest.java
+++ b/api/src/test/java/org/asynchttpclient/async/AsyncProvidersBasicTest.java
@@ -469,7 +469,7 @@ public abstract class AsyncProvidersBasicTest extends AbstractBasicTest {
             h.add("Test4", "Test4");
             h.add("Test5", "Test5");
 
-            final Cookie coo = Cookie.newValidCookie("/", "foo", "value", "/", -1, false);
+            final Cookie coo = Cookie.newValidCookie("/", "foo", "value", "value", "/", -1L, -1, false, false);
             client.prepareGet(getTargetUrl()).setHeaders(h).addCookie(coo).execute(new AsyncCompletionHandlerAdapter() {
 
                 @Override

--- a/api/src/test/java/org/asynchttpclient/async/RemoteSiteTest.java
+++ b/api/src/test/java/org/asynchttpclient/async/RemoteSiteTest.java
@@ -251,7 +251,7 @@ public abstract class RemoteSiteTest extends AbstractBasicTest {
             builder2.setFollowRedirects(true);
             builder2.setUrl("http://www.google.com/");
             builder2.addHeader("Content-Type", "text/plain");
-            builder2.addCookie(new Cookie(".google.com", "evilcookie", "evilcookie", "test", "/", 10, false, false));
+            builder2.addCookie(new Cookie(".google.com", "evilcookie", "evilcookie", "test", "/", -1L, 10, false, false));
             Request request2 = builder2.build();
             Response response = c.executeRequest(request2).get();
 

--- a/api/src/test/java/org/asynchttpclient/cookie/CookieDecoderTest.java
+++ b/api/src/test/java/org/asynchttpclient/cookie/CookieDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2012 Sonatype, Inc. All rights reserved.
+ * Copyright (c) 2014 AsyncHttpClient Project. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -25,7 +25,6 @@ public class CookieDecoderTest {
     public void testDecodeUnquoted() {
         Cookie cookie = CookieDecoder.decode("foo=value; domain=/; path=/");
         assertNotNull(cookie);
-
         assertEquals(cookie.getValue(), "value");
         assertEquals(cookie.getRawValue(), "value");
         assertEquals(cookie.getDomain(), "/");
@@ -36,7 +35,6 @@ public class CookieDecoderTest {
     public void testDecodeQuoted() {
         Cookie cookie = CookieDecoder.decode("ALPHA=\"VALUE1\"; Domain=docs.foo.com; Path=/accounts; Expires=Wed, 05 Feb 2014 07:37:38 GMT; Secure; HttpOnly");
         assertNotNull(cookie);
-
         assertEquals(cookie.getValue(), "VALUE1");
         assertEquals(cookie.getRawValue(), "\"VALUE1\"");
     }
@@ -45,7 +43,6 @@ public class CookieDecoderTest {
     public void testDecodeQuotedContainingEscapedQuote() {
         Cookie cookie = CookieDecoder.decode("ALPHA=\"VALUE1\\\"\"; Domain=docs.foo.com; Path=/accounts; Expires=Wed, 05 Feb 2014 07:37:38 GMT; Secure; HttpOnly");
         assertNotNull(cookie);
-
         assertEquals(cookie.getValue(), "VALUE1\"");
         assertEquals(cookie.getRawValue(), "\"VALUE1\\\"\"");
     }

--- a/api/src/test/java/org/asynchttpclient/date/RFC2616DateParserTest.java
+++ b/api/src/test/java/org/asynchttpclient/date/RFC2616DateParserTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2014 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.date;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import org.testng.annotations.Test;
+
+/**
+ * See http://tools.ietf.org/html/rfc2616#section-3.3
+ * 
+ * @author slandelle
+ */
+public class RFC2616DateParserTest {
+
+    @Test(groups = "fast")
+    public void testRFC822() {
+        RFC2616Date date = new RFC2616DateParser("Sun, 06 Nov 1994 08:49:37 GMT").parse();
+        assertNotNull(date);
+        assertEquals(date.dayOfMonth(), 6);
+        assertEquals(date.month(), 11);
+        assertEquals(date.year(), 1994);
+        assertEquals(date.hour(), 8);
+        assertEquals(date.minute(), 49);
+        assertEquals(date.second(), 37);
+    }
+
+    @Test(groups = "fast")
+    public void testRFC822SingleDigitDayOfMonth() {
+        RFC2616Date date = new RFC2616DateParser("Sun, 6 Nov 1994 08:49:37 GMT").parse();
+        assertNotNull(date);
+        assertEquals(date.dayOfMonth(), 6);
+    }
+
+    @Test(groups = "fast")
+    public void testRFC822TwoDigitsYear() {
+        RFC2616Date date = new RFC2616DateParser("Sun, 6 Nov 94 08:49:37 GMT").parse();
+        assertNotNull(date);
+        assertEquals(date.year(), 1994);
+    }
+
+    @Test(groups = "fast")
+    public void testRFC822SingleDigitHour() {
+        RFC2616Date date = new RFC2616DateParser("Sun, 6 Nov 1994 8:49:37 GMT").parse();
+        assertNotNull(date);
+        assertEquals(date.hour(), 8);
+    }
+
+    @Test(groups = "fast")
+    public void testRFC822SingleDigitMinute() {
+        RFC2616Date date = new RFC2616DateParser("Sun, 6 Nov 1994 08:9:37 GMT").parse();
+        assertNotNull(date);
+        assertEquals(date.minute(), 9);
+    }
+
+    @Test(groups = "fast")
+    public void testRFC822SingleDigitSecond() {
+        RFC2616Date date = new RFC2616DateParser("Sun, 6 Nov 1994 08:49:7 GMT").parse();
+        assertNotNull(date);
+        assertEquals(date.second(), 7);
+    }
+
+    @Test(groups = "fast")
+    public void testRFC6265() {
+        RFC2616Date date = new RFC2616DateParser("Sun, 06 Nov 1994 08:49:37").parse();
+        assertNotNull(date);
+        assertEquals(date.dayOfMonth(), 6);
+        assertEquals(date.month(), 11);
+        assertEquals(date.year(), 1994);
+        assertEquals(date.hour(), 8);
+        assertEquals(date.minute(), 49);
+        assertEquals(date.second(), 37);
+    }
+
+    @Test(groups = "fast")
+    public void testRFC850() {
+        RFC2616Date date = new RFC2616DateParser("Sunday, 06-Nov-94 08:49:37 GMT").parse();
+        assertNotNull(date);
+        assertEquals(date.dayOfMonth(), 6);
+        assertEquals(date.month(), 11);
+        assertEquals(date.year(), 1994);
+        assertEquals(date.hour(), 8);
+        assertEquals(date.minute(), 49);
+        assertEquals(date.second(), 37);
+    }
+
+    @Test(groups = "fast")
+    public void testANSIC() {
+        RFC2616Date date = new RFC2616DateParser("Sun Nov  6 08:49:37 1994").parse();
+        assertNotNull(date);
+        assertEquals(date.dayOfMonth(), 6);
+        assertEquals(date.month(), 11);
+        assertEquals(date.year(), 1994);
+        assertEquals(date.hour(), 8);
+        assertEquals(date.minute(), 49);
+        assertEquals(date.second(), 37);
+    }
+}

--- a/providers/grizzly/src/main/java/org/asynchttpclient/providers/grizzly/GrizzlyResponse.java
+++ b/providers/grizzly/src/main/java/org/asynchttpclient/providers/grizzly/GrizzlyResponse.java
@@ -170,6 +170,7 @@ public class GrizzlyResponse extends ResponseBase {
                                    gCookie.getValue(),
                                    gCookie.getValue(),
                                    gCookie.getPath(),
+                                   -1L,
                                    gCookie.getMaxAge(),
                                    gCookie.isSecure(),
                                    gCookie.isHttpOnly()));

--- a/providers/netty/src/main/java/org/asynchttpclient/providers/netty/request/NettyRequestFactory.java
+++ b/providers/netty/src/main/java/org/asynchttpclient/providers/netty/request/NettyRequestFactory.java
@@ -287,7 +287,7 @@ public final class NettyRequestFactory {
             }
 
             if (isNonEmpty(request.getCookies()))
-                httpRequest.headers().set(HttpHeaders.Names.COOKIE, CookieEncoder.encodeClientSide(request.getCookies()));
+                httpRequest.headers().set(HttpHeaders.Names.COOKIE, CookieEncoder.encode(request.getCookies()));
 
             if (config.isCompressionEnabled())
                 httpRequest.headers().set(HttpHeaders.Names.ACCEPT_ENCODING, GZIP_DEFLATE);

--- a/providers/netty/src/main/java/org/asynchttpclient/providers/netty/response/NettyResponse.java
+++ b/providers/netty/src/main/java/org/asynchttpclient/providers/netty/response/NettyResponse.java
@@ -24,25 +24,27 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import org.asynchttpclient.HttpResponseBodyPart;
 import org.asynchttpclient.HttpResponseHeaders;
 import org.asynchttpclient.HttpResponseStatus;
 import org.asynchttpclient.cookie.Cookie;
 import org.asynchttpclient.cookie.CookieDecoder;
+import org.asynchttpclient.date.TimeConverter;
 import org.asynchttpclient.providers.ResponseBase;
 import org.asynchttpclient.util.AsyncHttpProviderUtils;
+import org.asynchttpclient.util.MiscUtil;
 
 /**
  * Wrapper around the {@link org.asynchttpclient.Response} API.
  */
 public class NettyResponse extends ResponseBase {
 
-    public NettyResponse(HttpResponseStatus status,
-                         HttpResponseHeaders headers,
-                         List<HttpResponseBodyPart> bodyParts) {
+    private final TimeConverter timeConverter;
+
+    public NettyResponse(HttpResponseStatus status, HttpResponseHeaders headers, List<HttpResponseBodyPart> bodyParts, TimeConverter timeConverter) {
         super(status, headers, bodyParts);
+        this.timeConverter = timeConverter;
     }
 
     @Override
@@ -56,22 +58,26 @@ public class NettyResponse extends ResponseBase {
         byte[] b = AsyncHttpProviderUtils.contentToBytes(bodyParts, maxLength);
         return new String(b, charset);
     }
-    
+
     protected List<Cookie> buildCookies() {
-    	List<Cookie> cookies = new ArrayList<Cookie>();
-        for (Map.Entry<String, List<String>> header : headers.getHeaders().entrySet()) {
-            // FIXME what about SET_COOKIE2?
-            if (header.getKey().equalsIgnoreCase(HttpHeaders.Names.SET_COOKIE)) {
-                // TODO: ask for parsed header
-                List<String> v = header.getValue();
-                for (String value : v) {
-                    Cookie c = CookieDecoder.decode(value);
-                    if (c != null)
-                        cookies.add(c);
-                }
-            }
+
+        List<String> setCookieHeaders = headers.getHeaders().get(HttpHeaders.Names.SET_COOKIE2);
+
+        if (!MiscUtil.isNonEmpty(setCookieHeaders)) {
+            setCookieHeaders = headers.getHeaders().get(HttpHeaders.Names.SET_COOKIE);
         }
-        return Collections.unmodifiableList(cookies);
+
+        if (MiscUtil.isNonEmpty(setCookieHeaders)) {
+            List<Cookie> cookies = new ArrayList<Cookie>();
+            for (String value : setCookieHeaders) {
+                Cookie c = CookieDecoder.decode(value, timeConverter);
+                if (c != null)
+                    cookies.add(c);
+            }
+            return Collections.unmodifiableList(cookies);
+        }
+
+        return Collections.emptyList();
     }
 
     @Override
@@ -83,11 +89,11 @@ public class NettyResponse extends ResponseBase {
     public ByteBuffer getResponseBodyAsByteBuffer() throws IOException {
 
         int length = 0;
-        for (HttpResponseBodyPart part: bodyParts)
+        for (HttpResponseBodyPart part : bodyParts)
             length += part.length();
 
         ByteBuffer target = ByteBuffer.wrap(new byte[length]);
-        for (HttpResponseBodyPart part: bodyParts)
+        for (HttpResponseBodyPart part : bodyParts)
             target.put(part.getBodyPartBytes());
 
         return target;

--- a/providers/netty/src/main/java/org/asynchttpclient/providers/netty/response/ResponseStatus.java
+++ b/providers/netty/src/main/java/org/asynchttpclient/providers/netty/response/ResponseStatus.java
@@ -41,7 +41,7 @@ public class ResponseStatus extends HttpResponseStatus {
     
     @Override
     public Response prepareResponse(HttpResponseHeaders headers, List<HttpResponseBodyPart> bodyParts) {
-        return new NettyResponse(this, headers, bodyParts);
+        return new NettyResponse(this, headers, bodyParts, config.getTimeConverter());
     }
 
     /**

--- a/providers/netty/src/test/java/org/asynchttpclient/providers/netty/NettyAsyncResponseTest.java
+++ b/providers/netty/src/test/java/org/asynchttpclient/providers/netty/NettyAsyncResponseTest.java
@@ -48,7 +48,7 @@ public class NettyAsyncResponseTest {
             public FluentCaseInsensitiveStringsMap getHeaders() {
                 return new FluentCaseInsensitiveStringsMap().add("Set-Cookie", cookieDef);
             }
-        }, null);
+        }, null, null);
 
         List<Cookie> cookies = response.getCookies();
         assertEquals(cookies.size(), 1);
@@ -65,7 +65,7 @@ public class NettyAsyncResponseTest {
             public FluentCaseInsensitiveStringsMap getHeaders() {
                 return new FluentCaseInsensitiveStringsMap().add("Set-Cookie", cookieDef);
             }
-        }, null);
+        }, null, null);
         List<Cookie> cookies = response.getCookies();
         assertEquals(cookies.size(), 1);
 
@@ -81,7 +81,7 @@ public class NettyAsyncResponseTest {
             public FluentCaseInsensitiveStringsMap getHeaders() {
                 return new FluentCaseInsensitiveStringsMap().add("Set-Cookie", cookieDef);
             }
-        }, null);
+        }, null, null);
 
         List<Cookie> cookies = response.getCookies();
         assertEquals(cookies.size(), 1);


### PR DESCRIPTION
This PR introduces the following changes:
- A very fast [RFC2616 date](http://tools.ietf.org/html/rfc2616#section-3.3) parser that replaces the old `SimpleDateFormat`+`ThreadLocal` based implementation in `AsyncHttpProviderUtils.parseExpireField`. It uses a `TimeConverter` for converting date parts into a time. Default implementation is `Calendar` based, but one can pass a custom implementation in the config, such as a JodaTime or Java8 DateTime based one. Currently, only the Netty provider can use this user-defined TimeConverter because the Grizzly one uses static methods and singletons where I could not pass the config.
- `CookieDecoder` now uses this date parser. Benchmark results:
  - **old impl: 1729 ops/s**
  - **new impl w/ Calendar (default): 6608 ops/s**
  - **new impl w/ JodaTime (custom) : 8409 ops/s**
  - **new impl w/ ThreeTenBP (custom) : 8492 ops/s**
- It breaks the old Cookie behavior where `Expires` attribute was turned into a `Max-Age`. This behavior made testing a mess (Cookie.maxAge depended on currentTimeMillis). I separated both into dedicated attributes. Now `AsyncHttpProviderUtils` has a `secondsFromNow` for computing a maxAge from a expires value.
- It no longer supports multiple cookies inside the same `Set-Cookie` header. RFC6265 doesn't support this, as well as modern browsers that only pick the first one.
- It fixes a bug regarding `Set-Cookie2` header handling: it has precedence over regular `Set-Cookie`.
