### PR TITLE
Update Grizzly version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -591,7 +591,7 @@
         <compiler.exclude>com/ning/http/client/providers/grizzly/*.java</compiler.exclude>
         <test.compiler.exclude>com/ning/http/client/async/grizzly/*.java</test.compiler.exclude>
         <javadoc.package.exclude>com.ning.http.client.providers.grizzly</javadoc.package.exclude>
-        <grizzly.version>2.3.16</grizzly.version>
+        <grizzly.version>2.3.19</grizzly.version>
         <source.property>1.5</source.property>
         <target.property>1.5</target.property>
         <surefire.version>2.12</surefire.version>

--- a/src/main/java/com/ning/http/client/providers/grizzly/FeedableBodyGenerator.java
+++ b/src/main/java/com/ning/http/client/providers/grizzly/FeedableBodyGenerator.java
@@ -225,6 +225,10 @@ public class FeedableBodyGenerator implements BodyGenerator {
                     }
                 }
             }
+
+            public void onFailure(Connection connection, Throwable t) {
+                
+            }
         });
         filter.handshake(context.getConnection(),  null);
     }

--- a/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyAsyncHttpProvider.java
@@ -932,7 +932,7 @@ public class GrizzlyAsyncHttpProvider implements AsyncHttpProvider {
                     final URI wsURI = new URI(httpCtx.wsRequestURI);
                     secure = "wss".equalsIgnoreCase(wsURI.getScheme());
                     httpCtx.protocolHandler = Version.RFC6455.createHandler(true);
-                    httpCtx.handshake = httpCtx.protocolHandler.createHandShake(wsURI);
+                    httpCtx.handshake = httpCtx.protocolHandler.createClientHandShake(wsURI);
                     requestPacket = (HttpRequestPacket) httpCtx.handshake.composeHeaders().getHttpHeader();
                 } catch (URISyntaxException e) {
                     throw new IllegalArgumentException("Invalid WS URI: " + httpCtx.wsRequestURI);


### PR DESCRIPTION
The latest 2.3.19 grizzly release contains very important fixes but this library is not compatible with that version.