### PR TITLE
Fix stream suspending with FeedableBodyGenerator.

### DIFF
--- a/api/src/main/java/org/asynchttpclient/request/body/generator/FeedableBodyGenerator.java
+++ b/api/src/main/java/org/asynchttpclient/request/body/generator/FeedableBodyGenerator.java
@@ -56,7 +56,7 @@ public final class FeedableBodyGenerator implements BodyGenerator {
         ONGOING, CLOSING, FINISHED;
     }
     
-    private final class PushBody implements Body {
+    public final class PushBody implements Body {
 
         private PushBodyState state = PushBodyState.ONGOING;
 

--- a/providers/netty3/src/main/java/org/asynchttpclient/netty/request/body/BodyChunkedInput.java
+++ b/providers/netty3/src/main/java/org/asynchttpclient/netty/request/body/BodyChunkedInput.java
@@ -16,6 +16,7 @@ package org.asynchttpclient.netty.request.body;
 import java.nio.ByteBuffer;
 
 import org.asynchttpclient.request.body.Body;
+import org.asynchttpclient.request.body.generator.FeedableBodyGenerator;
 import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.handler.stream.ChunkedInput;
 
@@ -56,6 +57,9 @@ public class BodyChunkedInput implements ChunkedInput {
             long r = body.read(buffer);
             if (r < 0L) {
                 endOfInput = true;
+                return null;
+            } else if(r == 0 && body instanceof FeedableBodyGenerator.PushBody) {
+                //this will suspend the stream in ChunkedWriteHandler
                 return null;
             } else {
                 endOfInput = r == contentLength || r < chunkSize && contentLength > 0;


### PR DESCRIPTION
netty expects null as outgoing buffer to suspend the stream.

see ChunkedWriteHandler#222