### PR TITLE
Making contentLength a long to handle large files.

### DIFF
--- a/api/src/main/java/org/asynchttpclient/resumable/ResumableAsyncHandler.java
+++ b/api/src/main/java/org/asynchttpclient/resumable/ResumableAsyncHandler.java
@@ -42,7 +42,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class ResumableAsyncHandler implements AsyncHandler<Response> {
     private final static Logger logger = LoggerFactory.getLogger(TransferCompletionHandler.class);
     private final AtomicLong byteTransferred;
-    private Integer contentLength;
+    private Long contentLength;
     private String url;
     private final ResumableProcessor resumableProcessor;
     private final AsyncHandler<Response> decoratedAsyncHandler;
@@ -180,8 +180,8 @@ public class ResumableAsyncHandler implements AsyncHandler<Response> {
         responseBuilder.accumulate(headers);
         String contentLengthHeader = headers.getHeaders().getFirstValue("Content-Length");
         if (contentLengthHeader != null) {
-            contentLength = Integer.valueOf(contentLengthHeader);
-            if (contentLength == null || contentLength == -1) {
+            contentLength = Long.valueOf(contentLengthHeader);
+            if (contentLength == null || contentLength == -1L) {
                 return AsyncHandler.STATE.ABORT;
             }
         }


### PR DESCRIPTION
This fails on parsing the value when Content-Length is > Integer.MAX_VALUE.  There's no reason this shouldn't be a Long value instead.
