### PR TITLE
Percent encoding user info fix

### DIFF
--- a/src/main/java/com/ning/http/client/RequestBuilderBase.java
+++ b/src/main/java/com/ning/http/client/RequestBuilderBase.java
@@ -175,7 +175,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
             AsyncHttpProviderUtils.validateSupportedScheme(originalUri);
 
             StringBuilder builder = new StringBuilder();
-            builder.append(originalUri.getScheme()).append("://").append(originalUri.getAuthority());
+            builder.append(originalUri.getScheme()).append("://").append(originalUri.getRawAuthority());
             if (isNonEmpty(originalUri.getRawPath())) {
                 builder.append(originalUri.getRawPath());
             } else {

--- a/src/test/java/com/ning/http/client/async/RequestBuilderTest.java
+++ b/src/test/java/com/ning/http/client/async/RequestBuilderTest.java
@@ -105,4 +105,11 @@ public class RequestBuilderTest {
         assertEquals(req.getMethod(), "ABC");
         assertEquals(req.getUrl(), "http://foo.com");
     }
+
+    @Test(groups = {"standalone", "default_provider"})
+    public void testPercentageEncodedUserInfo() {
+        final Request req = new RequestBuilder("GET").setUrl("http://hello:wor%20ld@foo.com").build();
+        assertEquals(req.getMethod(), "GET");
+        assertEquals(req.getUrl(), "http://hello:wor%20ld@foo.com");
+    }
 }


### PR DESCRIPTION
RequestBuilderBase's toURI has a bug which fails to handle percent-encoded userinfo. 

This change fixes toURI to use getRawAuthority instead of getAuthority to pass down the percent encoded userinfo when constructing the new URI
