### PR TITLE
Issue/544 reactive streams support

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -43,4 +43,12 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.reactivestreams</groupId>
+			<artifactId>reactive-streams</artifactId>
+			<version>1.0.0</version>
+		</dependency>
+	</dependencies>
 </project>

--- a/api/src/main/java/org/asynchttpclient/RequestBuilderBase.java
+++ b/api/src/main/java/org/asynchttpclient/RequestBuilderBase.java
@@ -35,9 +35,11 @@ import org.asynchttpclient.channel.pool.ConnectionPoolPartitioning;
 import org.asynchttpclient.cookie.Cookie;
 import org.asynchttpclient.proxy.ProxyServer;
 import org.asynchttpclient.request.body.generator.BodyGenerator;
+import org.asynchttpclient.request.body.generator.ReactiveStreamsBodyGenerator;
 import org.asynchttpclient.request.body.multipart.Part;
 import org.asynchttpclient.uri.Uri;
 import org.asynchttpclient.util.UriEncoder;
+import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -473,6 +475,10 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
         resetBody();
         request.streamData = stream;
         return derived.cast(this);
+    }
+
+    public T setBody(Publisher<ByteBuffer> publisher) {
+        return setBody(new ReactiveStreamsBodyGenerator(publisher));
     }
 
     public T setBody(BodyGenerator bodyGenerator) {

--- a/api/src/main/java/org/asynchttpclient/handler/StreamedAsyncHandler.java
+++ b/api/src/main/java/org/asynchttpclient/handler/StreamedAsyncHandler.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.handler;
+
+import org.asynchttpclient.AsyncHandler;
+import org.asynchttpclient.HttpResponseBodyPart;
+import org.reactivestreams.Publisher;
+
+/**
+ * AsyncHandler that uses reactive streams to handle the request.
+ */
+public interface StreamedAsyncHandler<T> extends AsyncHandler<T> {
+
+    /**
+     * Called when the body is received. May not be called if there's no body.
+     *
+     * @param publisher The publisher of response body parts.
+     * @return Whether to continue or abort.
+     */
+    State onStream(Publisher<HttpResponseBodyPart> publisher);
+}

--- a/api/src/main/java/org/asynchttpclient/request/body/generator/ReactiveStreamsBodyGenerator.java
+++ b/api/src/main/java/org/asynchttpclient/request/body/generator/ReactiveStreamsBodyGenerator.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.request.body.generator;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.asynchttpclient.request.body.Body;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReactiveStreamsBodyGenerator implements FeedableBodyGenerator {
+    private static final ByteBuffer EMPTY = ByteBuffer.wrap("".getBytes());
+
+    private final Publisher<ByteBuffer> publisher;
+    private final FeedableBodyGenerator feedableBodyGenerator;
+    private final AtomicReference<FeedListener> feedListener = new AtomicReference<>(null);
+
+    public ReactiveStreamsBodyGenerator(Publisher<ByteBuffer> publisher) {
+        this.publisher = publisher;
+        this.feedableBodyGenerator = new SimpleFeedableBodyGenerator();
+    }
+
+    public Publisher<ByteBuffer> getPublisher() {
+        return this.publisher;
+    }
+
+    @Override
+    public void feed(ByteBuffer buffer, boolean isLast) {
+        feedableBodyGenerator.feed(buffer, isLast);
+    }
+
+    @Override
+    public void writeChunkBoundaries() {
+        feedableBodyGenerator.writeChunkBoundaries();
+    }
+
+    @Override
+    public void setListener(FeedListener listener) {
+        feedListener.set(listener);
+        feedableBodyGenerator.setListener(listener);
+    }
+
+    @Override
+    public Body createBody() {
+        return new StreamedBody(publisher, feedableBodyGenerator);
+    }
+
+    private class StreamedBody implements Body {
+        private final AtomicBoolean initialized = new AtomicBoolean(false);
+
+        private final SimpleSubscriber subscriber;
+        private final Body body;
+
+        public StreamedBody(Publisher<ByteBuffer> publisher, FeedableBodyGenerator bodyGenerator) {
+            this.body = bodyGenerator.createBody();
+            this.subscriber = new SimpleSubscriber(bodyGenerator);
+        }
+
+        @Override
+        public void close() throws IOException {
+            body.close();
+        }
+
+        @Override
+        public long getContentLength() {
+            return body.getContentLength();
+        }
+
+        @Override
+        public State read(ByteBuffer buffer) throws IOException {
+            if(initialized.compareAndSet(false, true))
+                publisher.subscribe(subscriber);
+
+            return body.read(buffer);
+        }
+    }
+
+    private class SimpleSubscriber implements Subscriber<ByteBuffer> {
+
+        private final Logger LOGGER = LoggerFactory.getLogger(SimpleSubscriber.class);
+
+        private final FeedableBodyGenerator feeder;
+        private volatile Subscription subscription;
+
+        public SimpleSubscriber(FeedableBodyGenerator feeder) {
+            this.feeder = feeder;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (s == null) throw null;
+
+            // If someone has made a mistake and added this Subscriber multiple times, let's handle it gracefully
+            if (this.subscription != null) { 
+                s.cancel(); // Cancel the additional subscription
+            }
+            else {
+              subscription = s;
+              subscription.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(ByteBuffer t) {
+            if (t == null) throw null;
+            try {
+                feeder.feed(t, false);
+            } catch (Exception e) {
+                LOGGER.error("Exception occurred while processing element in stream.", e);
+                subscription.cancel();
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (t == null) throw null;
+            LOGGER.debug("Error occurred while consuming body stream.", t);
+            FeedListener listener = feedListener.get();
+            if(listener != null) listener.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            try {
+              feeder.feed(EMPTY, true);
+            } 
+            catch (Exception e) {
+                LOGGER.info("Ignoring exception occurred while completing stream processing.", e);
+                this.subscription.cancel();
+            }
+        }
+    }
+}

--- a/api/src/main/java/org/asynchttpclient/request/body/generator/SimpleFeedableBodyGenerator.java
+++ b/api/src/main/java/org/asynchttpclient/request/body/generator/SimpleFeedableBodyGenerator.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2014 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.request.body.generator;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.asynchttpclient.request.body.Body;
+
+public final class SimpleFeedableBodyGenerator implements FeedableBodyGenerator, BodyGenerator {
+    private final static byte[] END_PADDING = "\r\n".getBytes(US_ASCII);
+    private final static byte[] ZERO = "0".getBytes(US_ASCII);
+    private final static ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);
+    private final Queue<BodyPart> queue = new ConcurrentLinkedQueue<>();
+    private FeedListener listener;
+
+    // must be set to true when using Netty 3 where native chunking is broken
+    private boolean writeChunkBoundaries = false;
+
+    @Override
+    public Body createBody() {
+        return new PushBody();
+    }
+
+    @Override
+    public void feed(final ByteBuffer buffer, final boolean isLast) {
+        queue.offer(new BodyPart(buffer, isLast));
+        if (listener != null) {
+            listener.onContentAdded();
+        }
+    }
+
+    @Override
+    public void setListener(FeedListener listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    public void writeChunkBoundaries() {
+        this.writeChunkBoundaries = true;
+    }
+
+    public final class PushBody implements Body {
+
+        private State state = State.Continue;
+
+        @Override
+        public long getContentLength() {
+            return -1;
+        }
+
+        @Override
+        public State read(final ByteBuffer buffer) throws IOException {
+            switch (state) {
+                case Continue:
+                    return readNextPart(buffer);
+                case Stop:
+                    return State.Stop;
+                default:
+                    throw new IllegalStateException("Illegal process state.");
+            }
+        }
+
+        private State readNextPart(ByteBuffer buffer) throws IOException {
+            State res = State.Suspend;
+            while (buffer.hasRemaining() && state != State.Stop) {
+                BodyPart nextPart = queue.peek();
+                if (nextPart == null) {
+                    // Nothing in the queue. suspend stream if nothing was read. (reads == 0)
+                    return res;
+                } else if (!nextPart.buffer.hasRemaining() && !nextPart.isLast) {
+                    // skip empty buffers
+                    queue.remove();
+                } else {
+                    res = State.Continue;
+                    readBodyPart(buffer, nextPart);
+                }
+            }
+            return res;
+        }
+
+        private void readBodyPart(ByteBuffer buffer, BodyPart part) {
+            part.initBoundaries();
+            move(buffer, part.size);
+            move(buffer, part.buffer);
+            move(buffer, part.endPadding);
+
+            if (!part.buffer.hasRemaining() && !part.endPadding.hasRemaining()) {
+                if (part.isLast) {
+                    state = State.Stop;
+                }
+                queue.remove();
+            }
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private void move(ByteBuffer destination, ByteBuffer source) {
+        int size = Math.min(destination.remaining(), source.remaining());
+        if (size > 0) {
+            ByteBuffer slice = source.slice();
+            slice.limit(size);
+            destination.put(slice);
+            source.position(source.position() + size);
+        }
+    }
+
+    private final class BodyPart {
+        private final boolean isLast;
+        private ByteBuffer size = null;
+        private final ByteBuffer buffer;
+        private ByteBuffer endPadding = null;
+
+        public BodyPart(final ByteBuffer buffer, final boolean isLast) {
+            this.buffer = buffer;
+            this.isLast = isLast;
+        }
+
+        private void initBoundaries() {
+            if(size == null && endPadding == null) {
+                if (SimpleFeedableBodyGenerator.this.writeChunkBoundaries) {
+                    if(buffer.hasRemaining()) {
+                        final byte[] sizeAsHex = Integer.toHexString(buffer.remaining()).getBytes(US_ASCII);
+                        size = ByteBuffer.allocate(sizeAsHex.length + END_PADDING.length);
+                        size.put(sizeAsHex);
+                        size.put(END_PADDING);
+                        size.flip();
+                    } else {
+                        size = EMPTY_BUFFER;
+                    }
+
+                    if(isLast) {
+                        endPadding = ByteBuffer.allocate(END_PADDING.length * 3 + ZERO.length);
+                        if(buffer.hasRemaining()) {
+                            endPadding.put(END_PADDING);
+                        }
+
+                        //add last empty
+                        endPadding.put(ZERO);
+                        endPadding.put(END_PADDING);
+                        endPadding.put(END_PADDING);
+                        endPadding.flip();
+                    } else {
+                        endPadding = ByteBuffer.wrap(END_PADDING);
+                    }
+                } else {
+                    size = EMPTY_BUFFER;
+                    endPadding = EMPTY_BUFFER;
+                }
+            }
+        }
+    }
+}

--- a/api/src/test/java/org/asynchttpclient/reactivestreams/ReactiveStreamsTest.java
+++ b/api/src/test/java/org/asynchttpclient/reactivestreams/ReactiveStreamsTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.reactivestreams;
+
+import static org.asynchttpclient.test.TestUtils.LARGE_IMAGE_BYTES;
+import static org.testng.Assert.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import org.asynchttpclient.AbstractBasicTest;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.HttpResponseBodyPart;
+import org.asynchttpclient.HttpResponseHeaders;
+import org.asynchttpclient.HttpResponseStatus;
+import org.asynchttpclient.ListenableFuture;
+import org.asynchttpclient.handler.StreamedAsyncHandler;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.testng.annotations.Test;
+
+public abstract class ReactiveStreamsTest extends AbstractBasicTest {
+
+    @Test(groups = { "standalone", "default_provider" })
+    public void streamedResponseTest() throws Throwable {
+        try (AsyncHttpClient c = getAsyncHttpClient(null)) {
+
+            ListenableFuture<SimpleStreamedAsyncHandler> future = c.preparePost(getTargetUrl())
+                    .setBody(LARGE_IMAGE_BYTES)
+                    .execute(new SimpleStreamedAsyncHandler());
+
+            assertEquals(future.get().getBytes(), LARGE_IMAGE_BYTES);
+
+            // Run it again to check that the pipeline is in a good state
+            future = c.preparePost(getTargetUrl())
+                    .setBody(LARGE_IMAGE_BYTES)
+                    .execute(new SimpleStreamedAsyncHandler());
+
+            assertEquals(future.get().getBytes(), LARGE_IMAGE_BYTES);
+
+            // Make sure a regular request still works
+            assertEquals(c.preparePost(getTargetUrl())
+                    .setBody("Hello")
+                    .execute().get().getResponseBody(), "Hello");
+
+        }
+    }
+
+    @Test(groups = { "standalone", "default_provider" })
+    public void cancelStreamedResponseTest() throws Throwable {
+        try (AsyncHttpClient c = getAsyncHttpClient(null)) {
+
+            // Cancel immediately
+            c.preparePost(getTargetUrl())
+                    .setBody(LARGE_IMAGE_BYTES)
+                    .execute(new CancellingStreamedAsyncProvider(0)).get();
+
+            // Cancel after 1 element
+            c.preparePost(getTargetUrl())
+                    .setBody(LARGE_IMAGE_BYTES)
+                    .execute(new CancellingStreamedAsyncProvider(1)).get();
+
+            // Cancel after 10 elements
+            c.preparePost(getTargetUrl())
+                    .setBody(LARGE_IMAGE_BYTES)
+                    .execute(new CancellingStreamedAsyncProvider(10)).get();
+
+            // Make sure a regular request works
+            assertEquals(c.preparePost(getTargetUrl())
+                    .setBody("Hello")
+                    .execute().get().getResponseBody(), "Hello");
+
+        }
+    }
+
+    static protected class SimpleStreamedAsyncHandler implements StreamedAsyncHandler<SimpleStreamedAsyncHandler>{
+        private final SimpleSubscriber<HttpResponseBodyPart> subscriber;
+
+        public SimpleStreamedAsyncHandler() {
+            this(new SimpleSubscriber<HttpResponseBodyPart>());
+        }
+
+        public SimpleStreamedAsyncHandler(SimpleSubscriber<HttpResponseBodyPart> subscriber) {
+            this.subscriber = subscriber;
+        }
+        @Override
+        public State onStream(Publisher<HttpResponseBodyPart> publisher) {
+            publisher.subscribe(subscriber);
+            return State.CONTINUE;
+        }
+
+        @Override
+        public void onThrowable(Throwable t) {
+            throw new AssertionError(t);
+        }
+
+        @Override
+        public State onBodyPartReceived(HttpResponseBodyPart bodyPart) throws Exception {
+            throw new AssertionError("Should not have received body part");
+        }
+
+        @Override
+        public State onStatusReceived(HttpResponseStatus responseStatus) throws Exception {
+            return State.CONTINUE;
+        }
+
+        @Override
+        public State onHeadersReceived(HttpResponseHeaders headers) throws Exception {
+            return State.CONTINUE;
+        }
+
+        @Override
+        public SimpleStreamedAsyncHandler onCompleted() throws Exception {
+            return this;
+        }
+
+        public byte[] getBytes() throws Throwable {
+            List<HttpResponseBodyPart> bodyParts = subscriber.getElements();
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            for (HttpResponseBodyPart part : bodyParts) {
+                part.writeTo(bytes);
+            }
+            return bytes.toByteArray();
+        }
+    }
+
+    /**
+     * Simple subscriber that requests and buffers one element at a time.
+     */
+    static protected class SimpleSubscriber<T> implements Subscriber<T> {
+        private volatile Subscription subscription;
+        private volatile Throwable error;
+        private final List<T> elements = Collections.synchronizedList(new ArrayList<T>());
+        private final CountDownLatch latch = new CountDownLatch(1);
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            this.subscription = subscription;
+            subscription.request(1);
+        }
+
+        @Override
+        public void onNext(T t) {
+            elements.add(t);
+            subscription.request(1);
+        }
+
+        @Override
+        public void onError(Throwable error) {
+            this.error = error;
+            latch.countDown();
+        }
+
+        @Override
+        public void onComplete() {
+            latch.countDown();
+        }
+
+        public List<T> getElements() throws Throwable {
+            latch.await();
+            if (error != null) {
+                throw error;
+            } else {
+                return elements;
+            }
+        }
+    }
+
+    static class CancellingStreamedAsyncProvider implements StreamedAsyncHandler<CancellingStreamedAsyncProvider> {
+        private final int cancelAfter;
+
+        public CancellingStreamedAsyncProvider(int cancelAfter) {
+            this.cancelAfter = cancelAfter;
+        }
+
+        @Override
+        public State onStream(Publisher<HttpResponseBodyPart> publisher) {
+            publisher.subscribe(new CancellingSubscriber<HttpResponseBodyPart>(cancelAfter));
+            return State.CONTINUE;
+        }
+
+        @Override
+        public void onThrowable(Throwable t) {
+            throw new AssertionError(t);
+        }
+
+        @Override
+        public State onBodyPartReceived(HttpResponseBodyPart bodyPart) throws Exception {
+            throw new AssertionError("Should not have received body part");
+        }
+
+        @Override
+        public State onStatusReceived(HttpResponseStatus responseStatus) throws Exception {
+            return State.CONTINUE;
+        }
+
+        @Override
+        public State onHeadersReceived(HttpResponseHeaders headers) throws Exception {
+            return State.CONTINUE;
+        }
+
+        @Override
+        public CancellingStreamedAsyncProvider onCompleted() throws Exception {
+            return this;
+        }
+    }
+
+    /**
+     * Simple subscriber that cancels after receiving n elements.
+     */
+    static class CancellingSubscriber<T> implements Subscriber<T> {
+        private final int cancelAfter;
+
+        public CancellingSubscriber(int cancelAfter) {
+            this.cancelAfter = cancelAfter;
+        }
+
+        private volatile Subscription subscription;
+        private volatile int count;
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            this.subscription = subscription;
+            if (cancelAfter == 0) {
+                subscription.cancel();
+            } else {
+                subscription.request(1);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            count++;
+            if (count == cancelAfter) {
+                subscription.cancel();
+            } else {
+                subscription.request(1);
+            }
+        }
+
+        @Override
+        public void onError(Throwable error) {
+        }
+
+        @Override
+        public void onComplete() {
+        }
+    }
+}

--- a/api/src/test/java/org/asynchttpclient/request/body/ChunkingTest.java
+++ b/api/src/test/java/org/asynchttpclient/request/body/ChunkingTest.java
@@ -33,6 +33,7 @@ import org.asynchttpclient.RequestBuilder;
 import org.asynchttpclient.Response;
 import org.asynchttpclient.request.body.generator.FeedableBodyGenerator;
 import org.asynchttpclient.request.body.generator.InputStreamBodyGenerator;
+import org.asynchttpclient.request.body.generator.SimpleFeedableBodyGenerator;
 import org.testng.annotations.Test;
 
 /**
@@ -86,7 +87,7 @@ abstract public class ChunkingTest extends AbstractBasicTest {
 
             RequestBuilder builder = new RequestBuilder("POST");
             builder.setUrl(getTargetUrl());
-            final FeedableBodyGenerator feedableBodyGenerator = new FeedableBodyGenerator();
+            final FeedableBodyGenerator feedableBodyGenerator = new SimpleFeedableBodyGenerator();
             builder.setBody(feedableBodyGenerator);
 
             Request r = builder.build();

--- a/api/src/test/java/org/asynchttpclient/request/body/ReactiveStreamsTest.java
+++ b/api/src/test/java/org/asynchttpclient/request/body/ReactiveStreamsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.request.body;
+
+import static org.asynchttpclient.test.TestUtils.LARGE_IMAGE_BYTES;
+import static org.asynchttpclient.test.TestUtils.LARGE_IMAGE_PUBLISHER;
+import static org.testng.Assert.assertEquals;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutionException;
+
+import org.asynchttpclient.AbstractBasicTest;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.AsyncHttpClientConfig;
+import org.asynchttpclient.BoundRequestBuilder;
+import org.asynchttpclient.Response;
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import rx.Observable;
+import rx.RxReactiveStreams;
+
+public abstract class ReactiveStreamsTest extends AbstractBasicTest {
+
+    @Test(groups = { "standalone", "default_provider" }, enabled = true)
+    public void testStreamingPutImage() throws Exception {
+        try (AsyncHttpClient client = getAsyncHttpClient(new AsyncHttpClientConfig.Builder().setRequestTimeout(100 * 6000).build())) {
+            Response response = client.preparePut(getTargetUrl()).setBody(LARGE_IMAGE_PUBLISHER).execute().get();
+            assertEquals(response.getStatusCode(), 200);
+            assertEquals(response.getResponseBodyAsBytes(), LARGE_IMAGE_BYTES);
+        }
+    }
+
+    @Test(groups = { "standalone", "default_provider" }, enabled = true)
+    public void testConnectionDoesNotGetClosed() throws Exception { // test that we can stream the same request multiple times
+        try (AsyncHttpClient client = getAsyncHttpClient(new AsyncHttpClientConfig.Builder().setRequestTimeout(100 * 6000).build())) {
+            BoundRequestBuilder requestBuilder = client.preparePut(getTargetUrl()).setBody(LARGE_IMAGE_PUBLISHER);
+            Response response = requestBuilder.execute().get();
+            assertEquals(response.getStatusCode(), 200);
+            assertEquals(response.getResponseBodyAsBytes(), LARGE_IMAGE_BYTES);
+            
+            response = requestBuilder.execute().get();
+            assertEquals(response.getStatusCode(), 200);
+            assertEquals(response.getResponseBodyAsBytes(), LARGE_IMAGE_BYTES);
+        }
+    }
+
+    @Test(groups = { "standalone", "default_provider" }, enabled = true, expectedExceptions = ExecutionException.class)
+    public void testFailingStream() throws Exception {
+        try (AsyncHttpClient client = getAsyncHttpClient(new AsyncHttpClientConfig.Builder().setRequestTimeout(100 * 6000).build())) {
+            Observable<ByteBuffer> failingObservable = Observable.error(new FailedStream());
+            Publisher<ByteBuffer> failingPublisher = RxReactiveStreams.toPublisher(failingObservable);
+
+            client.preparePut(getTargetUrl()).setBody(failingPublisher).execute().get();
+        }
+    }
+
+    @SuppressWarnings("serial")
+    private class FailedStream extends RuntimeException {}
+}

--- a/api/src/test/java/org/asynchttpclient/request/body/generator/FeedableBodyGeneratorTest.java
+++ b/api/src/test/java/org/asynchttpclient/request/body/generator/FeedableBodyGeneratorTest.java
@@ -26,12 +26,12 @@ import static org.testng.Assert.*;
 
 public class FeedableBodyGeneratorTest {
 
-    private FeedableBodyGenerator feedableBodyGenerator;
+    private SimpleFeedableBodyGenerator feedableBodyGenerator;
     private TestFeedListener listener;
 
     @BeforeMethod
     public void setUp() throws Exception {
-        feedableBodyGenerator = new FeedableBodyGenerator();
+        feedableBodyGenerator = new SimpleFeedableBodyGenerator();
         listener = new TestFeedListener();
         feedableBodyGenerator.setListener(listener);
     }
@@ -107,7 +107,7 @@ public class FeedableBodyGeneratorTest {
         return readBytes;
     }
 
-    private static class TestFeedListener implements FeedableBodyGenerator.FeedListener {
+    private static class TestFeedListener implements SimpleFeedableBodyGenerator.FeedListener {
 
         private int calls;
 
@@ -115,6 +115,9 @@ public class FeedableBodyGeneratorTest {
         public void onContentAdded() {
             calls++;
         }
+
+        @Override
+        public void onError(Throwable t) {}
 
         public int getCalls() {
             return calls;

--- a/pom.xml
+++ b/pom.xml
@@ -428,6 +428,12 @@
 			<version>${privilegedaccessor.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.reactivex</groupId>
+			<artifactId>rxjava-reactive-streams</artifactId>
+			<version>${rxjava-reactive-streams.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<properties>
 		<additionalparam>-Xdoclint:none</additionalparam>
@@ -444,6 +450,7 @@
 		<commons-io.version>2.4</commons-io.version>
 		<commons-fileupload.version>1.3</commons-fileupload.version>
 		<privilegedaccessor.version>1.2.2</privilegedaccessor.version>
+		<rxjava-reactive-streams.version>1.0.1</rxjava-reactive-streams.version>
 	</properties>
 </project>
 

--- a/providers/netty3/src/main/java/org/asynchttpclient/netty/request/body/NettyBodyBody.java
+++ b/providers/netty3/src/main/java/org/asynchttpclient/netty/request/body/NettyBodyBody.java
@@ -24,8 +24,8 @@ import org.asynchttpclient.netty.request.ProgressListener;
 import org.asynchttpclient.request.body.Body;
 import org.asynchttpclient.request.body.RandomAccessBody;
 import org.asynchttpclient.request.body.generator.BodyGenerator;
-import org.asynchttpclient.request.body.generator.FeedableBodyGenerator;
 import org.asynchttpclient.request.body.generator.FeedableBodyGenerator.FeedListener;
+import org.asynchttpclient.request.body.generator.FeedableBodyGenerator;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelFuture;
 import org.jboss.netty.handler.stream.ChunkedWriteHandler;
@@ -55,7 +55,7 @@ public class NettyBodyBody implements NettyBody {
     }
 
     @Override
-    public void write(final Channel channel, NettyResponseFuture<?> future) throws IOException {
+    public void write(final Channel channel, final NettyResponseFuture<?> future) throws IOException {
 
         Object msg;
         if (body instanceof RandomAccessBody && !ChannelManager.isSslHandlerConfigured(channel.getPipeline()) && !config.isDisableZeroCopy()) {
@@ -72,6 +72,10 @@ public class NettyBodyBody implements NettyBody {
                     @Override
                     public void onContentAdded() {
                         channel.getPipeline().get(ChunkedWriteHandler.class).resumeTransfer();
+                    }
+                    @Override
+                    public void onError(Throwable t) {
+                        future.abort(t);
                     }
                 });
             }

--- a/providers/netty3/src/test/java/org/asynchttpclient/netty/request/body/NettyReactiveStreamsTest.java
+++ b/providers/netty3/src/test/java/org/asynchttpclient/netty/request/body/NettyReactiveStreamsTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.netty.request.body;
+
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.AsyncHttpClientConfig;
+import org.asynchttpclient.netty.NettyProviderUtil;
+import org.asynchttpclient.request.body.ReactiveStreamsTest;
+
+public class NettyReactiveStreamsTest extends ReactiveStreamsTest {
+    @Override
+    public AsyncHttpClient getAsyncHttpClient(AsyncHttpClientConfig config) {
+        return NettyProviderUtil.nettyProvider(config);
+    }
+}

--- a/providers/netty4/pom.xml
+++ b/providers/netty4/pom.xml
@@ -18,6 +18,11 @@
 			<version>4.0.30.Final</version>
 		</dependency>
 		<dependency>
+			<groupId>com.typesafe.netty</groupId>
+			<artifactId>netty-reactive-streams</artifactId>
+			<version>1.0.0-M2</version>
+		</dependency>
+		<dependency>
 			<groupId>org.javassist</groupId>
 			<artifactId>javassist</artifactId>
 			<version>3.20.0-GA</version>

--- a/providers/netty4/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
+++ b/providers/netty4/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
@@ -205,10 +205,10 @@ public class ChannelManager {
     public void configureBootstraps(NettyRequestSender requestSender, AtomicBoolean closed) {
 
         HttpProtocol httpProtocol = new HttpProtocol(this, config, nettyConfig, requestSender);
-        final Processor httpProcessor = new Processor(config, this, requestSender, httpProtocol);
+        final Processor httpProcessor = new Processor(config, nettyConfig, this, requestSender, httpProtocol);
 
         WebSocketProtocol wsProtocol = new WebSocketProtocol(this, config, nettyConfig, requestSender);
-        wsProcessor = new Processor(config, this, requestSender, wsProtocol);
+        wsProcessor = new Processor(config, nettyConfig, this, requestSender, wsProtocol);
 
         httpBootstrap.handler(new ChannelInitializer<Channel>() {
             @Override
@@ -218,6 +218,8 @@ public class ChannelManager {
                         .addLast(INFLATER_HANDLER, newHttpContentDecompressor())//
                         .addLast(CHUNKED_WRITER_HANDLER, new ChunkedWriteHandler())//
                         .addLast(HTTP_PROCESSOR, httpProcessor);
+
+                ch.config().setOption(ChannelOption.AUTO_READ, false);
 
                 if (nettyConfig.getHttpAdditionalPipelineInitializer() != null)
                     nettyConfig.getHttpAdditionalPipelineInitializer().initPipeline(ch.pipeline());

--- a/providers/netty4/src/main/java/org/asynchttpclient/netty/handler/StreamedResponsePublisher.java
+++ b/providers/netty4/src/main/java/org/asynchttpclient/netty/handler/StreamedResponsePublisher.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.netty.handler;
+
+import com.typesafe.netty.HandlerPublisher;
+import io.netty.channel.Channel;
+import io.netty.util.concurrent.EventExecutor;
+import org.asynchttpclient.HttpResponseBodyPart;
+import org.asynchttpclient.netty.NettyResponseFuture;
+import org.asynchttpclient.netty.channel.ChannelManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StreamedResponsePublisher extends HandlerPublisher<HttpResponseBodyPart> {
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final ChannelManager channelManager;
+    private final NettyResponseFuture<?> future;
+    private final Channel channel;
+
+    public StreamedResponsePublisher(EventExecutor executor, ChannelManager channelManager, NettyResponseFuture<?> future, Channel channel) {
+        super(executor, HttpResponseBodyPart.class);
+        this.channelManager = channelManager;
+        this.future = future;
+        this.channel = channel;
+    }
+
+    @Override
+    protected void cancelled() {
+        logger.debug("Subscriber cancelled, ignoring the rest of the body");
+
+        // The subscriber cancelled early, we need to drain the remaining elements from the stream
+        channelManager.drainChannelAndOffer(channel, future);
+        channel.pipeline().remove(StreamedResponsePublisher.class);
+
+        try {
+            future.done();
+        } catch (Exception t) {
+            // Never propagate exception once we know we are done.
+            logger.debug(t.getMessage(), t);
+        }
+    }
+
+    NettyResponseFuture<?> future() {
+        return future;
+    }
+}

--- a/providers/netty4/src/main/java/org/asynchttpclient/netty/request/NettyRequestFactory.java
+++ b/providers/netty4/src/main/java/org/asynchttpclient/netty/request/NettyRequestFactory.java
@@ -62,9 +62,11 @@ import org.asynchttpclient.netty.request.body.NettyDirectBody;
 import org.asynchttpclient.netty.request.body.NettyFileBody;
 import org.asynchttpclient.netty.request.body.NettyInputStreamBody;
 import org.asynchttpclient.netty.request.body.NettyMultipartBody;
+import org.asynchttpclient.netty.request.body.NettyReactiveStreamsBody;
 import org.asynchttpclient.proxy.ProxyServer;
 import org.asynchttpclient.request.body.generator.FileBodyGenerator;
 import org.asynchttpclient.request.body.generator.InputStreamBodyGenerator;
+import org.asynchttpclient.request.body.generator.ReactiveStreamsBodyGenerator;
 import org.asynchttpclient.uri.Uri;
 import org.asynchttpclient.util.HttpUtils;
 import org.asynchttpclient.util.StringUtils;
@@ -118,7 +120,8 @@ public final class NettyRequestFactory extends NettyRequestFactoryBase {
 
             } else if (request.getBodyGenerator() instanceof InputStreamBodyGenerator)
                 nettyBody = new NettyInputStreamBody(InputStreamBodyGenerator.class.cast(request.getBodyGenerator()).getInputStream(), config);
-
+            else if (request.getBodyGenerator() instanceof ReactiveStreamsBodyGenerator)
+                nettyBody = new NettyReactiveStreamsBody(ReactiveStreamsBodyGenerator.class.cast(request.getBodyGenerator()).getPublisher());
             else if (request.getBodyGenerator() != null)
                 nettyBody = new NettyBodyBody(request.getBodyGenerator().createBody(), config);
         }

--- a/providers/netty4/src/main/java/org/asynchttpclient/netty/request/body/NettyBodyBody.java
+++ b/providers/netty4/src/main/java/org/asynchttpclient/netty/request/body/NettyBodyBody.java
@@ -29,7 +29,7 @@ import org.asynchttpclient.netty.request.ProgressListener;
 import org.asynchttpclient.request.body.Body;
 import org.asynchttpclient.request.body.RandomAccessBody;
 import org.asynchttpclient.request.body.generator.BodyGenerator;
-import org.asynchttpclient.request.body.generator.FeedableBodyGenerator;
+import org.asynchttpclient.request.body.generator.SimpleFeedableBodyGenerator;
 import org.asynchttpclient.request.body.generator.FeedableBodyGenerator.FeedListener;
 
 public class NettyBodyBody implements NettyBody {
@@ -67,12 +67,14 @@ public class NettyBodyBody implements NettyBody {
             msg = new BodyChunkedInput(body);
 
             BodyGenerator bg = future.getRequest().getBodyGenerator();
-            if (bg instanceof FeedableBodyGenerator) {
-                FeedableBodyGenerator.class.cast(bg).setListener(new FeedListener() {
+            if (bg instanceof SimpleFeedableBodyGenerator) {
+                SimpleFeedableBodyGenerator.class.cast(bg).setListener(new FeedListener() {
                     @Override
                     public void onContentAdded() {
                         channel.pipeline().get(ChunkedWriteHandler.class).resumeTransfer();
                     }
+                    @Override
+                    public void onError(Throwable t) {}
                 });
             }
         }

--- a/providers/netty4/src/main/java/org/asynchttpclient/netty/request/body/NettyReactiveStreamsBody.java
+++ b/providers/netty4/src/main/java/org/asynchttpclient/netty/request/body/NettyReactiveStreamsBody.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.netty.request.body;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.NoSuchElementException;
+
+import org.asynchttpclient.netty.NettyResponseFuture;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.typesafe.netty.HandlerSubscriber;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.concurrent.EventExecutor;
+
+public class NettyReactiveStreamsBody implements NettyBody {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NettyReactiveStreamsBody.class);
+    private static final String NAME_IN_CHANNEL_PIPELINE = "request-body-streamer";
+
+    private final Publisher<ByteBuffer> publisher;
+
+    public NettyReactiveStreamsBody(Publisher<ByteBuffer> publisher) {
+        this.publisher = publisher;
+    }
+
+    @Override
+    public long getContentLength() {
+        return -1L;
+    }
+
+    @Override
+    public String getContentType() {
+        return null;
+    }
+
+    @Override
+    public void write(Channel channel, NettyResponseFuture<?> future) throws IOException {
+        if (future.isStreamWasAlreadyConsumed()) {
+            LOGGER.warn("Stream has already been consumed and cannot be reset");
+        } else {
+            future.setStreamWasAlreadyConsumed(true);
+            NettySubscriber subscriber = new NettySubscriber(channel, future);
+            channel.pipeline().addLast(NAME_IN_CHANNEL_PIPELINE, subscriber);
+            publisher.subscribe(new SubscriberAdapter(subscriber));
+        }
+    }
+
+    private static class SubscriberAdapter implements Subscriber<ByteBuffer> {
+        private volatile Subscriber<HttpContent> subscriber;
+        
+        public SubscriberAdapter(Subscriber<HttpContent> subscriber) {
+            this.subscriber = subscriber;
+        }
+        @Override
+        public void onSubscribe(Subscription s) {
+           subscriber.onSubscribe(s);
+        }
+        @Override
+        public void onNext(ByteBuffer t) {
+            ByteBuf buffer = Unpooled.wrappedBuffer(t.array());
+            HttpContent content = new DefaultHttpContent(buffer);
+            subscriber.onNext(content);
+        }
+        @Override
+        public void onError(Throwable t) {
+            subscriber.onError(t);
+        }
+        @Override
+        public void onComplete() {
+            subscriber.onComplete();
+        }        
+    }
+    
+    private static class NettySubscriber extends HandlerSubscriber<HttpContent> {
+        private static final Logger LOGGER = LoggerFactory.getLogger(NettySubscriber.class);
+
+        private final Channel channel;
+        private final NettyResponseFuture<?> future;
+
+        public NettySubscriber(Channel channel, NettyResponseFuture<?> future) {
+            super(channel.eventLoop());
+            this.channel = channel;
+            this.future = future;
+        }
+
+        @Override
+        protected void complete() {
+            EventExecutor executor = channel.eventLoop();
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    channel.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT).addListener(new ChannelFutureListener() {
+                        @Override
+                        public void operationComplete(ChannelFuture future) throws Exception {
+                            removeFromPipeline();
+                        }
+                    });
+                }
+            });
+        }
+
+        @Override
+        protected void error(Throwable error) {
+            if(error == null) throw null;
+            removeFromPipeline();
+            future.abort(error);
+        }
+
+        private void removeFromPipeline() {
+            try {
+                channel.pipeline().remove(this);
+                LOGGER.debug(String.format("Removed handler %s from pipeline.", NAME_IN_CHANNEL_PIPELINE));
+            } catch (NoSuchElementException e) {
+                LOGGER.debug(String.format("Failed to remove handler %s from pipeline.", NAME_IN_CHANNEL_PIPELINE), e);
+            }
+        }
+    }
+}

--- a/providers/netty4/src/test/java/org/asynchttpclient/netty/request/body/NettyReactiveStreamsTest.java
+++ b/providers/netty4/src/test/java/org/asynchttpclient/netty/request/body/NettyReactiveStreamsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.netty.request.body;
+
+import static org.asynchttpclient.test.TestUtils.LARGE_IMAGE_BYTES;
+import static org.asynchttpclient.test.TestUtils.LARGE_IMAGE_PUBLISHER;
+import static org.testng.Assert.assertEquals;
+
+import java.nio.ByteBuffer;
+
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.AsyncHttpClientConfig;
+import org.asynchttpclient.Response;
+import org.asynchttpclient.netty.NettyProviderUtil;
+import org.asynchttpclient.request.body.Body;
+import org.asynchttpclient.request.body.ReactiveStreamsTest;
+import org.asynchttpclient.request.body.generator.BodyGenerator;
+import org.asynchttpclient.request.body.generator.ReactiveStreamsBodyGenerator;
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+public class NettyReactiveStreamsTest extends ReactiveStreamsTest {
+    @Override
+    public AsyncHttpClient getAsyncHttpClient(AsyncHttpClientConfig config) {
+        return NettyProviderUtil.nettyProvider(config);
+    }
+
+    @Test(groups = { "standalone" }, enabled = true)
+    public void testEagerPutImage() throws Exception { // this tests the `ReactiveStreamBodyGenerator.createBody` implementation
+        try (AsyncHttpClient client = getAsyncHttpClient(new AsyncHttpClientConfig.Builder().setRequestTimeout(100 * 6000).build())) {
+            BodyGenerator bodyGenerator = new GenericBodyGenerator(createBody(LARGE_IMAGE_PUBLISHER));
+            Response response = client.preparePut(getTargetUrl()).setBody(bodyGenerator).execute().get();
+            assertEquals(response.getStatusCode(), 200);
+            assertEquals(response.getResponseBodyAsBytes(), LARGE_IMAGE_BYTES);
+        }
+    }
+
+    public BodyGenerator createBody(Publisher<ByteBuffer> publisher) {
+        return new ReactiveStreamsBodyGenerator(publisher);
+    }
+
+    // Because NettyRequestFactory#body uses the type information to decide the type of body to create, this class allows to hide
+    // the type so that the generic `NettyBodyBody` is used.
+    // This is useful to test that the implementation of ReactiveStreamBodyGenerator#createBody works as expected.
+    private class GenericBodyGenerator implements BodyGenerator {
+
+        private final BodyGenerator bodyGenerator;
+
+        public GenericBodyGenerator(BodyGenerator bodyGenerator) {
+            this.bodyGenerator = bodyGenerator;
+        }
+
+        @Override
+        public Body createBody() {
+            return this.bodyGenerator.createBody();
+        }
+    }
+}


### PR DESCRIPTION
Here is an initial proposal to fix #544.

I'm entirely new to both Netty and AHC, so if you notice anything weird it's very likely that I haven't understood something :-)

~~Other than that, something is puzzling me with the tests I wrote. Basically, if I change the `CHUNK_SIZE` in https://github.com/AsyncHttpClient/async-http-client/compare/AsyncHttpClient:master...dotta:issue/544-reactive-streams-support?expand=1#diff-5133f4e3fed98f7a99081a1ae643c4c0R104 to a value around `20000` (or lower), the tests start to fail because there is a mismatch between the received bytes and the expected ones. I honestly have no good explanation for this, but I thought it may have something to do with the internals of Netty (or maybe a config flag?). I'd really appreciate it if someone more experienced with Netty could have a look.~~
EDIT: This issue is now fixed after using RxJava instead of providing my own implementation of `Publisher` in the test :-)

This PR also includes @jroper commit to add support for handling response bodies.