### PR TITLE
avoid writing 2 new lines without content

### DIFF
--- a/src/main/java/com/ning/http/client/providers/netty/FeedableBodyGenerator.java
+++ b/src/main/java/com/ning/http/client/providers/netty/FeedableBodyGenerator.java
@@ -75,12 +75,14 @@ public class FeedableBodyGenerator implements BodyGenerator {
             }
             int capacity = buffer.remaining() - 10; // be safe (we'll have to add size, ending, etc.)
             int size = Math.min(nextPart.buffer.remaining(), capacity);
-            buffer.put(getBytes(Integer.toHexString(size)));
-            buffer.put(END_PADDING);
-            for (int i = 0; i < size; i++) {
-                buffer.put(nextPart.buffer.get());
+            if (size != 0) {
+                buffer.put(getBytes(Integer.toHexString(size)));
+                buffer.put(END_PADDING);
+                for (int i = 0; i < size; i++) {
+                    buffer.put(nextPart.buffer.get());
+                }
+                buffer.put(END_PADDING);
             }
-            buffer.put(END_PADDING);
             if (!nextPart.buffer.hasRemaining()) {
                 if (nextPart.isLast) {
                     finishState = CLOSING;


### PR DESCRIPTION
Fix the following error happening on the server side:
java.lang.NullPointerException: null
    at org.jboss.netty.handler.codec.http.HttpClientCodec$Decoder.isContentAlwaysEmpty(HttpClientCodec.java:179) ~[netty-3.9.2.Final.jar:na]
