### PR TITLE
Support NTLM protocol with the proxy: fixed the header name for Proxy-Authorization

### DIFF
--- a/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -1229,7 +1229,7 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
     }
 
     private Realm kerberosChallenge(List<String> proxyAuth, Request request, ProxyServer proxyServer, FluentCaseInsensitiveStringsMap headers, Realm realm,
-            NettyResponseFuture<?> future) throws NTLMEngineException {
+            NettyResponseFuture<?> future, boolean proxyInd) throws NTLMEngineException {
 
         URI uri = request.getURI();
         String host = request.getVirtualHost() == null ? AsyncHttpProviderUtils.getHost(uri) : request.getVirtualHost();
@@ -1248,30 +1248,38 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
             return realmBuilder.setUri(uri.getRawPath()).setMethodName(request.getMethod()).setScheme(Realm.AuthScheme.KERBEROS).build();
         } catch (Throwable throwable) {
             if (isNTLM(proxyAuth)) {
-                return ntlmChallenge(proxyAuth, request, proxyServer, headers, realm, future);
+                return ntlmChallenge(proxyAuth, request, proxyServer, headers, realm, future, proxyInd);
             }
             abort(future, throwable);
             return null;
         }
     }
 
-    private void addNTLMAuthorization(FluentCaseInsensitiveStringsMap headers, String challengeHeader) {
-        headers.add(HttpHeaders.Names.AUTHORIZATION, "NTLM " + challengeHeader);
+    private void addNTLMAuthorization(FluentCaseInsensitiveStringsMap headers, String challengeHeader, boolean proxyInd) {
+        if ( proxyInd ) {
+            headers.add(HttpHeaders.Names.PROXY_AUTHORIZATION, "NTLM " + challengeHeader);
+        } else {
+            headers.add(HttpHeaders.Names.AUTHORIZATION, "NTLM " + challengeHeader);
+        }
     }
 
-    private void addType3NTLMAuthorizationHeader(List<String> auth, FluentCaseInsensitiveStringsMap headers, String username, String password, String domain, String workstation)
+    private void addType3NTLMAuthorizationHeader(List<String> auth, FluentCaseInsensitiveStringsMap headers, String username, String password, String domain, String workstation, boolean proxyInd)
             throws NTLMEngineException {
-        headers.remove(HttpHeaders.Names.AUTHORIZATION);
+        if ( proxyInd ) {
+            headers.remove(HttpHeaders.Names.PROXY_AUTHORIZATION);
+        } else {
+            headers.remove(HttpHeaders.Names.AUTHORIZATION);
+        }
 
         // Beware of space!, see #462
         if (isNonEmpty(auth) && auth.get(0).startsWith("NTLM ")) {
             String serverChallenge = auth.get(0).trim().substring("NTLM ".length());
             String challengeHeader = ntlmEngine.generateType3Msg(username, password, domain, workstation, serverChallenge);
-            addNTLMAuthorization(headers, challengeHeader);
+            addNTLMAuthorization(headers, challengeHeader, proxyInd);
         }
     }
 
-    private Realm ntlmChallenge(List<String> wwwAuth, Request request, ProxyServer proxyServer, FluentCaseInsensitiveStringsMap headers, Realm realm, NettyResponseFuture<?> future)
+    private Realm ntlmChallenge(List<String> wwwAuth, Request request, ProxyServer proxyServer, FluentCaseInsensitiveStringsMap headers, Realm realm, NettyResponseFuture<?> future, boolean proxyInd)
             throws NTLMEngineException {
 
         boolean useRealm = (proxyServer == null && realm != null);
@@ -1286,12 +1294,12 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
             String challengeHeader = ntlmEngine.generateType1Msg(ntlmDomain, ntlmHost);
 
             URI uri = request.getURI();
-            addNTLMAuthorization(headers, challengeHeader);
+            addNTLMAuthorization(headers, challengeHeader, proxyInd);
             newRealm = new Realm.RealmBuilder().clone(realm).setScheme(realm.getAuthScheme()).setUri(uri.getRawPath()).setMethodName(request.getMethod())
                     .setNtlmMessageType2Received(true).build();
             future.getAndSetAuth(false);
         } else {
-            addType3NTLMAuthorizationHeader(wwwAuth, headers, principal, password, ntlmDomain, ntlmHost);
+            addType3NTLMAuthorizationHeader(wwwAuth, headers, principal, password, ntlmDomain, ntlmHost, proxyInd);
 
             Realm.RealmBuilder realmBuilder;
             Realm.AuthScheme authScheme;
@@ -1312,7 +1320,7 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
             NettyResponseFuture<?> future) throws NTLMEngineException {
         future.getAndSetAuth(false);
 
-        addType3NTLMAuthorizationHeader(wwwAuth, headers, proxyServer.getPrincipal(), proxyServer.getPassword(), proxyServer.getNtlmDomain(), proxyServer.getHost());
+        addType3NTLMAuthorizationHeader(wwwAuth, headers, proxyServer.getPrincipal(), proxyServer.getPassword(), proxyServer.getNtlmDomain(), proxyServer.getHost(), true);
         Realm newRealm;
 
         Realm.RealmBuilder realmBuilder = new Realm.RealmBuilder();
@@ -2115,10 +2123,10 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
 
                         // NTLM
                         if (!wwwAuth.contains("Kerberos") && (isNTLM(wwwAuth) || (wwwAuth.contains("Negotiate")))) {
-                            newRealm = ntlmChallenge(wwwAuth, request, proxyServer, headers, realm, future);
+                            newRealm = ntlmChallenge(wwwAuth, request, proxyServer, headers, realm, future, false);
                             // SPNEGO KERBEROS
                         } else if (wwwAuth.contains("Negotiate")) {
-                            newRealm = kerberosChallenge(wwwAuth, request, proxyServer, headers, realm, future);
+                            newRealm = kerberosChallenge(wwwAuth, request, proxyServer, headers, realm, future, false);
                             if (newRealm == null)
                                 return;
                         } else {
@@ -2167,7 +2175,7 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
                             newRealm = ntlmProxyChallenge(proxyAuth, request, proxyServer, headers, realm, future);
                             // SPNEGO KERBEROS
                         } else if (proxyAuth.contains("Negotiate")) {
-                            newRealm = kerberosChallenge(proxyAuth, request, proxyServer, headers, realm, future);
+                            newRealm = kerberosChallenge(proxyAuth, request, proxyServer, headers, realm, future, true);
                             if (newRealm == null)
                                 return;
                         } else {


### PR DESCRIPTION
Support for NTLM proxies, using the Netty provider, did not appear to function due to the wrong header name being used on the second request from the client to the server in the handshake: `Authorization` should be `Proxy-Authorization`.

Attached is a pull request that fixes the problem against 1.8.10-SNAPSHOT.

Here's a snippet of code that shows how the NTLM proxy is configured.

```
/**
 * Configure the Async HTTP Client
 */
protected AsyncHttpClientConfig  getConfig () {
    AsyncHttpClientConfig.Builder configBuilder = new AsyncHttpClientConfig.Builder();

    if ( ntlmDomain != null ) {
        configBuilder
                .setRealm(new Realm.RealmBuilder()
                        .setPrincipal(this.username)
                        .setPassword(this.password)
                        .setNtlmDomain(this.ntlmDomain)
                        .setUsePreemptiveAuth(true)
                        .build());
    }

    return configBuilder.build();
}

public void execute () {
    AsyncHttpClientConfig config = this.getConfig();

    this.client = new AsyncHttpClient(config);

    try {
        Future<WebSocket> futureWebsocket;
        ProxyServer proxy = new ProxyServer(this.proxyProtocol, this.proxyServer, this.proxyServerPort,
                                            this.username, this.password);
        if ( ntlmDomain != null ) {
            proxy.setNtlmDomain(ntlmDomain);
        }

        futureWebsocket =
                this.client.prepareGet(this.wsUrl)
                        .setProxyServer(proxy)
                        .execute(new WebSocketUpgradeHandler.Builder().build());

        LOG.info("waiting for websocket connection");
        final WebSocket websocket = futureWebsocket.get();

        if ( websocket != null ) {
            LOG.info("received websocket connection");

            websocket.addWebSocketListener(new WebSocketTextListener() {
                @Override
                public void onMessage(String s) {
                    LOG.info("received response {}", s);
                    processAgentRequest(websocket, s);
                }

            ...
}
```
