### PR TITLE
Update Grizzly version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -556,7 +556,7 @@
         <distMgmtSnapshotsUrl>http://oss.sonatype.org/content/repositories/snapshots</distMgmtSnapshotsUrl>
         <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
         <netty.version>3.10.0.Final</netty.version>
-        <grizzly.version>2.3.18</grizzly.version>
+        <grizzly.version>2.3.19</grizzly.version>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <surefire.version>2.12</surefire.version>

--- a/src/main/java/com/ning/http/client/providers/grizzly/FeedableBodyGenerator.java
+++ b/src/main/java/com/ning/http/client/providers/grizzly/FeedableBodyGenerator.java
@@ -221,6 +221,9 @@ public class FeedableBodyGenerator implements BodyGenerator {
                     }
                 }
             }
+
+            public void onFailure(Connection connection, Throwable t) {
+            }
         });
         filter.handshake(context.getConnection(),  null);
     }

--- a/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/grizzly/GrizzlyAsyncHttpProvider.java
@@ -731,7 +731,7 @@ public class GrizzlyAsyncHttpProvider implements AsyncHttpProvider {
                     final URI wsURI = httpCtx.wsRequestURI.toJavaNetURI();
                     secure = "wss".equalsIgnoreCase(wsURI.getScheme());
                     httpCtx.protocolHandler = Version.RFC6455.createHandler(true);
-                    httpCtx.handshake = httpCtx.protocolHandler.createHandShake(wsURI);
+                    httpCtx.handshake = httpCtx.protocolHandler.createClientHandShake(wsURI);
                     requestPacket = (HttpRequestPacket) httpCtx.handshake.composeHeaders().getHttpHeader();
                 } catch (URISyntaxException e) {
                     throw new IllegalArgumentException("Invalid WS URI: " + httpCtx.wsRequestURI);

--- a/src/main/java/com/ning/http/client/providers/grizzly/HostnameVerifierListener.java
+++ b/src/main/java/com/ning/http/client/providers/grizzly/HostnameVerifierListener.java
@@ -56,7 +56,13 @@ class HostnameVerifierListener implements SSLBaseFilter.HandshakeListener {
             task.verify();
         }
     }
-    
+
+    @Override
+    public void onFailure(Connection connection, Throwable t) {
+        // do nothing
+        LOGGER.debug("SSL Handshake onFailure: ", t);
+    }
+
     static CompletionHandler<Connection> wrapWithHostnameVerifierHandler(
             final CompletionHandler<Connection> completionHandler,
             final HostnameVerifier verifier, final String host) {


### PR DESCRIPTION
The latest 2.3.19 grizzly release contains very important fixes but
this library is not compatible with that version.