### PR TITLE
fix unnecessary percent encoding

### DIFF
--- a/api/src/main/java/org/asynchttpclient/oauth/OAuthSignatureCalculator.java
+++ b/api/src/main/java/org/asynchttpclient/oauth/OAuthSignatureCalculator.java
@@ -32,6 +32,7 @@ import org.asynchttpclient.SignatureCalculator;
 import org.asynchttpclient.uri.Uri;
 import org.asynchttpclient.util.Base64;
 import org.asynchttpclient.util.StringUtils;
+import org.asynchttpclient.util.Utf8UrlDecoder;
 import org.asynchttpclient.util.Utf8UrlEncoder;
 
 /**
@@ -139,12 +140,12 @@ public class OAuthSignatureCalculator implements SignatureCalculator {
 
         if (formParams != null) {
             for (Param param : formParams) {
-                allParameters.add(param.getName(), param.getValue());
+                allParameters.add(param.getName(), Utf8UrlDecoder.decode(param.getValue()).toString());
             }
         }
         if (queryParams != null) {
             for (Param param : queryParams) {
-                allParameters.add(param.getName(), param.getValue());
+                allParameters.add(param.getName(), Utf8UrlDecoder.decode(param.getValue()).toString());
             }
         }
         return allParameters.sortAndConcat();

--- a/api/src/test/java/org/asynchttpclient/oauth/OAuthSignatureCalculatorTest.java
+++ b/api/src/test/java/org/asynchttpclient/oauth/OAuthSignatureCalculatorTest.java
@@ -47,7 +47,7 @@ public class OAuthSignatureCalculatorTest {
 
     public static final String TOKEN_SECRET = "pfkkdhi9sl3r4s00";
 
-    public static final String NONCE = "kllo9940pd9333jh";
+    public static final String NONCE = "9940pd/933+3jh==";
 
     final static long TIMESTAMP = 1191242096;
 
@@ -83,10 +83,11 @@ public class OAuthSignatureCalculatorTest {
         List<Param> queryParams = new ArrayList<>();
         queryParams.add(new Param("file", "vacation.jpg"));
         queryParams.add(new Param("size", "original"));
+        queryParams.add(new Param("csv", "aaa%2Cbbb")); // add percent encoded test case
         String url = "http://photos.example.net/photos";
         String sig = calc.calculateSignature("GET", Uri.create(url), TIMESTAMP, NONCE, null, queryParams);
 
-        assertEquals(sig, "tR3+Ty81lMeYAr/Fid0kMTYa/WM=");
+        assertEquals(sig, "oc/GQouurhlY1gWFyaqz9/w7fAg=");
     }
 
     @Test(groups = "fast")
@@ -98,6 +99,7 @@ public class OAuthSignatureCalculatorTest {
         List<Param> formParams = new ArrayList<Param>();
         formParams.add(new Param("file", "vacation.jpg"));
         formParams.add(new Param("size", "original"));
+        formParams.add(new Param("csv", "aaa%2Cbbb")); // add percent encoded test case
         String url = "http://photos.example.net/photos";
         final Request req = new RequestBuilder("POST")
                 .setUri(Uri.create(url))
@@ -105,10 +107,10 @@ public class OAuthSignatureCalculatorTest {
                 .setSignatureCalculator(calc).build();
 
         // From the signature tester, POST should look like:
-        // normalized parameters: file=vacation.jpg&oauth_consumer_key=dpf43f3p2l4k3l03&oauth_nonce=kllo9940pd9333jh&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1191242096&oauth_token=nnch734d00sl2jdk&oauth_version=1.0&size=original
-        // signature base string: POST&http%3A%2F%2Fphotos.example.net%2Fphotos&file%3Dvacation.jpg%26oauth_consumer_key%3Ddpf43f3p2l4k3l03%26oauth_nonce%3Dkllo9940pd9333jh%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1191242096%26oauth_token%3Dnnch734d00sl2jdk%26oauth_version%3D1.0%26size%3Doriginal
-        // signature: wPkvxykrw+BTdCcGqKr+3I+PsiM=
-        // header: OAuth realm="",oauth_version="1.0",oauth_consumer_key="dpf43f3p2l4k3l03",oauth_token="nnch734d00sl2jdk",oauth_timestamp="1191242096",oauth_nonce="kllo9940pd9333jh",oauth_signature_method="HMAC-SHA1",oauth_signature="wPkvxykrw%2BBTdCcGqKr%2B3I%2BPsiM%3D"
+        // normalized parameters: csv=aaa%2Cbbb&file=vacation.jpg&oauth_consumer_key=dpf43f3p2l4k3l03&oauth_nonce=9940pd%2F933%2B3jh%3D%3D&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1191242096&oauth_token=nnch734d00sl2jdk&oauth_version=1.0&size=original
+        // signature base string: POST&http%3A%2F%2Fphotos.example.net%2Fphotos&csv%3Daaa%252Cbbb%26file%3Dvacation.jpg%26oauth_consumer_key%3Ddpf43f3p2l4k3l03%26oauth_nonce%3D9940pd%252F933%252B3jh%253D%253D%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1191242096%26oauth_token%3Dnnch734d00sl2jdk%26oauth_version%3D1.0%26size%3Doriginal
+        // signature: pxSjRMay8t6HUKsENIGdg8QjYY4=
+        // header: OAuth realm="",oauth_version="1.0",oauth_consumer_key="dpf43f3p2l4k3l03",oauth_token="nnch734d00sl2jdk",oauth_timestamp="1191242096",oauth_nonce="9940pd%2F933%2B3jh%3D%3D",oauth_signature_method="HMAC-SHA1",oauth_signature="pxSjRMay8t6HUKsENIGdg8QjYY4%3D"
 
         String authHeader = req.getHeaders().get("Authorization").get(0);
         Matcher m = Pattern.compile("oauth_signature=\"(.+?)\"").matcher(authHeader);
@@ -121,7 +123,7 @@ public class OAuthSignatureCalculatorTest {
             fail("bad encoding", e);
         }
 
-        assertEquals(sig, "wPkvxykrw+BTdCcGqKr+3I+PsiM=");
+        assertEquals(sig, "pxSjRMay8t6HUKsENIGdg8QjYY4=");
     }
 
     @Test(groups = "fast")
@@ -133,6 +135,7 @@ public class OAuthSignatureCalculatorTest {
         List<Param> queryParams = new ArrayList<Param>();
         queryParams.add(new Param("file", "vacation.jpg"));
         queryParams.add(new Param("size", "original"));
+        queryParams.add(new Param("params", "aaa bbb ccc")); // add percent encoded test case
         String url = "http://photos.example.net/photos";
 
         final Request req = new RequestBuilder("GET")
@@ -141,13 +144,13 @@ public class OAuthSignatureCalculatorTest {
                 .setSignatureCalculator(calc).build();
 
         final List<Param> params = req.getQueryParams();
-        assertEquals(params.size(), 2);
+        assertEquals(params.size(), 3);
         
         // From the signature tester, the URL should look like:
-        //normalized parameters: file=vacation.jpg&oauth_consumer_key=dpf43f3p2l4k3l03&oauth_nonce=kllo9940pd9333jh&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1191242096&oauth_token=nnch734d00sl2jdk&oauth_version=1.0&size=original
-        //signature base string: GET&http%3A%2F%2Fphotos.example.net%2Fphotos&file%3Dvacation.jpg%26oauth_consumer_key%3Ddpf43f3p2l4k3l03%26oauth_nonce%3Dkllo9940pd9333jh%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1191242096%26oauth_token%3Dnnch734d00sl2jdk%26oauth_version%3D1.0%26size%3Doriginal
-        //signature: tR3+Ty81lMeYAr/Fid0kMTYa/WM=
-        //Authorization header: OAuth realm="",oauth_version="1.0",oauth_consumer_key="dpf43f3p2l4k3l03",oauth_token="nnch734d00sl2jdk",oauth_timestamp="1191242096",oauth_nonce="kllo9940pd9333jh",oauth_signature_method="HMAC-SHA1",oauth_signature="tR3%2BTy81lMeYAr%2FFid0kMTYa%2FWM%3D"
+        //normalized parameters: file=vacation.jpg&oauth_consumer_key=dpf43f3p2l4k3l03&oauth_nonce=9940pd%2F933%2B3jh%3D%3D&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1191242096&oauth_token=nnch734d00sl2jdk&oauth_version=1.0&params=aaa%20bbb%20ccc&size=original
+        //signature base string: GET&http%3A%2F%2Fphotos.example.net%2Fphotos&file%3Dvacation.jpg%26oauth_consumer_key%3Ddpf43f3p2l4k3l03%26oauth_nonce%3D9940pd%252F933%252B3jh%253D%253D%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1191242096%26oauth_token%3Dnnch734d00sl2jdk%26oauth_version%3D1.0%26params%3Daaa%2520bbb%2520ccc%26size%3Doriginal
+        //signature: SKOUFsG+VUvS7vWaUpCSNN8RBXM=
+        //Authorization header: OAuth realm="",oauth_version="1.0",oauth_consumer_key="dpf43f3p2l4k3l03",oauth_token="nnch734d00sl2jdk",oauth_timestamp="1191242096",oauth_nonce="9940pd%2F933%2B3jh%3D%3D",oauth_signature_method="HMAC-SHA1",oauth_signature="SKOUFsG%2BVUvS7vWaUpCSNN8RBXM%3D"
 
         String authHeader = req.getHeaders().get("Authorization").get(0);
         Matcher m = Pattern.compile("oauth_signature=\"(.+?)\"").matcher(authHeader);
@@ -160,7 +163,7 @@ public class OAuthSignatureCalculatorTest {
             fail("bad encoding", e);
         }
 
-        assertEquals(sig, "tR3+Ty81lMeYAr/Fid0kMTYa/WM=");
+        assertEquals(sig, "SKOUFsG+VUvS7vWaUpCSNN8RBXM=");
 
     }
 


### PR DESCRIPTION
#### before
```java
normalized parameters:
 csv=aaa%[25]2Cbbb&file=vacation.jpg&oauth_consumer_key=dpf43f3p2l4k3l03&oauth_nonce=9940pd%2F933%2B3jh%3D%3D&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1191242096&oauth_token=nnch734d00sl2jdk&oauth_version=1.0&size=original

signature base string:
 POST&http%3A%2F%2Fphotos.example.net%2Fphotos&csv%3Daaa%25[25]2Cbbb%26file%3Dvacation.jpg%26oauth_consumer_key%3Ddpf43f3p2l4k3l03%26oauth_nonce%3D9940pd%252F933%252B3jh%253D%253D%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1191242096%26oauth_token%3Dnnch734d00sl2jdk%26oauth_version%3D1.0%26size%3Doriginal
```

#### after
```java
normalized parameters:
 csv=aaa%[]2Cbbb&file=vacation.jpg&oauth_consumer_key=dpf43f3p2l4k3l03&oauth_nonce=9940pd%2F933%2B3jh%3D%3D&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1191242096&oauth_token=nnch734d00sl2jdk&oauth_version=1.0&size=original

signature base string:
 POST&http%3A%2F%2Fphotos.example.net%2Fphotos&csv%3Daaa%25[]2Cbbb%26file%3Dvacation.jpg%26oauth_consumer_key%3Ddpf43f3p2l4k3l03%26oauth_nonce%3D9940pd%252F933%252B3jh%253D%253D%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1191242096%26oauth_token%3Dnnch734d00sl2jdk%26oauth_version%3D1.0%26size%3Doriginal
```