### PR TITLE
fix to enable client-specified nonce count (NC)

### DIFF
--- a/src/main/java/com/ning/http/client/Realm.java
+++ b/src/main/java/com/ning/http/client/Realm.java
@@ -33,7 +33,7 @@ import java.security.NoSuchAlgorithmException;
  */
 public class Realm {
 
-    private static final String NC = "00000001";
+    private static final String DEFAULT_NC = "00000001";
 
     private final String principal;
     private final String password;
@@ -288,7 +288,7 @@ public class Realm {
         private String response = "";
         private String opaque = "";
         private String qop = "auth";
-        private String nc = "00000001";
+        private String nc = DEFAULT_NC;
         private String cnonce = "";
         private Uri uri;
         private String methodName = "GET";
@@ -590,7 +590,7 @@ public class Realm {
             
             if (isNonEmpty(qop)) {
                 //qop ="auth" or "auth-int"
-                sb.append(NC)//
+                sb.append(nc)//
                         .append(':')//
                         .append(cnonce)//
                         .append(':')//


### PR DESCRIPTION
Current implementation seems to contain a minor oversight. The static final (default) field `NC` is used when calculating the response, instead of the member variable `nc`, so the latter is ignored here (and, dangerously, is not ignored when composing the Digest header in `AuthenticatorUtils.computeDigestAuthentication()`

Existing functionality is not affected since we maintain the original default (renamed the constant field for clarity).
