### PR TITLE
Propagate charset from Content-Type into Request's bodyEncoding

### DIFF
--- a/src/main/java/com/ning/http/client/RequestBuilderBase.java
+++ b/src/main/java/com/ning/http/client/RequestBuilderBase.java
@@ -612,9 +612,22 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
     }
 
     public Request build() {
+        try {
+            final String contentType = request.headers.getFirstValue("Content-Type");
+            if (contentType != null) {
+                final String charset = AsyncHttpProviderUtils.parseCharset(contentType);
+                if (charset != null) {
+                    // ensure that if charset is provided with the Content-Type header,
+                    // we propagate that down to the charset of the Request object
+                    request.charset = charset;
+                }
+            }
+        } catch (Throwable e) {
+            // NoOp -- we can't fix the Content-Type or charset from here
+        }
         if (request.length < 0 && request.streamData == null) {
             // can't concatenate content-length
-            String contentLength = request.headers.getFirstValue("Content-Length");
+            final String contentLength = request.headers.getFirstValue("Content-Length");
 
             if (contentLength != null) {
                 try {

--- a/src/test/java/com/ning/http/client/async/RequestBuilderTest.java
+++ b/src/test/java/com/ning/http/client/async/RequestBuilderTest.java
@@ -105,4 +105,12 @@ public class RequestBuilderTest {
         assertEquals(req.getMethod(), "ABC");
         assertEquals(req.getUrl(), "http://foo.com");
     }
+
+    @Test(groups = {"standalone", "default_provider"})
+    public void testContentTypeCharsetToBodyEncoding() {
+        final Request req = new RequestBuilder("GET").setHeader("Content-Type", "application/json; charset=utf-8").build();
+        assertEquals(req.getBodyEncoding(), "utf-8");
+        final Request req2 = new RequestBuilder("GET").setHeader("Content-Type", "application/json; charset=\"utf-8\"").build();
+        assertEquals(req2.getBodyEncoding(), "utf-8");
+    }
 }


### PR DESCRIPTION
If charset is defined in Content-Type, propagate that into RequestImpl's charset when RequestBuilderBase.build() is called 
