### PR TITLE
Fixed realm URI computation for the case of non absolute uri, null query, and not omit query

### DIFF
--- a/providers/netty/src/main/java/org/asynchttpclient/providers/netty/handler/HttpProtocol.java
+++ b/providers/netty/src/main/java/org/asynchttpclient/providers/netty/handler/HttpProtocol.java
@@ -220,7 +220,7 @@ final class HttpProtocol extends Protocol {
                 return requestURI.toString();
             }
         } else {
-            if (realm.isOmitQuery() && isNonEmpty(requestURI.getQuery())) {
+            if (realm.isOmitQuery() || !isNonEmpty(requestURI.getQuery())) {
                 return requestURI.getPath();
             } else {
                 return requestURI.getPath() + "?" + requestURI.getQuery();


### PR DESCRIPTION
Cases and returned results by values of realm.isOmitQuery() and query:

Before:
omit, "query" => "path"
omit, null => "path?null"
don't omit, "query" => "path?query"
don't omit, null => "path?null"

"path?null" is obviously a wrong result.

After:
omit, "query" => "path"
omit, null => "path"
don't omit, "query" => "path?query"
don't omit, null => "path"
