### PR TITLE
resetting terminate to close the urlconnection also in redirected cases

### DIFF
--- a/src/main/java/com/ning/http/client/providers/jdk/JDKAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/jdk/JDKAsyncHttpProvider.java
@@ -224,6 +224,7 @@ public class JDKAsyncHttpProvider implements AsyncHttpProvider {
         }
 
         public T call() throws Exception {
+            terminate = true;
             AsyncHandler.STATE state = AsyncHandler.STATE.ABORT;
             try {
                 Uri uri = request.getUri();


### PR DESCRIPTION
Pull request to fix https://github.com/AsyncHttpClient/async-http-client/issues/813
I cannot execute all tests in my environment.