### PR TITLE
use passed in config instead of default config. This is to fix config in...

### DIFF
--- a/api/src/main/java/org/asynchttpclient/DefaultAsyncHttpClient.java
+++ b/api/src/main/java/org/asynchttpclient/DefaultAsyncHttpClient.java
@@ -105,7 +105,7 @@ public class DefaultAsyncHttpClient implements AsyncHttpClient {
      * @param providerClass a {@link AsyncHttpProvider}
      */
     public DefaultAsyncHttpClient(String providerClass, AsyncHttpClientConfig config) {
-        this(loadProvider(providerClass, config), new AsyncHttpClientConfig.Builder().build());
+        this(loadProvider(providerClass, config), config);
     }
 
     /**


### PR DESCRIPTION
This constructor uses config builder to build a default config object, and use the passed in config object during creating the provider .  This results in config inconsistency between newly created client's config and client's provider's config. The fix is to use passed in config instead of default config to create the client.
