### PR TITLE
AsyncHttpClient `name` option

### DIFF
--- a/api/src/main/java/org/asynchttpclient/config/AsyncHttpClientConfigBean.java
+++ b/api/src/main/java/org/asynchttpclient/config/AsyncHttpClientConfigBean.java
@@ -51,6 +51,7 @@ public class AsyncHttpClientConfigBean extends AsyncHttpClientConfig {
     void configureDefaults() {
         maxConnections = defaultMaxConnections();
         maxConnectionsPerHost = defaultMaxConnectionsPerHost();
+        name = defaultName();
         connectTimeout = defaultConnectTimeout();
         webSocketTimeout = defaultWebSocketTimeout();
         pooledConnectionIdleTimeout = defaultPooledConnectionIdleTimeout();
@@ -86,6 +87,11 @@ public class AsyncHttpClientConfigBean extends AsyncHttpClientConfig {
                 return t;
             }
         });
+    }
+
+    public AsyncHttpClientConfigBean setName(String name) {
+        this.name = name;
+        return this;
     }
 
     public AsyncHttpClientConfigBean setMaxTotalConnections(int maxConnections) {

--- a/api/src/main/java/org/asynchttpclient/config/AsyncHttpClientConfigDefaults.java
+++ b/api/src/main/java/org/asynchttpclient/config/AsyncHttpClientConfigDefaults.java
@@ -19,6 +19,10 @@ public final class AsyncHttpClientConfigDefaults {
 
     public static final String ASYNC_CLIENT_CONFIG_ROOT = "org.asynchttpclient.";
 
+    public static String defaultName() {
+        return AsyncHttpClientConfigHelper.getAsyncHttpClientConfig().getString(ASYNC_CLIENT_CONFIG_ROOT + "name");
+    }
+
     public static int defaultMaxConnections() {
         return AsyncHttpClientConfigHelper.getAsyncHttpClientConfig().getInt(ASYNC_CLIENT_CONFIG_ROOT + "maxConnections");
     }

--- a/api/src/main/java/org/asynchttpclient/util/PrefixIncrementThreadFactory.java
+++ b/api/src/main/java/org/asynchttpclient/util/PrefixIncrementThreadFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.util;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Thread factory that generates thread names by adding incrementing number
+ * to the specified prefix.
+ *
+ * @author Stepan Koltsov
+ */
+public class PrefixIncrementThreadFactory implements ThreadFactory {
+    private final String namePrefix;
+    private final AtomicInteger threadNumber = new AtomicInteger();
+
+    public PrefixIncrementThreadFactory(String namePrefix) {
+        if (namePrefix == null || namePrefix.isEmpty()) {
+            throw new IllegalArgumentException("namePrefix must not be empty");
+        }
+        this.namePrefix = namePrefix;
+    }
+
+    public Thread newThread(Runnable r) {
+        return new Thread(r, namePrefix + threadNumber.incrementAndGet());
+    }
+}

--- a/api/src/main/resources/ahc-default.properties
+++ b/api/src/main/resources/ahc-default.properties
@@ -1,3 +1,4 @@
+org.asynchttpclient.name=AsyncHttpClient
 org.asynchttpclient.maxConnections=-1
 org.asynchttpclient.maxConnectionsPerHost=-1
 org.asynchttpclient.connectTimeout=5000

--- a/api/src/test/java/org/asynchttpclient/ThreadNameTest.java
+++ b/api/src/test/java/org/asynchttpclient/ThreadNameTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Tests configured client name is used for thread names.
+ *
+ * @author Stepan Koltsov
+ */
+public abstract class ThreadNameTest extends AbstractBasicTest {
+
+    private static Thread[] getThreads() {
+        int count = Thread.activeCount() + 1;
+        for (;;) {
+            Thread[] threads = new Thread[count];
+            int filled = Thread.enumerate(threads);
+            if (filled < threads.length) {
+                return Arrays.copyOf(threads, filled);
+            }
+
+            count *= 2;
+        }
+    }
+
+    @Test(groups = { "standalone", "default_provider" })
+    public void testQueryParameters() throws Exception {
+        String name = "ahc-" + (new Random().nextLong() & 0x7fffffffffffffffL);
+        AsyncHttpClientConfig.Builder config = new AsyncHttpClientConfig.Builder();
+        config.setName(name);
+        try (AsyncHttpClient client = getAsyncHttpClient(config.build())) {
+            Future<Response> f = client.prepareGet("http://127.0.0.1:" + port1 + "/").execute();
+            f.get(3, TimeUnit.SECONDS);
+
+            // We cannot assert that all threads are created with specified name,
+            // so we checking that at least one thread is.
+            boolean found = false;
+            for (Thread thread : getThreads()) {
+                if (thread.getName().startsWith(name)) {
+                    found = true;
+                    break;
+                }
+            }
+
+            Assert.assertTrue(found, "must found threads starting with random string " + name);
+        }
+    }
+}

--- a/providers/netty3/src/test/java/org/asynchttpclient/netty/NettyThreadNameTest.java
+++ b/providers/netty3/src/test/java/org/asynchttpclient/netty/NettyThreadNameTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.netty;
+
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.AsyncHttpClientConfig;
+import org.asynchttpclient.RetryRequestTest;
+import org.asynchttpclient.ThreadNameTest;
+
+/**
+ * @author Stepan Koltsov
+ */
+public class NettyThreadNameTest extends ThreadNameTest {
+    @Override
+    public AsyncHttpClient getAsyncHttpClient(AsyncHttpClientConfig config) {
+        return NettyProviderUtil.nettyProvider(config);
+    }
+}

--- a/providers/netty4/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
+++ b/providers/netty4/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
@@ -38,6 +38,7 @@ import io.netty.handler.codec.http.websocketx.WebSocketFrameAggregator;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.util.Timer;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.internal.chmv8.ConcurrentHashMapV8;
 
 import java.io.IOException;
@@ -172,7 +173,12 @@ public class ChannelManager {
 
         // check if external EventLoopGroup is defined
         allowReleaseEventLoopGroup = nettyConfig.getEventLoopGroup() == null;
-        eventLoopGroup = allowReleaseEventLoopGroup ? new NioEventLoopGroup() : nettyConfig.getEventLoopGroup();
+        if (allowReleaseEventLoopGroup) {
+            DefaultThreadFactory threadFactory = new DefaultThreadFactory(config.getNameOrDefault());
+            eventLoopGroup = new NioEventLoopGroup(0, threadFactory);
+        } else {
+            eventLoopGroup = nettyConfig.getEventLoopGroup();
+        }
         if (eventLoopGroup instanceof OioEventLoopGroup)
             throw new IllegalArgumentException("Oio is not supported");
 

--- a/providers/netty4/src/test/java/org/asynchttpclient/netty/NettyThreadNameTest.java
+++ b/providers/netty4/src/test/java/org/asynchttpclient/netty/NettyThreadNameTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.netty;
+
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.AsyncHttpClientConfig;
+import org.asynchttpclient.ThreadNameTest;
+
+/**
+ * @author Stepan Koltsov
+ */
+public class NettyThreadNameTest extends ThreadNameTest {
+    @Override
+    public AsyncHttpClient getAsyncHttpClient(AsyncHttpClientConfig config) {
+        return NettyProviderUtil.nettyProvider(config);
+    }
+}


### PR DESCRIPTION
Fixes #952

Name option is useful for two purposes:

## Thread name

Typical application with several netty and/or async-http-client
instances may have hundreds of threads like "New I/O worker 120",
which makes it hard to understand which thread belongs to which
part of the application.

Specified name is used in AsyncHttpClient to name threads created
by AsyncHttpClient and netty.

If name is not specified, `AsyncHttpClient` string is used.

## Debugging

`name` is stored in `AsyncHttpClientConfig`, and available in
debugger debugging when application has multiple client instances.
It can be useful to distinguish between instance, for example, when
breakpoint is set inside of AsyncHttpClient.