### PR TITLE
Netty: Fix releasing limit for connections pool per host

### DIFF
--- a/src/main/java/com/ning/http/client/providers/netty/channel/ChannelManager.java
+++ b/src/main/java/com/ning/http/client/providers/netty/channel/ChannelManager.java
@@ -155,8 +155,8 @@ public class ChannelManager {
         }
 
         if (maxConnectionsPerHostEnabled) {
-            freeChannelsPerHost = new ConcurrentHashMap<String, Semaphore>();
-            channelId2KeyPool = new ConcurrentHashMap<Integer, String>();
+            freeChannelsPerHost = new ConcurrentHashMap<>();
+            channelId2KeyPool = new ConcurrentHashMap<>();
         } else {
             freeChannelsPerHost = null;
             channelId2KeyPool = null;
@@ -381,8 +381,11 @@ public class ChannelManager {
             getFreeConnectionsForHost(poolKey).release();
     }
 
-    public void registerOpenChannel(Channel channel) {
+    public void registerOpenChannel(Channel channel, final String poolKey) {
         openChannels.add(channel);
+        if (maxConnectionsPerHostEnabled) {
+            channelId2KeyPool.put(channel.getId(), poolKey);
+        }
     }
 
     private HttpClientCodec newHttpClientCodec() {

--- a/src/main/java/com/ning/http/client/providers/netty/request/NettyConnectListener.java
+++ b/src/main/java/com/ning/http/client/providers/netty/request/NettyConnectListener.java
@@ -74,7 +74,7 @@ public final class NettyConnectListener<T> implements ChannelFutureListener {
         if (future.getAsyncHandler() instanceof AsyncHandlerExtensions)
             AsyncHandlerExtensions.class.cast(future.getAsyncHandler()).onConnectionOpen();
 
-        channelManager.registerOpenChannel(channel);
+        channelManager.registerOpenChannel(channel, poolKey);
         future.attachChannel(channel, false);
         requestSender.writeRequest(future, channel);
     }


### PR DESCRIPTION
I've found a bug in async-http-client.
1.set 'maxConnections' and 'maxConnectionsPerHost' simultaneously.
2.try to GET the same host multiple times. With channels auto-closed after each request (with no chance here: tryToOfferChannelToPool https://github.com/AsyncHttpClient/async-http-client/blob/async-http-client-1.9.10/src/main/java/com/ning/http/client/providers/netty/channel/ChannelManager.java#L285)
3.Semaphore freeChannelsForHost (here https://github.com/AsyncHttpClient/async-http-client/blob/async-http-client-1.9.10/src/main/java/com/ning/http/client/providers/netty/channel/ChannelManager.java#L142) won't be decremented on channel close and you'll get 
"Caused by: java.io.IOException: Too many connections per host XXX"

Because there is no mapping in channelId2KeyPool
(https://github.com/AsyncHttpClient/async-http-client/blob/async-http-client-1.9.10/src/main/java/com/ning/http/client/providers/netty/channel/ChannelManager.java#L140)

I think it should be added here, while "registerOpenChannel" (https://github.com/AsyncHttpClient/async-http-client/blob/async-http-client-1.9.10/src/main/java/com/ning/http/client/providers/netty/channel/ChannelManager.java#L384)


prove-of-fail can be found here https://github.com/kullfar/async-test
steps to reproduce:
git clone 'https://github.com/kullfar/async-test.git'
cd async-test
mvn clean install
java -jar target/async-test-1.0-SNAPSHOT.jar


You will get "Caused by: java.io.IOException: Too many connections per host 3" line shortly

If you'll compile my pull request version and change pom.xml to use 1.9.11-SNAPSHOT version, there will be no Exceptions.

ps. It's the pull request to the 1.9.x branch (just because I use it ritgh now in prod), but as I can see 2.x branch needs to be fixed as well
    