### PR TITLE
#941: Adding NTLM proxy test case.

### DIFF
--- a/src/test/java/com/ning/http/client/async/NTLMProxyTest.java
+++ b/src/test/java/com/ning/http/client/async/NTLMProxyTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.ning.http.client.async;
+
+import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.AsyncHttpClientConfig;
+import com.ning.http.client.ProxyServer;
+import com.ning.http.client.Realm.AuthScheme;
+import com.ning.http.client.Request;
+import com.ning.http.client.RequestBuilder;
+import com.ning.http.client.Response;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public abstract class NTLMProxyTest extends AbstractBasicTest {
+
+    public static class NTLMProxyHandler extends AbstractHandler {
+
+        @Override
+        public void handle(String pathInContext, org.eclipse.jetty.server.Request request, HttpServletRequest httpRequest,
+                           HttpServletResponse httpResponse) throws IOException, ServletException {
+
+            String authorization = httpRequest.getHeader("Proxy-Authorization");
+            if (authorization == null) {
+                httpResponse.setStatus(407);
+                httpResponse.setHeader("Proxy-Authenticate", "NTLM");
+
+            } else if (authorization.equals("NTLM TlRMTVNTUAABAAAAAYIIogAAAAAoAAAAAAAAACgAAAAFASgKAAAADw==")) {
+                httpResponse.setStatus(407);
+                httpResponse.setHeader("Proxy-Authenticate", "NTLM TlRMTVNTUAACAAAAAAAAACgAAAABggAAU3J2Tm9uY2UAAAAAAAAAAA==");
+
+            } else if (authorization
+                    .equals("NTLM TlRMTVNTUAADAAAAGAAYAEgAAAAYABgAYAAAABQAFAB4AAAADAAMAIwAAAASABIAmAAAAAAAAACqAAAAAYIAAgUBKAoAAAAPrYfKbe/jRoW5xDxHeoxC1gBmfWiS5+iX4OAN4xBKG/IFPwfH3agtPEia6YnhsADTVQBSAFMAQQAtAE0ASQBOAE8AUgBaAGEAcABoAG8AZABMAGkAZwBoAHQAQwBpAHQAeQA=")) {
+                httpResponse.setStatus(200);
+            } else {
+                httpResponse.setStatus(401);
+            }
+            httpResponse.setContentLength(0);
+            httpResponse.getOutputStream().flush();
+            httpResponse.getOutputStream().close();
+        }
+    }
+
+    @Override
+    public AbstractHandler configureHandler() throws Exception {
+        return new NTLMProxyHandler();
+    }
+
+    @Test
+    public void ntlmProxyTest() throws IOException, InterruptedException, ExecutionException {
+
+        AsyncHttpClientConfig config = new AsyncHttpClientConfig.Builder().build();
+
+        try (AsyncHttpClient client = getAsyncHttpClient(config)) {
+            Request request = new RequestBuilder("GET").setProxyServer(ntlmProxy()).setUrl(getTargetUrl()).build();
+            Future<Response> responseFuture = client.executeRequest(request);
+            int status = responseFuture.get().getStatusCode();
+            Assert.assertEquals(status, 200);
+        }
+    }
+
+    private ProxyServer ntlmProxy() throws UnknownHostException
+    {
+        ProxyServer proxyServer = new ProxyServer("127.0.0.1", port2, "Zaphod", "Beeblebrox").setNtlmDomain("Ursa-Minor");
+        proxyServer.setNtlmHost("LightCity");
+        proxyServer.setScheme(AuthScheme.NTLM);
+        return proxyServer;
+    }
+
+}

--- a/src/test/java/com/ning/http/client/async/grizzly/GrizzlyNTLMProxyTest.java
+++ b/src/test/java/com/ning/http/client/async/grizzly/GrizzlyNTLMProxyTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.ning.http.client.async.grizzly;
+
+import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.AsyncHttpClientConfig;
+import com.ning.http.client.async.NTLMProxyTest;
+import com.ning.http.client.async.ProviderUtil;
+
+public class GrizzlyNTLMProxyTest extends NTLMProxyTest
+{
+
+    @Override
+    public AsyncHttpClient getAsyncHttpClient(AsyncHttpClientConfig config)
+    {
+        return ProviderUtil.grizzlyProvider(config);
+    }
+}

--- a/src/test/java/com/ning/http/client/async/netty/NettyNTLMProxyTest.java
+++ b/src/test/java/com/ning/http/client/async/netty/NettyNTLMProxyTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.ning.http.client.async.netty;
+
+import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.AsyncHttpClientConfig;
+import com.ning.http.client.async.NTLMProxyTest;
+import com.ning.http.client.async.ProviderUtil;
+
+public class NettyNTLMProxyTest extends NTLMProxyTest
+{
+    @Override
+    public AsyncHttpClient getAsyncHttpClient(AsyncHttpClientConfig config) {
+        return ProviderUtil.nettyProvider(config);
+    }
+}


### PR DESCRIPTION
Grizzly test is currently failing, but this test should work once the issue (#941) is fixed.