### PR TITLE
add a link to automatically hosted javadocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Async Http Client
 -----------------
 
+[Javadoc](http://www.javadoc.io/doc/com.ning/async-http-client/)
+
 Getting started [HTML](https://asynchttpclient.github.io/async-http-client/), 
                 with [WebSockets](http://jfarcand.wordpress.com/2011/12/21/writing-websocket-clients-using-asynchttpclient/)
 
@@ -20,7 +22,7 @@ You can also download the artifact
 
 [Maven Search](http://search.maven.org)
 
-Then in your code you can simply do [Javadoc](https://asynchttpclient.github.io/async-http-client/apidocs/reference/packages.html)
+Then in your code you can simply do
 
 ```java
 import com.ning.http.client.*;


### PR DESCRIPTION
This PR addresses https://github.com/AsyncHttpClient/async-http-client/issues/798 and simply adds the link in the README to the automatically hosted Javadocs. 