### PR TITLE
Fixed Utf8UrlEncoder to respect BNF for Uri syntax components on RFC3986

### DIFF
--- a/src/main/java/com/ning/http/client/RequestBuilderBase.java
+++ b/src/main/java/com/ning/http/client/RequestBuilderBase.java
@@ -174,9 +174,11 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
             AsyncHttpProviderUtils.validateSupportedScheme(originalUri);
 
             StringBuilder builder = new StringBuilder();
-            builder.append(originalUri.getScheme()).append("://").append(originalUri.getAuthority());
-            if (isNonEmpty(originalUri.getRawPath())) {
-                builder.append(originalUri.getRawPath());
+            UTF8UrlEncoder.encodeAppendScheme(builder, originalUri.getScheme()).append("://");
+            UTF8UrlEncoder.encodeAppendAuthority(builder, originalUri.getAuthority());
+
+            if (isNonEmpty(originalUri.getPath())) {
+                UTF8UrlEncoder.encodeAppendPath(builder, originalUri.getPath());
             } else {
                 builder.append("/");
             }
@@ -191,14 +193,14 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
                     for (Iterator<String> j = param.getValue().iterator(); j.hasNext();) {
                         String value = j.next();
                         if (encode) {
-                            UTF8UrlEncoder.appendEncoded(builder, name);
+                            UTF8UrlEncoder.encodeAppendQueryParamPart(builder, name);
                         } else {
                             builder.append(name);
                         }
                         if (value != null) {
                             builder.append('=');
                             if (encode) {
-                                UTF8UrlEncoder.appendEncoded(builder, value);
+                                UTF8UrlEncoder.encodeAppendQueryParamPart(builder, value);
                             } else {
                                 builder.append(value);
                             }

--- a/src/main/java/com/ning/http/util/UTF8UrlEncoder.java
+++ b/src/main/java/com/ning/http/util/UTF8UrlEncoder.java
@@ -124,6 +124,10 @@ public class UTF8UrlEncoder {
         USERINFO[':'] = true;
     }
 
+    /**
+     * host        = IP-literal / IPv4address / reg-name
+     * reg-name    = *( unreserved / pct-encoded / sub-delims )
+     */
     private final static boolean[] HOSTPORT = new boolean[128];
     static {
         for(int i=0; i < 128; i++)
@@ -131,6 +135,9 @@ public class UTF8UrlEncoder {
             HOSTPORT[':'] = true;
     }
 
+    /**
+     * pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+     */
     private final static boolean[] PCHAR = new boolean[128];
     static {
         for(int i=0; i < 128; i++)
@@ -139,6 +146,9 @@ public class UTF8UrlEncoder {
         PCHAR['@'] = true;
     }
 
+    /**
+     * query       = *( pchar / "/" / "?" )
+     */
     private final static boolean[] QUERY = new boolean[128];
     static {
         System.arraycopy(PCHAR, 0, QUERY, 0, 128);
@@ -146,6 +156,11 @@ public class UTF8UrlEncoder {
         QUERY['?'] = true;
     }
 
+    /**
+     * used to encode individual name and value parts of query
+     * =& are characters used to separate name and value pairs
+     * + needs to be encoded to differentiate from encoded spaces
+     */
     private final static boolean[] QUERY_PARAM = new boolean[128];
     static {
         System.arraycopy(QUERY, 0, QUERY_PARAM, 0, 128);
@@ -154,6 +169,26 @@ public class UTF8UrlEncoder {
         QUERY_PARAM['&'] = false;
     }
 
+    /**
+     * path          = path-abempty    ; begins with "/" or is empty
+     / path-absolute   ; begins with "/" but not "//"
+     / path-noscheme   ; begins with a non-colon segment
+     / path-rootless   ; begins with a segment
+     / path-empty      ; zero characters
+
+     path-abempty  = *( "/" segment )
+     path-absolute = "/" [ segment-nz *( "/" segment ) ]
+     path-noscheme = segment-nz-nc *( "/" segment )
+     path-rootless = segment-nz *( "/" segment )
+     path-empty    = 0<pchar>
+
+     segment       = *pchar
+     segment-nz    = 1*pchar
+     segment-nz-nc = 1*( unreserved / pct-encoded / sub-delims / "@" )
+     ; non-zero-length segment without any colon ":"
+
+     pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+     */
     private final static boolean[] PATH = new boolean[128];
     static {
         System.arraycopy(PCHAR, 0, PATH, 0, 128);

--- a/src/main/java/com/ning/http/util/UTF8UrlEncoder.java
+++ b/src/main/java/com/ning/http/util/UTF8UrlEncoder.java
@@ -130,9 +130,10 @@ public class UTF8UrlEncoder {
      */
     private final static boolean[] HOSTPORT = new boolean[128];
     static {
-        for(int i=0; i < 128; i++)
+        for(int i=0; i < 128; i++) {
             HOSTPORT[i] = UNRESERVED[i] || SUB_DELIMS[i];
-            HOSTPORT[':'] = true;
+        }
+        HOSTPORT[':'] = true;
     }
 
     /**
@@ -140,8 +141,9 @@ public class UTF8UrlEncoder {
      */
     private final static boolean[] PCHAR = new boolean[128];
     static {
-        for(int i=0; i < 128; i++)
+        for(int i=0; i < 128; i++) {
             PCHAR[i] = UNRESERVED[i] || SUB_DELIMS[i];
+        }
         PCHAR[':'] = true;
         PCHAR['@'] = true;
     }

--- a/src/test/java/com/ning/http/client/async/AsyncProvidersBasicTest.java
+++ b/src/test/java/com/ning/http/client/async/AsyncProvidersBasicTest.java
@@ -72,7 +72,7 @@ public abstract class AsyncProvidersBasicTest extends AbstractBasicTest {
         try {
             Request request = new RequestBuilder("GET").setUrl(getTargetUrl() + "?q=+%20x").build();
             String requestUrl = request.getUrl();
-            Assert.assertEquals(requestUrl, getTargetUrl() + "?q=%20%20x");
+            Assert.assertEquals(requestUrl, getTargetUrl() + "?q=++x");
             Future<String> responseFuture = client.executeRequest(request, new AsyncCompletionHandler<String>() {
                 @Override
                 public String onCompleted(Response response) throws Exception {
@@ -87,7 +87,7 @@ public abstract class AsyncProvidersBasicTest extends AbstractBasicTest {
 
             });
             String url = responseFuture.get();
-            Assert.assertEquals(url, getTargetUrl() + "?q=%20%20x");
+            Assert.assertEquals(url, getTargetUrl() + "?q=++x");
         } finally {
             client.close();
         }
@@ -113,7 +113,7 @@ public abstract class AsyncProvidersBasicTest extends AbstractBasicTest {
 
             });
             String url = responseFuture.get();
-            Assert.assertEquals(url, getTargetUrl() + "?q=a%20b");
+            Assert.assertEquals(url, getTargetUrl() + "?q=a+b");
         } finally {
             client.close();
         }

--- a/src/test/java/com/ning/http/client/async/QueryParametersTest.java
+++ b/src/test/java/com/ning/http/client/async/QueryParametersTest.java
@@ -109,7 +109,7 @@ public abstract class QueryParametersTest extends AbstractBasicTest {
             String query = "test:colon:";
             Response response = c.prepareGet(String.format("http://127.0.0.1:%d/foo/test/colon?q=%s", port1, query)).setHeader("Content-Type", "text/html").execute().get(TIMEOUT, TimeUnit.SECONDS);
 
-            assertEquals(response.getHeader("q"), URLEncoder.encode(query, "UTF-8"));
+            assertEquals(response.getHeader("q"), query);
         } finally {
             c.close();
         }
@@ -122,7 +122,7 @@ public abstract class QueryParametersTest extends AbstractBasicTest {
             String query = "test:colon:";
             Response response = c.prepareGet(String.format("http://127.0.0.1:%d/foo/test/colon?q=%s", port1, query)).setHeader("Content-Type", "text/html").execute().get(TIMEOUT, TimeUnit.SECONDS);
 
-            assertEquals(response.getHeader("q"), URLEncoder.encode(query, "UTF-8"));
+            assertEquals(response.getHeader("q"), query);
         } finally {
             c.close();
         }

--- a/src/test/java/com/ning/http/client/async/RequestBuilderTest.java
+++ b/src/test/java/com/ning/http/client/async/RequestBuilderTest.java
@@ -29,7 +29,7 @@ import static org.testng.Assert.assertEquals;
 public class RequestBuilderTest {
 
     private final static String SAFE_CHARS =
-            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890-_~.";
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890-_~.!@()$*,/?;:'";
     private final static String HEX_CHARS = "0123456789ABCDEF";
 
     @Test(groups = {"standalone", "default_provider"})
@@ -61,6 +61,8 @@ public class RequestBuilderTest {
                 char c = value.charAt(i);
                 if (SAFE_CHARS.indexOf(c) >= 0) {
                     sb.append(c);
+                } else if(c == ' ') {
+                   sb.append('+');
                 } else {
                     int hi = (c >> 4);
                     int lo = c & 0xF;
@@ -104,5 +106,19 @@ public class RequestBuilderTest {
         Request req = new RequestBuilder("ABC").setUrl("http://foo.com").build();
         assertEquals(req.getMethod(), "ABC");
         assertEquals(req.getUrl(), "http://foo.com");
+    }
+
+    @Test(groups = {"standalone", "default_provider"})
+    public void testPercentageEncodedUserInfo() {
+        final Request req = new RequestBuilder("GET").setUrl("http://hello:wor%20ld@foo.com").build();
+        assertEquals(req.getMethod(), "GET");
+        assertEquals(req.getUrl(), "http://hello:wor%20ld@foo.com");
+    }
+
+    @Test(groups = {"standalone", "default_provider"})
+    public void testPercentageEncodedUserInfoWithPortAndPath() {
+        final Request req = new RequestBuilder("GET").setUrl("http://hello:wor%20ld@foo.com:8080/hello").build();
+        assertEquals(req.getMethod(), "GET");
+        assertEquals(req.getUrl(), "http://hello:wor%20ld@foo.com:8080/hello");
     }
 }


### PR DESCRIPTION
Previously Utf8UrlEncoder and RequestBuilderBase tries to percent encode everything other than a small set of ASCII characters (SAFE_ASCII). 

This adds a few more methods into Utf8UrlEncoder to encode specific Uri syntax components with the allowed characters specified on rfc3986.

RequestBuilderBase's toURI is also modified to use those methods when encoding different parts of the URI. 