### PR TITLE
Netty HttpProtocol.finishUpdate should offer channel back to pool after markAsDone

### DIFF
--- a/providers/netty3/src/main/java/org/asynchttpclient/providers/netty3/handler/HttpProtocol.java
+++ b/providers/netty3/src/main/java/org/asynchttpclient/providers/netty3/handler/HttpProtocol.java
@@ -189,12 +189,13 @@ public final class HttpProtocol extends Protocol {
 
     private void finishUpdate(final NettyResponseFuture<?> future, Channel channel, boolean expectOtherChunks) throws IOException {
 
+        markAsDone(future, channel);
+
         boolean keepAlive = future.isKeepAlive();
         if (expectOtherChunks && keepAlive)
             channelManager.drainChannelAndOffer(channel, future);
         else
             channelManager.tryToOfferChannelToPool(channel, keepAlive, future.getPartitionId());
-        markAsDone(future, channel);
     }
 
     private boolean updateBodyAndInterrupt(NettyResponseFuture<?> future, AsyncHandler<?> handler, NettyResponseBodyPart bodyPart)


### PR DESCRIPTION
HttpProtocol.finishUpdate attempts to put the channel back into the pool then calls markAsDone. This permits a case were the same channel is selected in the callback which can lead to a "read timeout". 

https://github.com/AsyncHttpClient/async-http-client/issues/844