### PR TITLE
UTF8UrlDecoder tests and fixes

### DIFF
--- a/src/main/java/com/ning/http/util/UTF8UrlDecoder.java
+++ b/src/main/java/com/ning/http/util/UTF8UrlDecoder.java
@@ -40,15 +40,18 @@ public final class UTF8UrlDecoder {
                 i++;
 
             } else if (c == '%') {
-                if (numChars - i < 2)
+                if (numChars - i < 3) // We expect 3 chars. 0 based i vs. 1 based length!
                     throw new IllegalArgumentException("UTF8UrlDecoder: Incomplete trailing escape (%) pattern");
 
                 int x, y;
-                if ((x = hexaDigit(s.charAt(++i))) == -1 || (y = hexaDigit(s.charAt(++i))) == -1)
+                if ((x = hexaDigit(s.charAt(i+1))) == -1 || (y = hexaDigit(s.charAt(i+2))) == -1)
                     throw new IllegalArgumentException("UTF8UrlDecoder: Malformed");
 
                 sb = initSb(sb, initialSbLength, s, i);
-                sb.append((byte) ((x << 4) + y));
+                byte b = (byte)((x << 4) + y);
+                char cc = (char)(b);
+                sb.append(cc);
+                i+=3;
             } else {
                 if (sb != null)
                     sb.append(c);

--- a/src/test/java/com/ning/http/util/TestUTF8UrlCodec.java
+++ b/src/test/java/com/ning/http/util/TestUTF8UrlCodec.java
@@ -38,4 +38,31 @@ public class TestUTF8UrlCodec
         // Plane 15
         Assert.assertEquals(UTF8UrlEncoder.encode("\udb80\udc01"), "%F3%B0%80%81");
     }
+
+    @Test(groups="fast")
+    public void testDecodeBasics()
+    {
+        Assert.assertEquals(UTF8UrlDecoder.decode("foobar"), "foobar");
+        Assert.assertEquals(UTF8UrlDecoder.decode("a&b"), "a&b");
+        Assert.assertEquals(UTF8UrlDecoder.decode("a+b"), "a b");
+
+        Assert.assertEquals(UTF8UrlDecoder.decode("+"), " ");
+        Assert.assertEquals(UTF8UrlDecoder.decode("%20"), " ");
+        Assert.assertEquals(UTF8UrlDecoder.decode("%25"), "%");
+
+        Assert.assertEquals(UTF8UrlDecoder.decode("+%20x"), "  x");
+    }
+
+    @Test(groups="fast")
+    public void testDecodeTooShort()
+    {
+        try {
+            UTF8UrlDecoder.decode("%2");
+            Assert.assertTrue(false, "No exception thrown on illegal encoding length");
+        } catch (IllegalArgumentException ex) {
+            Assert.assertEquals("UTF8UrlDecoder: Incomplete trailing escape (%) pattern", ex.getMessage());
+        } catch (StringIndexOutOfBoundsException ex) {
+            Assert.assertTrue(false, "String Index Out of Bound thrown, but should be IllegalArgument");
+        }
+    }
 }


### PR DESCRIPTION
I added some tests for Utf8UrlDecoder and noticed it was decoding "%20" to "320".

Fixed this. 

I also checked for the correct exception to be thrown if string is too short.
