### PR TITLE
Semaphore (in connection tracking) permit leak when host is not contactable

### DIFF
--- a/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -1136,6 +1136,10 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
         if (!c.future().isCancelled() || !c.future().isDone()) {
             openChannels.add(channelFuture.getChannel());
             c.future().attachChannel(channelFuture.getChannel(), false);
+        } else {
+            if (acquiredConnection) {
+                freeConnections.release();
+            }
         }
         return c.future();
     }


### PR DESCRIPTION
Hi there,

This is a potential fix for en edge that causes permits to leak from the semaphore in the NettyAsyncHttpProvider,  when connections are being tracked. 

The issue occurs where the host is not contactable.  When the connection to the host is attempted, the future is completed before it is added to closed channel group (when using blocking connections).  As a result the permit associated with that attempted connection is leaked (as it is not freed).   This edge case is much more evident when using a blocking connect attempt, but can occur for Async connection is enabled (NettyAsyncHttpProviderConfig.EXECUTE_ASYNC_CONNECT,true) where c.future.isCancelled() || c.future.isDone() are true

I've provided a test case to replicate the issue, and provided a the potential fix for the leak.

cheers
/dom
