### PR TITLE
[1.9.x] Fix #852: query paramters should not be removed from the redirec...

### DIFF
--- a/src/main/java/com/ning/http/client/providers/grizzly/AhcEventFilter.java
+++ b/src/main/java/com/ning/http/client/providers/grizzly/AhcEventFilter.java
@@ -827,7 +827,6 @@ final class AhcEventFilter extends HttpClientFilter {
             builder.setMethod("GET");
         }
         builder.setUrl(uri.toString());
-        builder.resetQuery();
         for (String cookieStr : response.getHeaders().values(Header.Cookie)) {
             builder.addOrReplaceCookie(CookieDecoder.decode(cookieStr));
         }


### PR DESCRIPTION
...t URI.