### PR TITLE
correct default value for maxConnectionLifetimeInMs and enable customization of strict302Handling

### DIFF
--- a/api/src/main/java/org/asynchttpclient/AsyncHttpClientConfigBean.java
+++ b/api/src/main/java/org/asynchttpclient/AsyncHttpClientConfigBean.java
@@ -130,6 +130,11 @@ public class AsyncHttpClientConfigBean extends AsyncHttpClientConfig {
         return this;
     }
 
+    public AsyncHttpClientConfigBean setStrict302Handling(boolean strict302Handling) {
+        this.strict302Handling = strict302Handling;
+        return this;
+    }
+
     public AsyncHttpClientConfigBean setCompressionEnabled(boolean compressionEnabled) {
         this.compressionEnabled = compressionEnabled;
         return this;


### PR DESCRIPTION
AsyncHttpClientConfig and AsyncHttpClientConfigBean all have default value 0 for maxConnectionLifetimeInMs, this breaks the connection pool.
