### PR TITLE
Code quality fix - Constructors should only call non-overridable methods

### DIFF
--- a/client/src/main/java/org/asynchttpclient/ntlm/NtlmEngine.java
+++ b/client/src/main/java/org/asynchttpclient/ntlm/NtlmEngine.java
@@ -795,7 +795,7 @@ public final class NtlmEngine {
         }
 
         /** Get the message length */
-        protected int getMessageLength() {
+        protected final int getMessageLength() {
             return currentOutputPosition;
         }
 
@@ -808,7 +808,7 @@ public final class NtlmEngine {
         }
 
         /** Read a bunch of bytes from a position in the message buffer */
-        protected void readBytes(final byte[] buffer, final int position) throws NtlmEngineException {
+        protected final void readBytes(final byte[] buffer, final int position) throws NtlmEngineException {
             if (messageContents.length < position + buffer.length) {
                 throw new NtlmEngineException("NTLM: Message too short");
             }
@@ -821,12 +821,12 @@ public final class NtlmEngine {
         }
 
         /** Read a ulong from a position within the message buffer */
-        protected int readULong(final int position) throws NtlmEngineException {
+        protected final int readULong(final int position) throws NtlmEngineException {
             return NtlmEngine.readULong(messageContents, position);
         }
 
         /** Read a security buffer from a position within the message buffer */
-        protected byte[] readSecurityBuffer(final int position) throws NtlmEngineException {
+        protected final byte[] readSecurityBuffer(final int position) throws NtlmEngineException {
             return NtlmEngine.readSecurityBuffer(messageContents, position);
         }
 

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/FileLikePart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/FileLikePart.java
@@ -48,7 +48,7 @@ public abstract class FileLikePart extends PartBase {
                 transfertEncoding == null ? DEFAULT_TRANSFER_ENCODING : transfertEncoding);
     }
 
-    public void setFileName(String fileName) {
+    public final void setFileName(String fileName) {
         this.fileName = fileName;
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1699 - “Constructors should only call non-overridable methods”. 
You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1699

Please let me know if you have any questions.

Faisal.