### PR TITLE
Pass the InetSocketAddress instance to the onDnsResolved extensions callback

### DIFF
--- a/api/src/main/java/org/asynchttpclient/AsyncHandlerExtensions.java
+++ b/api/src/main/java/org/asynchttpclient/AsyncHandlerExtensions.java
@@ -63,5 +63,5 @@ public interface AsyncHandlerExtensions {
     /**
      * Notify the callback after DNS resolution has completed.
      */
-    void onDnsResolved();
+    void onDnsResolved(java.net.InetSocketAddress remoteAddress);
 }

--- a/api/src/test/java/org/asynchttpclient/async/util/EventCollectingHandler.java
+++ b/api/src/test/java/org/asynchttpclient/async/util/EventCollectingHandler.java
@@ -99,7 +99,7 @@ public class EventCollectingHandler extends AsyncCompletionHandlerBase implement
     }
 
     @Override
-    public void onDnsResolved() {
+    public void onDnsResolved(java.net.InetSocketAddress remoteAddress) {
         firedEvents.add("DnsResolved");
     }
 }

--- a/providers/netty3/src/main/java/org/asynchttpclient/providers/netty3/request/NettyRequestSender.java
+++ b/providers/netty3/src/main/java/org/asynchttpclient/providers/netty3/request/NettyRequestSender.java
@@ -363,7 +363,7 @@ public final class NettyRequestSender {
         InetSocketAddress remoteAddress = remoteAddress(request, uri, proxy, useProxy);
 
         if (asyncHandler instanceof AsyncHandlerExtensions)
-            AsyncHandlerExtensions.class.cast(asyncHandler).onDnsResolved();
+            AsyncHandlerExtensions.class.cast(asyncHandler).onDnsResolved(remoteAddress);
 
         if (request.getLocalAddress() != null)
             return bootstrap.connect(remoteAddress, new InetSocketAddress(request.getLocalAddress(), 0));

--- a/providers/netty4/src/main/java/org/asynchttpclient/providers/netty4/request/NettyRequestSender.java
+++ b/providers/netty4/src/main/java/org/asynchttpclient/providers/netty4/request/NettyRequestSender.java
@@ -361,7 +361,7 @@ public final class NettyRequestSender {
         InetSocketAddress remoteAddress = remoteAddress(request, uri, proxy, useProxy);
 
         if (asyncHandler instanceof AsyncHandlerExtensions)
-            AsyncHandlerExtensions.class.cast(asyncHandler).onDnsResolved();
+            AsyncHandlerExtensions.class.cast(asyncHandler).onDnsResolved(remoteAddress);
 
         if (request.getLocalAddress() != null)
             return bootstrap.connect(remoteAddress, new InetSocketAddress(request.getLocalAddress(), 0));


### PR DESCRIPTION
In order to extract the IP address that was used for the connection without resolving it again from outside AHC, this callback can surface the remote address instance.