### PR TITLE
Fix handling of multiple double dots above root in parsing of relative URI

### DIFF
--- a/api/src/main/java/org/asynchttpclient/uri/UriParser.java
+++ b/api/src/main/java/org/asynchttpclient/uri/UriParser.java
@@ -212,6 +212,8 @@ final class UriParser {
                 if (end >= 0 && path.indexOf("/../", end) != 0) {
                     path = path.substring(0, end) + path.substring(i + 3);
                     i = 0;
+                } else if (end == 0) {
+                    break;
                 }
             } else
                 i = i + 3;

--- a/api/src/test/java/org/asynchttpclient/uri/UriTest.java
+++ b/api/src/test/java/org/asynchttpclient/uri/UriTest.java
@@ -15,6 +15,7 @@ package org.asynchttpclient.uri;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 public class UriTest {
 
@@ -83,5 +84,134 @@ public class UriTest {
         assertEquals(url.getPath(), "/750198471659552/accounts/test-users");
         assertEquals(url.getQuery(), "method=get&access_token=750198471659552lleveCvbUu_zqBa9tkT3tcgaPh4");
     }
-}
 
+    @Test
+    public void testRelativeUriWithDots() {
+        Uri context = Uri.create("https://hello.com/level1/level2/");
+
+        Uri url = Uri.create(context, "../other/content/img.png");
+
+        assertEquals(url.getScheme(), "https");
+        assertEquals(url.getHost(), "hello.com");
+        assertEquals(url.getPort(), -1);
+        assertEquals(url.getPath(), "/level1/other/content/img.png");
+        assertNull(url.getQuery());
+    }
+
+    @Test
+    public void testRelativeUriWithDotsAboveRoot() {
+        Uri context = Uri.create("https://hello.com/level1");
+
+        Uri url = Uri.create(context, "../other/content/img.png");
+
+        assertEquals(url.getScheme(), "https");
+        assertEquals(url.getHost(), "hello.com");
+        assertEquals(url.getPort(), -1);
+        assertEquals(url.getPath(), "/../other/content/img.png");
+        assertNull(url.getQuery());
+    }
+
+    @Test
+    public void testRelativeUriWithAbsoluteDots() {
+        Uri context = Uri.create("https://hello.com/level1/");
+
+        Uri url = Uri.create(context, "/../other/content/img.png");
+
+        assertEquals(url.getScheme(), "https");
+        assertEquals(url.getHost(), "hello.com");
+        assertEquals(url.getPort(), -1);
+        assertEquals(url.getPath(), "/../other/content/img.png");
+        assertNull(url.getQuery());
+    }
+
+    @Test
+    public void testRelativeUriWithConsecutiveDots() {
+        Uri context = Uri.create("https://hello.com/level1/level2/");
+
+        Uri url = Uri.create(context, "../../other/content/img.png");
+
+        assertEquals(url.getScheme(), "https");
+        assertEquals(url.getHost(), "hello.com");
+        assertEquals(url.getPort(), -1);
+        assertEquals(url.getPath(), "/other/content/img.png");
+        assertNull(url.getQuery());
+    }
+
+    @Test
+    public void testRelativeUriWithConsecutiveDotsAboveRoot() {
+        Uri context = Uri.create("https://hello.com/level1/level2");
+
+        Uri url = Uri.create(context, "../../other/content/img.png");
+
+        assertEquals(url.getScheme(), "https");
+        assertEquals(url.getHost(), "hello.com");
+        assertEquals(url.getPort(), -1);
+        assertEquals(url.getPath(), "/../other/content/img.png");
+        assertNull(url.getQuery());
+    }
+
+    @Test
+    public void testRelativeUriWithAbsoluteConsecutiveDots() {
+        Uri context = Uri.create("https://hello.com/level1/level2/");
+
+        Uri url = Uri.create(context, "/../../other/content/img.png");
+
+        assertEquals(url.getScheme(), "https");
+        assertEquals(url.getHost(), "hello.com");
+        assertEquals(url.getPort(), -1);
+        assertEquals(url.getPath(), "/../../other/content/img.png");
+        assertNull(url.getQuery());
+    }
+
+    @Test
+    public void testRelativeUriWithConsecutiveDotsFromRoot() {
+        Uri context = Uri.create("https://hello.com/");
+
+        Uri url = Uri.create(context, "../../../other/content/img.png");
+
+        assertEquals(url.getScheme(), "https");
+        assertEquals(url.getHost(), "hello.com");
+        assertEquals(url.getPort(), -1);
+        assertEquals(url.getPath(), "/../../../other/content/img.png");
+        assertNull(url.getQuery());
+    }
+
+    @Test
+    public void testRelativeUriWithConsecutiveDotsFromRootResource() {
+        Uri context = Uri.create("https://hello.com/level1");
+
+        Uri url = Uri.create(context, "../../../other/content/img.png");
+
+        assertEquals(url.getScheme(), "https");
+        assertEquals(url.getHost(), "hello.com");
+        assertEquals(url.getPort(), -1);
+        assertEquals(url.getPath(), "/../../../other/content/img.png");
+        assertNull(url.getQuery());
+    }
+
+    @Test
+    public void testRelativeUriWithConsecutiveDotsFromSubrootResource() {
+        Uri context = Uri.create("https://hello.com/level1/level2");
+
+        Uri url = Uri.create(context, "../../../other/content/img.png");
+
+        assertEquals(url.getScheme(), "https");
+        assertEquals(url.getHost(), "hello.com");
+        assertEquals(url.getPort(), -1);
+        assertEquals(url.getPath(), "/../../other/content/img.png");
+        assertNull(url.getQuery());
+    }
+
+    @Test
+    public void testRelativeUriWithConsecutiveDotsFromLevel3Resource() {
+        Uri context = Uri.create("https://hello.com/level1/level2/level3");
+
+        Uri url = Uri.create(context, "../../../other/content/img.png");
+
+        assertEquals(url.getScheme(), "https");
+        assertEquals(url.getHost(), "hello.com");
+        assertEquals(url.getPort(), -1);
+        assertEquals(url.getPath(), "/../other/content/img.png");
+        assertNull(url.getQuery());
+    }
+}


### PR DESCRIPTION
Attempt to fix #751.

I encountered this error through usage of Gatling on a page which in some cases produced resource URLs like the ones mentioned in the issue. Although one may argue that such URLs should not be present on a page, it poses a problem in that Gatling just appears to hang (when AHC enters its infinite loop).

Due to its usage in Gatling, I think this fix should probably be merged to the 1.9.x branch as well.
