### PR TITLE
Make the fairness semantics of the ThrottleRequestFilter configurable

### DIFF
--- a/api/src/main/java/org/asynchttpclient/extra/ThrottleRequestFilter.java
+++ b/api/src/main/java/org/asynchttpclient/extra/ThrottleRequestFilter.java
@@ -35,7 +35,7 @@ public class ThrottleRequestFilter implements RequestFilter {
     }
 
     public ThrottleRequestFilter(int maxConnections, int maxWait) {
-      this(maxConnections, maxWait, true);
+      this(maxConnections, maxWait, false);
     }
 
     public ThrottleRequestFilter(int maxConnections, int maxWait, boolean fair) {


### PR DESCRIPTION
The default fairness setting for j.u.c.Semaphore is false for a good reason. Don't force the users of the ThrottleRequestFilter to use a fair j.u.c.Semaphore. 

[1] mentions a fairness penalty of nearly two orders of magnitudes.
So "Don't pay for fairness if you don't need it" [1]

[1] http://goo.gl/FUbfHt p.284
