### PR TITLE
Respect isUseRawUrl right in the Request itself

### DIFF
--- a/src/main/java/com/ning/http/client/Request.java
+++ b/src/main/java/com/ning/http/client/Request.java
@@ -69,8 +69,11 @@ public interface Request {
      */
     public String getUrl();
 
+    public String getEscapedUrl();
+
     public URI getOriginalURI();
     public URI getURI();
+    public URI getEscapedURI();
     public URI getRawURI();
 
     /**

--- a/src/main/java/com/ning/http/client/RequestBuilderBase.java
+++ b/src/main/java/com/ning/http/client/RequestBuilderBase.java
@@ -141,7 +141,17 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
 
         /* @Override */
         public String getUrl() {
-            return removeTrailingSlash(getURI());
+            if (isUseRawUrl()) {
+                return getRawUrl();
+            } else {
+                return getEscapedUrl();
+            }
+        }
+
+
+        /* @Override */
+        public String getEscapedUrl() {
+            return removeTrailingSlash(getEscapedURI());
         }
 
         /* @Override */
@@ -154,6 +164,14 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
         }
 
         public URI getURI() {
+            if (isUseRawUrl()) {
+                return getRawURI();
+            } else {
+                return getEscapedURI();
+            }
+        }
+
+        public URI getEscapedURI() {
             if (uri == null)
                 uri = toURI(true);
             return uri;


### PR DESCRIPTION
We are still struggeling with URLs that get escaped twice due to a isUseRawURL() setting not taken into account. This happens in providers for Grizzly, Apache, and Java URL.

I therefore would propose to solve this right at the source, the Request itself. 

The idea is to provide functions getEscapedX() similar to getRawX(), and make getX() choose between the 2 depending on the isUseRawUrl() setting. 

This makes e.g. getUrl() always return the correct URL, and this how it is indeed used throughout the code base.

Old code like

```
URL url = req.isUseRawUrl() ? req.getRawUrl() : req.getUrl();
```

also still would act like before. Although it also be safely removed in the future.
