### PR TITLE
Cast correct object to WebSocketUpgradeHandler

### DIFF
--- a/providers/netty4/src/main/java/org/asynchttpclient/netty/handler/WebSocketProtocol.java
+++ b/providers/netty4/src/main/java/org/asynchttpclient/netty/handler/WebSocketProtocol.java
@@ -206,7 +206,7 @@ public final class WebSocketProtocol extends Protocol {
         logger.trace("onClose {}");
 
         try {
-            WebSocketUpgradeHandler h = WebSocketUpgradeHandler.class.cast(future);
+            WebSocketUpgradeHandler h = WebSocketUpgradeHandler.class.cast(future.getAsyncHandler());
             NettyWebSocket webSocket = NettyWebSocket.class.cast(h.onCompleted());
 
             logger.trace("Connection was closed abnormally (that is, with no close frame being sent).");


### PR DESCRIPTION
The NettyResponseFuture can not be cast to a WebSocketUpgradeHandler, resulting in a cast class exception and the close-callback never being called. Calling getAsyncHandler() on the future and casting that results in the correct behaviour.