### PR TITLE
[1.9.x] Upgrade to animal-sniffer-maven-plugin 1.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.6</version>
+                <version>1.11</version>
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>


### PR DESCRIPTION
During local builds I experienced something that might have been
http://jira.codehaus.org/browse/MANIMALSNIFFER-8, which is fixed in
newer builds.

Newer animal-sniffer releases also have some performance improvements.
The animal-sniffer:check task now takes roughly three quarters of a
second less time as before on my machine.
