### PR TITLE
Fix #720: On exception abort Future, do not rethrow

### DIFF
--- a/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyAsyncHttpProvider.java
@@ -250,17 +250,28 @@ public class GrizzlyAsyncHttpProvider implements AsyncHttpProvider {
             connectionManager.doAsyncTrackedConnection(request, future, connectHandler);
         } catch (Exception e) {
             if (e instanceof RuntimeException) {
-                throw (RuntimeException) e;
+                abort(future, e);
             } else if (e instanceof IOException) {
-                throw (IOException) e;
-            }
-            if (LOGGER.isWarnEnabled()) {
-                LOGGER.warn(e.toString(), e);
+                abort(future, e);
+            } else {
+                if (LOGGER.isWarnEnabled()) {
+                    LOGGER.warn(e.toString(), e);
+                    abort(future, e);
+                }
             }
         }
 
         return future;
     }
+
+    private void abort(GrizzlyResponseFuture<?> future, Throwable t) {
+        if (!future.isDone()) {
+            LOGGER.debug("Aborting Future {}\n", future);
+            LOGGER.debug(t.getMessage(), t);
+            future.abort(t);
+        }
+    }
+
 
     @Override
     public void close() {


### PR DESCRIPTION
The problem seems to be that the Grizzly provider does not abort the Future if an error occurs, but rather re-throws any exception. The test on the other hand expects the creation of a request to not throw at all (Exception should be re-thrown on Future.get()).
