### PR TITLE
Netty: Add remote channel ip address to read timeout exception

### DIFF
--- a/src/main/java/com/ning/http/client/providers/netty/NettyResponseFuture.java
+++ b/src/main/java/com/ning/http/client/providers/netty/NettyResponseFuture.java
@@ -17,6 +17,7 @@ package com.ning.http.client.providers.netty;
 
 import static com.ning.http.util.DateUtil.millisTime;
 
+import java.net.SocketAddress;
 import java.net.URI;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
@@ -477,6 +478,13 @@ public final class NettyResponseFuture<V> extends AbstractListenableFuture<V> {
             return false;
         }
         return true;
+    }
+
+    public SocketAddress getChannelRemoteAddress() {
+        if (channel() != null && channel().getRemoteAddress() != null) {
+            return channel().getRemoteAddress();
+        }
+        return null;
     }
 
     public void setRequest(Request request) {

--- a/src/main/java/com/ning/http/client/providers/netty/timeout/RequestTimeoutTimerTask.java
+++ b/src/main/java/com/ning/http/client/providers/netty/timeout/RequestTimeoutTimerTask.java
@@ -38,7 +38,8 @@ public class RequestTimeoutTimerTask extends TimeoutTimerTask {
         }
 
         if (!nettyResponseFuture.isDone() && !nettyResponseFuture.isCancelled()) {
-            expire("Request timeout of " + nettyResponseFuture.getRequestTimeoutInMs() + " ms", millisTime() - nettyResponseFuture.getStart());
+            long age = millisTime() - nettyResponseFuture.getStart();
+            expire("Request timed out to " + nettyResponseFuture.getChannelRemoteAddress() + " of " + nettyResponseFuture.getRequestTimeoutInMs() + " ms after " + age + " ms", age);
             nettyResponseFuture.setRequestTimeoutReached();
         }
     }

--- a/src/test/java/com/ning/http/client/async/netty/NettyPerRequestTimeoutTest.java
+++ b/src/test/java/com/ning/http/client/async/netty/NettyPerRequestTimeoutTest.java
@@ -22,7 +22,9 @@ import com.ning.http.client.async.ProviderUtil;
 public class NettyPerRequestTimeoutTest extends PerRequestTimeoutTest {
 
     protected void checkTimeoutMessage(String message) {
-        assertTrue(message.equals("Request timeout of 100 ms"));
+        assertTrue(message.startsWith("Request timed out"), "error message indicates reason of error");
+        assertTrue(message.contains("127.0.0.1"), "error message contains remote ip address");
+        assertTrue(message.contains("of 100 ms"), "error message contains timeout configuration value");
     }
 
     @Override


### PR DESCRIPTION
Connect exception contains remote ip address in error message like:

```
org.jboss.netty.channel.ConnectTimeoutException: connection timed out: localhost/127.0.0.1:12345
    at org.jboss.netty.channel.socket.nio.NioClientBoss.processConnectTimeout(NioClientBoss.java:137)
```

To make it easier to investigate read timeout exceptions (esp. in case DNS name of remote server is globally load balanced or geo load balanced) would be nice to have remote ip address in error message as well for read timeouts.
