### PR TITLE
Netty: Prevent overwriting the host header with the host from the URI

### DIFF
--- a/providers/netty/src/main/java/org/asynchttpclient/providers/netty/request/NettyRequestFactory.java
+++ b/providers/netty/src/main/java/org/asynchttpclient/providers/netty/request/NettyRequestFactory.java
@@ -299,7 +299,7 @@ public final class NettyRequestFactory {
         }
 
         String hostHeader = hostHeader(request, uri);
-        if (hostHeader != null)
+        if (hostHeader != null && !headers.contains(HttpHeaders.Names.HOST))
             headers.set(HttpHeaders.Names.HOST, hostHeader);
 
         Realm realm = request.getRealm() != null ? request.getRealm() : config.getRealm();


### PR DESCRIPTION
Without this change it is impossible to make requests to a host with a different host header.
