### PR TITLE
Send END_PADDING to server

### DIFF
--- a/api/src/main/java/org/asynchttpclient/request/body/generator/FeedableBodyGenerator.java
+++ b/api/src/main/java/org/asynchttpclient/request/body/generator/FeedableBodyGenerator.java
@@ -78,10 +78,10 @@ public final class FeedableBodyGenerator implements BodyGenerator {
                 case CLOSING:
                     buffer.put(ZERO);
                     buffer.put(END_PADDING);
+                    buffer.put(END_PADDING);
                     finishState = FINISHED;
                     return buffer.position();
                 case FINISHED:
-                    buffer.put(END_PADDING);
                     return -1;
                 }
             }


### PR DESCRIPTION
In the finished state -1 is returned. So the caller assumes that nothing was written to the outgoing buffer
and misses the end padding.