### PR TITLE
Do not block the WebSocket from receiving bytes or text fragments

### DIFF
--- a/src/main/java/com/ning/http/client/providers/netty/ws/NettyWebSocket.java
+++ b/src/main/java/com/ning/http/client/providers/netty/ws/NettyWebSocket.java
@@ -186,10 +186,8 @@ public class NettyWebSocket implements WebSocket {
     @Override
     public WebSocket addWebSocketListener(WebSocketListener l) {
         listeners.add(l);
-        if (l instanceof WebSocketByteListener)
-            interestedInByteMessages = true;
-        else if (l instanceof WebSocketTextListener)
-            interestedInTextMessages = true;
+        interestedInByteMessages = interestedInByteMessages || l instanceof WebSocketByteListener;
+        interestedInTextMessages = interestedInTextMessages || l instanceof WebSocketTextListener;
         return this;
     }
 
@@ -199,7 +197,7 @@ public class NettyWebSocket implements WebSocket {
 
         if (l instanceof WebSocketByteListener)
             interestedInByteMessages = hasWebSocketByteListener();
-        else if (l instanceof WebSocketTextListener)
+        if (l instanceof WebSocketTextListener)
             interestedInTextMessages = hasWebSocketTextListener();
 
         return this;


### PR DESCRIPTION
In NettyWebSocket, when the first WebSocketListener was registered, depending on its type (whether `WebSocketByteListener` or `WebSocketTextListener`), the WebSocket was "locked" into processing bytes or text fragments, but it couldn't handle both anymore.

This PR fixes this behaviour.
