### PR TITLE
Fix MiscUtils: closeSilently should check for nullity

### DIFF
--- a/src/main/java/com/ning/http/util/MiscUtils.java
+++ b/src/main/java/com/ning/http/util/MiscUtils.java
@@ -49,9 +49,12 @@ public final class MiscUtils {
     }
 
     public static void closeSilently(Closeable closeable) {
-        try {
-            closeable.close();
-        } catch (IOException e) {
+        if(closeable != null) {
+            try {
+                closeable.close();
+            } catch (IOException ioe) {
+                // Ignored
+            }
         }
     }
 }


### PR DESCRIPTION
Speaks for itself: not checking for nullity made some tests fail and it's quite possible this could cause NPE outside tests too.
