### PR TITLE
ISSUES-976: FluentCaseInsensitiveStringsMap keyLookup un-sync with values after iterator remove 

### DIFF
--- a/api/src/main/java/org/asynchttpclient/FluentCaseInsensitiveStringsMap.java
+++ b/api/src/main/java/org/asynchttpclient/FluentCaseInsensitiveStringsMap.java
@@ -116,7 +116,7 @@ public class FluentCaseInsensitiveStringsMap implements Map<String, List<String>
         // small optimization: resync only when size is different, hopefully may reduce unnecessary loops
         if (keyLookup.size() != values.size()) {
             for (Iterator<String> iterator = keyLookup.values().iterator(); iterator.hasNext(); ) {
-                // remove if exists in keyLoopup but not in values
+                // remove if exists in keyLookup but not in values
                 if (!values.containsKey(iterator.next())) {
                     iterator.remove();
                 }

--- a/api/src/main/java/org/asynchttpclient/FluentCaseInsensitiveStringsMap.java
+++ b/api/src/main/java/org/asynchttpclient/FluentCaseInsensitiveStringsMap.java
@@ -112,6 +112,18 @@ public class FluentCaseInsensitiveStringsMap implements Map<String, List<String>
         return result;
     }
 
+    private void resyncKeyLookupWithValues() {
+        // small optimization: resync only when size is different, hopefully may reduce unnecessary loops
+        if (keyLookup.size() != values.size()) {
+            for (Iterator<String> iterator = keyLookup.values().iterator(); iterator.hasNext(); ) {
+                // remove if exists in keyLoopup but not in values
+                if (!values.containsKey(iterator.next())) {
+                    iterator.remove();
+                }
+            }
+        }
+    }
+
     /**
      * Adds the specified values and returns this object.
      *
@@ -356,6 +368,7 @@ public class FluentCaseInsensitiveStringsMap implements Map<String, List<String>
      */
     @Override
     public Set<String> keySet() {
+        resyncKeyLookupWithValues();
         return new LinkedHashSet<>(keyLookup.values());
     }
 
@@ -388,7 +401,11 @@ public class FluentCaseInsensitiveStringsMap implements Map<String, List<String>
      */
     @Override
     public boolean containsKey(Object key) {
-        return key == null ? false : keyLookup.containsKey(key.toString().toLowerCase(Locale.ENGLISH));
+        if (key != null) {
+            resyncKeyLookupWithValues();
+            return keyLookup.containsKey(key.toString().toLowerCase(Locale.US));
+        }
+        return false;
     }
 
     /**

--- a/api/src/test/java/org/asynchttpclient/FluentCaseInsensitiveStringsMapTest.java
+++ b/api/src/test/java/org/asynchttpclient/FluentCaseInsensitiveStringsMapTest.java
@@ -18,6 +18,7 @@ package org.asynchttpclient;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertFalse;
 
 import org.asynchttpclient.FluentCaseInsensitiveStringsMap;
 import org.testng.annotations.Test;
@@ -25,8 +26,10 @@ import org.testng.annotations.Test;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 
 public class FluentCaseInsensitiveStringsMapTest {
@@ -621,5 +624,23 @@ public class FluentCaseInsensitiveStringsMapTest {
         assertEquals(map.getFirstValue("baz"), "foo");
         assertEquals(map.getJoinedValue("baz", ", "), "foo, bar");
         assertEquals(map.get("baz"), Arrays.asList("foo", "bar"));
+    }
+
+    @Test
+    public void keySetInSyncAfterIterateRemoveTest() {
+        FluentCaseInsensitiveStringsMap map = new FluentCaseInsensitiveStringsMap();
+        map.add("foo", "FOO");
+        map.add("bar", "BAR");
+        map.add("baz", "BAZ");
+
+        for (Iterator<Map.Entry<String, List<String>>> iter = map.entrySet().iterator(); iter.hasNext(); ) {
+            if (iter.next().getKey().equalsIgnoreCase("foo")) {
+                iter.remove();
+            }
+        }
+
+        assertEquals(map.keySet(), new LinkedHashSet<>(Arrays.asList("bar", "baz")));
+        assertFalse(map.containsKey("foo"));
+        assertEquals(map.get("foo"), Collections.<String> emptyList());
     }
 }


### PR DESCRIPTION
Just proposing a quick fix unless we're planning to do something fancier.

Thanks,
Ben