### PR TITLE
Digest auth broken by #530 as query is no longer passed in the realm uri

### DIFF
--- a/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -2107,7 +2107,7 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
                                     .parseWWWAuthenticateHeader(wwwAuth.get(0)).build();
                         }
 
-                        final Realm nr = new Realm.RealmBuilder().clone(newRealm).setUri(request.getURI().getPath()).build();
+                        final Realm nr = new Realm.RealmBuilder().clone(newRealm).setUri(request.getURI().toString()).build();
 
                         log.debug("Sending authentication to {}", request.getUrl());
                         AsyncCallable ac = new AsyncCallable(future) {


### PR DESCRIPTION
- digest auth requires full uri for computation instead of the path part only (see: https://github.com/AsyncHttpClient/async-http-client/pull/530). E.g. requests with query parameters will not work anymore.
