### PR TITLE
Made logger static to improve performance. Fixed logger name.

### DIFF
--- a/api/src/main/java/org/asynchttpclient/AsyncCompletionHandler.java
+++ b/api/src/main/java/org/asynchttpclient/AsyncCompletionHandler.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AsyncCompletionHandler<T> implements AsyncHandler<T>, ProgressAsyncHandler<T> {
 
-    private final Logger log = LoggerFactory.getLogger(AsyncCompletionHandlerBase.class);
+    private static final Logger log = LoggerFactory.getLogger(AsyncCompletionHandler.class);
     private final Response.ResponseBuilder builder = new Response.ResponseBuilder();
 
     /**


### PR DESCRIPTION
During profiling one of our applications I found that LoggerFactory.getLogger has some performance impact in AsyncCompletionHandler, so I made the logger static. Additionally I fixed the logger name from AsyncCompletionHandlerBase to AsyncCompletionHandler.
