### PR TITLE
Upgrade Netty 3.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -565,7 +565,7 @@
     <properties>
         <distMgmtSnapshotsUrl>http://oss.sonatype.org/content/repositories/snapshots</distMgmtSnapshotsUrl>
         <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
-        <netty.version>3.9.2.Final</netty.version>
+        <netty.version>3.9.3.Final</netty.version>
         <grizzly.version>2.3.16</grizzly.version>
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>


### PR DESCRIPTION
Netty 3.9.3 was released yesterday and contains fixes on WebSockets.
