### PR TITLE
Code quality fix - IP addresses should not be hardcoded

### DIFF
--- a/client/src/test/java/org/asynchttpclient/AbstractBasicTest.java
+++ b/client/src/test/java/org/asynchttpclient/AbstractBasicTest.java
@@ -21,6 +21,7 @@ import static org.asynchttpclient.test.TestUtils.newJettyHttpServer;
 import static org.testng.Assert.fail;
 
 import org.asynchttpclient.test.EchoHandler;
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.slf4j.Logger;
@@ -59,11 +60,11 @@ public abstract class AbstractBasicTest {
     }
 
     protected String getTargetUrl() {
-        return String.format("http://127.0.0.1:%d/foo/test", port1);
+        return String.format("http://%s:%d/foo/test", TestUtils.getUnitTestIpAddress(), port1);
     }
 
     protected String getTargetUrl2() {
-        return String.format("https://127.0.0.1:%d/foo/test", port2);
+        return String.format("https://%s:%d/foo/test", TestUtils.getUnitTestIpAddress(), port2);
     }
 
     public AbstractHandler configureHandler() throws Exception {

--- a/client/src/test/java/org/asynchttpclient/AuthTimeoutTest.java
+++ b/client/src/test/java/org/asynchttpclient/AuthTimeoutTest.java
@@ -26,6 +26,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.asynchttpclient.test.TestUtils;
 import org.asynchttpclient.util.HttpUtils;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
@@ -189,7 +190,7 @@ public class AuthTimeoutTest extends AbstractBasicTest {
 
     @Override
     protected String getTargetUrl() {
-        return "http://127.0.0.1:" + port1 + "/";
+        return String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), port1);
     }
 
     @Override

--- a/client/src/test/java/org/asynchttpclient/BasicAuthTest.java
+++ b/client/src/test/java/org/asynchttpclient/BasicAuthTest.java
@@ -31,6 +31,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -81,16 +82,16 @@ public class BasicAuthTest extends AbstractBasicTest {
 
     @Override
     protected String getTargetUrl() {
-        return "http://127.0.0.1:" + port1 + "/";
+        return String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), port1);
     }
 
     @Override
     protected String getTargetUrl2() {
-        return "http://127.0.0.1:" + port2 + "/uff";
+        return String.format("http://%s:%d/uff", TestUtils.getUnitTestIpAddress(), port2);
     }
 
     protected String getTargetUrlNoAuth() {
-        return "http://127.0.0.1:" + portNoAuth + "/";
+        return String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), portNoAuth);
     }
 
     @Override

--- a/client/src/test/java/org/asynchttpclient/BasicHttpTest.java
+++ b/client/src/test/java/org/asynchttpclient/BasicHttpTest.java
@@ -51,6 +51,7 @@ import org.asynchttpclient.handler.MaxRedirectException;
 import org.asynchttpclient.request.body.multipart.Part;
 import org.asynchttpclient.request.body.multipart.StringPart;
 import org.asynchttpclient.test.EventCollectingHandler;
+import org.asynchttpclient.test.TestUtils;
 import org.testng.annotations.Test;
 
 public class BasicHttpTest extends AbstractBasicTest {
@@ -644,7 +645,7 @@ public class BasicHttpTest extends AbstractBasicTest {
 
     @Test(groups = { "standalone", "async" })
     public void asyncDoPostProxyTest() throws Exception {
-        try (AsyncHttpClient client = asyncHttpClient(config().setProxyServer(proxyServer("127.0.0.1", port2).build()))) {
+        try (AsyncHttpClient client = asyncHttpClient(config().setProxyServer(proxyServer(TestUtils.getUnitTestIpAddress(), port2).build()))) {
             HttpHeaders h = new DefaultHttpHeaders();
             h.add(HttpHeaders.Names.CONTENT_TYPE, HttpHeaders.Values.APPLICATION_X_WWW_FORM_URLENCODED);
             StringBuilder sb = new StringBuilder();
@@ -687,7 +688,7 @@ public class BasicHttpTest extends AbstractBasicTest {
             if (response.getHeader("X-Host").startsWith("localhost")) {
                 assertEquals(response.getHeader("X-Host"), "localhost:" + port1);
             } else {
-                assertEquals(response.getHeader("X-Host"), "127.0.0.1:" + port1);
+                assertEquals(response.getHeader("X-Host"), TestUtils.getUnitTestIpAddress() + port1);
             }
         }
     }
@@ -849,7 +850,7 @@ public class BasicHttpTest extends AbstractBasicTest {
             final AtomicInteger count = new AtomicInteger();
             for (int i = 0; i < 20; i++) {
                 try {
-                    Response response = client.preparePost(String.format("http://127.0.0.1:%d/", dummyPort)).execute(new AsyncCompletionHandlerAdapter() {
+                    Response response = client.preparePost(String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), dummyPort)).execute(new AsyncCompletionHandlerAdapter() {
                         @Override
                         public void onThrowable(Throwable t) {
                             count.incrementAndGet();
@@ -872,7 +873,7 @@ public class BasicHttpTest extends AbstractBasicTest {
         try (AsyncHttpClient client = asyncHttpClient()) {
             int dummyPort = findFreePort();
             try {
-                Response response = client.preparePost(String.format("http://127.0.0.1:%d/", dummyPort)).execute(new AsyncCompletionHandlerAdapter() {
+                Response response = client.preparePost(String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), dummyPort)).execute(new AsyncCompletionHandlerAdapter() {
                     @Override
                     public void onThrowable(Throwable t) {
                         t.printStackTrace();
@@ -895,7 +896,7 @@ public class BasicHttpTest extends AbstractBasicTest {
             int port = findFreePort();
 
             try {
-                Response response = client.preparePost(String.format("http://127.0.0.1:%d/", port)).execute(new AsyncCompletionHandlerAdapter() {
+                Response response = client.preparePost(String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), port)).execute(new AsyncCompletionHandlerAdapter() {
                     @Override
                     public void onThrowable(Throwable t) {
                         t.printStackTrace();
@@ -914,7 +915,7 @@ public class BasicHttpTest extends AbstractBasicTest {
             final CountDownLatch l = new CountDownLatch(1);
             int port = findFreePort();
 
-            client.prepareGet(String.format("http://127.0.0.1:%d/", port)).execute(new AsyncCompletionHandlerAdapter() {
+            client.prepareGet(String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), port)).execute(new AsyncCompletionHandlerAdapter() {
                 @Override
                 public void onThrowable(Throwable t) {
                     try {
@@ -964,7 +965,7 @@ public class BasicHttpTest extends AbstractBasicTest {
             int port = findFreePort();
 
             try {
-                Response response = client.prepareGet(String.format("http://127.0.0.1:%d/", port)).execute(new AsyncCompletionHandlerAdapter() {
+                Response response = client.prepareGet(String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), port)).execute(new AsyncCompletionHandlerAdapter() {
                     @Override
                     public void onThrowable(Throwable t) {
                         called.set(true);
@@ -1364,7 +1365,7 @@ public class BasicHttpTest extends AbstractBasicTest {
     @Test(groups = "standalone", expectedExceptions = { NullPointerException.class })
     public void invalidUri() throws Exception {
         try (AsyncHttpClient client = asyncHttpClient()) {
-            client.prepareGet(String.format("http:127.0.0.1:%d/foo/test", port1)).build();
+            client.prepareGet(String.format("http:%s:%d/foo/test", TestUtils.getUnitTestIpAddress(), port1)).build();
         }
     }
 
@@ -1388,7 +1389,7 @@ public class BasicHttpTest extends AbstractBasicTest {
 
     @Test(groups = { "standalone", "async" })
     public void testNewConnectionEventsFired() throws Exception {
-        Request request = get("http://127.0.0.1:" + port1 + "/Test").build();
+        Request request = get(String.format("http://%s:%d/Test", TestUtils.getUnitTestIpAddress(), port1)).build();
 
         try (AsyncHttpClient client = asyncHttpClient()) {
             EventCollectingHandler handler = new EventCollectingHandler();

--- a/client/src/test/java/org/asynchttpclient/BasicHttpsTest.java
+++ b/client/src/test/java/org/asynchttpclient/BasicHttpsTest.java
@@ -31,12 +31,13 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.asynchttpclient.channel.pool.KeepAliveStrategy;
 import org.asynchttpclient.test.EventCollectingHandler;
+import org.asynchttpclient.test.TestUtils;
 import org.testng.annotations.Test;
 
 public class BasicHttpsTest extends AbstractBasicHttpsTest {
 
     protected String getTargetUrl() {
-        return String.format("https://127.0.0.1:%d/foo/test", port1);
+        return String.format("https://%s:%d/foo/test", TestUtils.getUnitTestIpAddress(), port1);
     }
 
     @Test(groups = "standalone")

--- a/client/src/test/java/org/asynchttpclient/ByteBufferCapacityTest.java
+++ b/client/src/test/java/org/asynchttpclient/ByteBufferCapacityTest.java
@@ -27,6 +27,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.testng.annotations.Test;
@@ -92,6 +93,6 @@ public class ByteBufferCapacityTest extends AbstractBasicTest {
     }
 
     public String getTargetUrl() {
-        return String.format("http://127.0.0.1:%d/foo/test", port1);
+        return String.format("http://%s:%d/foo/test", TestUtils.getUnitTestIpAddress(), port1);
     }
 }

--- a/client/src/test/java/org/asynchttpclient/ComplexClientTest.java
+++ b/client/src/test/java/org/asynchttpclient/ComplexClientTest.java
@@ -20,6 +20,7 @@ import static org.testng.Assert.assertEquals;
 
 import java.util.concurrent.TimeUnit;
 
+import org.asynchttpclient.test.TestUtils;
 import org.testng.annotations.Test;
 
 public class ComplexClientTest extends AbstractBasicTest {
@@ -45,7 +46,7 @@ public class ComplexClientTest extends AbstractBasicTest {
     public void urlWithoutSlashTest() throws Exception {
         try (AsyncHttpClient c = asyncHttpClient()) {
             String body = "hello there";
-            Response response = c.preparePost(String.format("http://127.0.0.1:%d/foo/test", port1)).setBody(body).setHeader("Content-Type", "text/html").execute().get(TIMEOUT, TimeUnit.SECONDS);
+            Response response = c.preparePost(String.format("http://%s:%d/foo/test", TestUtils.getUnitTestIpAddress(), port1)).setBody(body).setHeader("Content-Type", "text/html").execute().get(TIMEOUT, TimeUnit.SECONDS);
             assertEquals(response.getResponseBody(), body);
         }
     }

--- a/client/src/test/java/org/asynchttpclient/DigestAuthTest.java
+++ b/client/src/test/java/org/asynchttpclient/DigestAuthTest.java
@@ -26,6 +26,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.testng.annotations.BeforeClass;
@@ -62,7 +63,7 @@ public class DigestAuthTest extends AbstractBasicTest {
     @Test(groups = "standalone")
     public void digestAuthTest() throws IOException, ExecutionException, TimeoutException, InterruptedException {
         try (AsyncHttpClient client = asyncHttpClient()) {
-            Future<Response> f = client.prepareGet("http://127.0.0.1:" + port1 + "/")//
+            Future<Response> f = client.prepareGet(String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), port1))//
                     .setRealm(digestAuthRealm(USER, ADMIN).setRealmName("MyRealm").build())//
                     .execute();
             Response resp = f.get(60, TimeUnit.SECONDS);
@@ -75,7 +76,7 @@ public class DigestAuthTest extends AbstractBasicTest {
     @Test(groups = "standalone")
     public void digestAuthTestWithoutScheme() throws IOException, ExecutionException, TimeoutException, InterruptedException {
         try (AsyncHttpClient client = asyncHttpClient()) {
-            Future<Response> f = client.prepareGet("http://127.0.0.1:" + port1 + "/")//
+            Future<Response> f = client.prepareGet(String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), port1))//
                     .setRealm(digestAuthRealm(USER, ADMIN).setRealmName("MyRealm").build())//
                     .execute();
             Response resp = f.get(60, TimeUnit.SECONDS);
@@ -88,7 +89,7 @@ public class DigestAuthTest extends AbstractBasicTest {
     @Test(groups = "standalone")
     public void digestAuthNegativeTest() throws IOException, ExecutionException, TimeoutException, InterruptedException {
         try (AsyncHttpClient client = asyncHttpClient()) {
-            Future<Response> f = client.prepareGet("http://127.0.0.1:" + port1 + "/")//
+            Future<Response> f = client.prepareGet(String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), port1))//
                     .setRealm(digestAuthRealm("fake", ADMIN).build())//
                     .execute();
             Response resp = f.get(20, TimeUnit.SECONDS);

--- a/client/src/test/java/org/asynchttpclient/ErrorResponseTest.java
+++ b/client/src/test/java/org/asynchttpclient/ErrorResponseTest.java
@@ -29,6 +29,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.testng.annotations.Test;
@@ -63,7 +64,7 @@ public class ErrorResponseTest extends AbstractBasicTest {
     @Test(groups = "standalone")
     public void testQueryParameters() throws Exception {
         try (AsyncHttpClient client = asyncHttpClient()) {
-            Future<Response> f = client.prepareGet("http://127.0.0.1:" + port1 + "/foo").addHeader("Accepts", "*/*").execute();
+            Future<Response> f = client.prepareGet(String.format("http://%s:%d/foo", TestUtils.getUnitTestIpAddress(), port1)).addHeader("Accepts", "*/*").execute();
             Response resp = f.get(3, TimeUnit.SECONDS);
             assertNotNull(resp);
             assertEquals(resp.getStatusCode(), 400);

--- a/client/src/test/java/org/asynchttpclient/Expect100ContinueTest.java
+++ b/client/src/test/java/org/asynchttpclient/Expect100ContinueTest.java
@@ -26,6 +26,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.testng.annotations.Test;
@@ -61,7 +62,7 @@ public class Expect100ContinueTest extends AbstractBasicTest {
     @Test(groups = "standalone")
     public void Expect100Continue() throws Exception {
         try (AsyncHttpClient client = asyncHttpClient()) {
-            Future<Response> f = client.preparePut("http://127.0.0.1:" + port1 + "/").setHeader("Expect", "100-continue").setBody(SIMPLE_TEXT_FILE).execute();
+            Future<Response> f = client.preparePut(String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), port1)).setHeader("Expect", "100-continue").setBody(SIMPLE_TEXT_FILE).execute();
             Response resp = f.get();
             assertNotNull(resp);
             assertEquals(resp.getStatusCode(), HttpServletResponse.SC_OK);

--- a/client/src/test/java/org/asynchttpclient/Head302Test.java
+++ b/client/src/test/java/org/asynchttpclient/Head302Test.java
@@ -29,6 +29,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.testng.annotations.Test;
 
@@ -66,7 +67,7 @@ public class Head302Test extends AbstractBasicTest {
     public void testHEAD302() throws IOException, BrokenBarrierException, InterruptedException, ExecutionException, TimeoutException {
         try (AsyncHttpClient client = asyncHttpClient()) {
             final CountDownLatch l = new CountDownLatch(1);
-            Request request = head("http://127.0.0.1:" + port1 + "/Test").build();
+            Request request = head(String.format("http://%s:%d/Test", TestUtils.getUnitTestIpAddress(), port1)).build();
 
             client.executeRequest(request, new AsyncCompletionHandlerBase() {
                 @Override

--- a/client/src/test/java/org/asynchttpclient/ParamEncodingTest.java
+++ b/client/src/test/java/org/asynchttpclient/ParamEncodingTest.java
@@ -29,6 +29,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.testng.annotations.Test;
@@ -58,7 +59,7 @@ public class ParamEncodingTest extends AbstractBasicTest {
 
         String value = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKQLMNOPQRSTUVWXYZ1234567809`~!@#$%^&*()_+-=,.<>/?;:'\"[]{}\\| ";
         try (AsyncHttpClient client = asyncHttpClient()) {
-            Future<Response> f = client.preparePost("http://127.0.0.1:" + port1).addFormParam("test", value).execute();
+            Future<Response> f = client.preparePost(String.format("http://%s:%d", TestUtils.getUnitTestIpAddress(), port1)).addFormParam("test", value).execute();
             Response resp = f.get(10, TimeUnit.SECONDS);
             assertNotNull(resp);
             assertEquals(resp.getStatusCode(), HttpServletResponse.SC_OK);

--- a/client/src/test/java/org/asynchttpclient/PerRequestRelative302Test.java
+++ b/client/src/test/java/org/asynchttpclient/PerRequestRelative302Test.java
@@ -29,6 +29,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.asynchttpclient.test.TestUtils;
 import org.asynchttpclient.uri.Uri;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -132,7 +133,7 @@ public class PerRequestRelative302Test extends AbstractBasicTest {
         isSet.getAndSet(false);
         try (AsyncHttpClient c = asyncHttpClient()) {
             // If the test hit a proxy, no ConnectException will be thrown and instead of 404 will be returned.
-            Response response = c.preparePost(getTargetUrl()).setFollowRedirect(true).setHeader("X-redirect", String.format("http://127.0.0.1:%d/", port2)).execute().get();
+            Response response = c.preparePost(getTargetUrl()).setFollowRedirect(true).setHeader("X-redirect", String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), port2)).execute().get();
 
             assertNotNull(response);
             assertEquals(response.getStatusCode(), 404);

--- a/client/src/test/java/org/asynchttpclient/PerRequestTimeoutTest.java
+++ b/client/src/test/java/org/asynchttpclient/PerRequestTimeoutTest.java
@@ -29,6 +29,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.continuation.Continuation;
 import org.eclipse.jetty.continuation.ContinuationSupport;
 import org.eclipse.jetty.server.Request;
@@ -45,7 +46,7 @@ public class PerRequestTimeoutTest extends AbstractBasicTest {
 
     private void checkTimeoutMessage(String message) {
         assertTrue(message.startsWith("Request timed out"), "error message indicates reason of error");
-        assertTrue(message.contains("127.0.0.1"), "error message contains remote ip address");
+        assertTrue(message.contains(TestUtils.getUnitTestIpAddress()), "error message contains remote ip address");
         assertTrue(message.contains("of 100 ms"), "error message contains timeout configuration value");
     }
 

--- a/client/src/test/java/org/asynchttpclient/PostWithQSTest.java
+++ b/client/src/test/java/org/asynchttpclient/PostWithQSTest.java
@@ -31,6 +31,7 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.testng.annotations.Test;
@@ -70,7 +71,7 @@ public class PostWithQSTest extends AbstractBasicTest {
     @Test(groups = "standalone")
     public void postWithQS() throws IOException, ExecutionException, TimeoutException, InterruptedException {
         try (AsyncHttpClient client = asyncHttpClient()) {
-            Future<Response> f = client.preparePost("http://127.0.0.1:" + port1 + "/?a=b").setBody("abc".getBytes()).execute();
+            Future<Response> f = client.preparePost(String.format("http://%s:%d/?a=b", TestUtils.getUnitTestIpAddress(), port1)).setBody("abc".getBytes()).execute();
             Response resp = f.get(3, TimeUnit.SECONDS);
             assertNotNull(resp);
             assertEquals(resp.getStatusCode(), HttpServletResponse.SC_OK);
@@ -80,11 +81,11 @@ public class PostWithQSTest extends AbstractBasicTest {
     @Test(groups = "standalone")
     public void postWithNulParamQS() throws IOException, ExecutionException, TimeoutException, InterruptedException {
         try (AsyncHttpClient client = asyncHttpClient()) {
-            Future<Response> f = client.preparePost("http://127.0.0.1:" + port1 + "/?a=").setBody("abc".getBytes()).execute(new AsyncCompletionHandlerBase() {
+            Future<Response> f = client.preparePost(String.format("http://%s:%d/?a=", TestUtils.getUnitTestIpAddress(), port1)).setBody("abc".getBytes()).execute(new AsyncCompletionHandlerBase() {
 
                 @Override
                 public State onStatusReceived(final HttpResponseStatus status) throws Exception {
-                    if (!status.getUri().toUrl().equals("http://127.0.0.1:" + port1 + "/?a=")) {
+                    if (!status.getUri().toUrl().equals(String.format("http://%s:%d/?a=", TestUtils.getUnitTestIpAddress(), port1))) {
                         throw new IOException(status.getUri().toUrl());
                     }
                     return super.onStatusReceived(status);
@@ -100,11 +101,11 @@ public class PostWithQSTest extends AbstractBasicTest {
     @Test(groups = "standalone")
     public void postWithNulParamsQS() throws IOException, ExecutionException, TimeoutException, InterruptedException {
         try (AsyncHttpClient client = asyncHttpClient()) {
-            Future<Response> f = client.preparePost("http://127.0.0.1:" + port1 + "/?a=b&c&d=e").setBody("abc".getBytes()).execute(new AsyncCompletionHandlerBase() {
+            Future<Response> f = client.preparePost(String.format("http://%s:%d/?a=b&c&d=e", TestUtils.getUnitTestIpAddress(), port1)).setBody("abc".getBytes()).execute(new AsyncCompletionHandlerBase() {
 
                 @Override
                 public State onStatusReceived(final HttpResponseStatus status) throws Exception {
-                    if (!status.getUri().toUrl().equals("http://127.0.0.1:" + port1 + "/?a=b&c&d=e")) {
+                    if (!status.getUri().toUrl().equals(String.format("http://%s:%d/?a=b&c&d=e", TestUtils.getUnitTestIpAddress(), port1))) {
                         throw new IOException("failed to parse the query properly");
                     }
                     return super.onStatusReceived(status);
@@ -120,11 +121,11 @@ public class PostWithQSTest extends AbstractBasicTest {
     @Test(groups = "standalone")
     public void postWithEmptyParamsQS() throws IOException, ExecutionException, TimeoutException, InterruptedException {
         try (AsyncHttpClient client = asyncHttpClient()) {
-            Future<Response> f = client.preparePost("http://127.0.0.1:" + port1 + "/?a=b&c=&d=e").setBody("abc".getBytes()).execute(new AsyncCompletionHandlerBase() {
+            Future<Response> f = client.preparePost(String.format("http://%s:%d/?a=b&c=&d=e", TestUtils.getUnitTestIpAddress(), port1)).setBody("abc".getBytes()).execute(new AsyncCompletionHandlerBase() {
 
                 @Override
                 public State onStatusReceived(final HttpResponseStatus status) throws Exception {
-                    if (!status.getUri().toUrl().equals("http://127.0.0.1:" + port1 + "/?a=b&c=&d=e")) {
+                    if (!status.getUri().toUrl().equals(String.format("http://%s:%d/?a=b&c=&d=e", TestUtils.getUnitTestIpAddress(), port1))) {
                         throw new IOException("failed to parse the query properly");
                     }
                     return super.onStatusReceived(status);

--- a/client/src/test/java/org/asynchttpclient/QueryParametersTest.java
+++ b/client/src/test/java/org/asynchttpclient/QueryParametersTest.java
@@ -32,6 +32,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.slf4j.LoggerFactory;
@@ -71,7 +72,7 @@ public class QueryParametersTest extends AbstractBasicTest {
     @Test(groups = "standalone")
     public void testQueryParameters() throws IOException, ExecutionException, TimeoutException, InterruptedException {
         try (AsyncHttpClient client = asyncHttpClient()) {
-            Future<Response> f = client.prepareGet("http://127.0.0.1:" + port1).addQueryParam("a", "1").addQueryParam("b", "2").execute();
+            Future<Response> f = client.prepareGet(String.format("http://%s:%d", TestUtils.getUnitTestIpAddress(), port1)).addQueryParam("a", "1").addQueryParam("b", "2").execute();
             Response resp = f.get(3, TimeUnit.SECONDS);
             assertNotNull(resp);
             assertEquals(resp.getStatusCode(), HttpServletResponse.SC_OK);
@@ -98,7 +99,7 @@ public class QueryParametersTest extends AbstractBasicTest {
     public void urlWithColonTest() throws Exception {
         try (AsyncHttpClient c = asyncHttpClient()) {
             String query = "test:colon:";
-            Response response = c.prepareGet(String.format("http://127.0.0.1:%d/foo/test/colon?q=%s", port1, query)).setHeader("Content-Type", "text/html").execute().get(TIMEOUT, TimeUnit.SECONDS);
+            Response response = c.prepareGet(String.format("http://%s:%d/foo/test/colon?q=%s", TestUtils.getUnitTestIpAddress(), port1, query)).setHeader("Content-Type", "text/html").execute().get(TIMEOUT, TimeUnit.SECONDS);
 
             assertEquals(response.getHeader("q"), query);
         }

--- a/client/src/test/java/org/asynchttpclient/RC10KTest.java
+++ b/client/src/test/java/org/asynchttpclient/RC10KTest.java
@@ -31,6 +31,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -96,7 +97,7 @@ public class RC10KTest extends AbstractBasicTest {
             List<Future<Integer>> resps = new ArrayList<>(C10K);
             int i = 0;
             while (i < C10K) {
-                resps.add(ahc.prepareGet(String.format("http://127.0.0.1:%d/%d", ports[i % SRV_COUNT], i)).execute(new MyAsyncHandler(i++)));
+                resps.add(ahc.prepareGet(String.format("http://%s:%d/%d", TestUtils.getUnitTestIpAddress(), ports[i % SRV_COUNT], i)).execute(new MyAsyncHandler(i++)));
             }
             i = 0;
             for (Future<Integer> fResp : resps) {

--- a/client/src/test/java/org/asynchttpclient/Relative302Test.java
+++ b/client/src/test/java/org/asynchttpclient/Relative302Test.java
@@ -30,6 +30,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.asynchttpclient.test.TestUtils;
 import org.asynchttpclient.uri.Uri;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -100,7 +101,7 @@ public class Relative302Test extends AbstractBasicTest {
 
         // If the test hit a proxy, no ConnectException will be thrown and instead of 404 will be returned.
         try (AsyncHttpClient c = asyncHttpClient(config().setFollowRedirect(true))) {
-            Response response = c.prepareGet(getTargetUrl()).setHeader("X-redirect", String.format("http://127.0.0.1:%d/", port2)).execute().get();
+            Response response = c.prepareGet(getTargetUrl()).setHeader("X-redirect", String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), port2)).execute().get();
 
             assertNotNull(response);
             assertEquals(response.getStatusCode(), 404);

--- a/client/src/test/java/org/asynchttpclient/RetryRequestTest.java
+++ b/client/src/test/java/org/asynchttpclient/RetryRequestTest.java
@@ -22,6 +22,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.asynchttpclient.test.TestUtils;
 import org.asynchttpclient.util.HttpUtils;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -60,7 +61,7 @@ public class RetryRequestTest extends AbstractBasicTest {
     }
 
     protected String getTargetUrl() {
-        return String.format("http://127.0.0.1:%d/", port1);
+        return String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), port1);
     }
 
     @Override

--- a/client/src/test/java/org/asynchttpclient/ThreadNameTest.java
+++ b/client/src/test/java/org/asynchttpclient/ThreadNameTest.java
@@ -20,6 +20,7 @@ import java.util.Random;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.asynchttpclient.test.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -47,7 +48,7 @@ public class ThreadNameTest extends AbstractBasicTest {
     public void testThreadName() throws Exception {
         String threadPoolName = "ahc-" + (new Random().nextLong() & 0x7fffffffffffffffL);
         try (AsyncHttpClient client = asyncHttpClient(config().setThreadPoolName(threadPoolName))) {
-            Future<Response> f = client.prepareGet("http://127.0.0.1:" + port1 + "/").execute();
+            Future<Response> f = client.prepareGet(String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), port1)).execute();
             f.get(3, TimeUnit.SECONDS);
 
             // We cannot assert that all threads are created with specified name,

--- a/client/src/test/java/org/asynchttpclient/channel/MaxConnectionsInThreads.java
+++ b/client/src/test/java/org/asynchttpclient/channel/MaxConnectionsInThreads.java
@@ -37,6 +37,7 @@ import org.asynchttpclient.AsyncCompletionHandlerBase;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.AsyncHttpClientConfig;
 import org.asynchttpclient.Response;
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.slf4j.Logger;
@@ -135,12 +136,12 @@ public class MaxConnectionsInThreads extends AbstractBasicTest {
 
         server.start();
 
-        String endpoint = "http://127.0.0.1:" + port1 + "/timeout/";
+        String endpoint = String.format("http://%s:%d/timeout/", TestUtils.getUnitTestIpAddress(), port1);
         servletEndpointUri = new URI(endpoint);
     }
 
     public String getTargetUrl() {
-        String s = "http://127.0.0.1:" + port1 + "/timeout/";
+        String s = String.format("http://%s:%d/timeout/", TestUtils.getUnitTestIpAddress(), port1);
         try {
             servletEndpointUri = new URI(s);
         } catch (URISyntaxException e) {

--- a/client/src/test/java/org/asynchttpclient/channel/pool/ConnectionPoolTest.java
+++ b/client/src/test/java/org/asynchttpclient/channel/pool/ConnectionPoolTest.java
@@ -38,6 +38,7 @@ import org.asynchttpclient.ListenableFuture;
 import org.asynchttpclient.RequestBuilder;
 import org.asynchttpclient.Response;
 import org.asynchttpclient.test.EventCollectingHandler;
+import org.asynchttpclient.test.TestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
@@ -140,7 +141,7 @@ public class ConnectionPoolTest extends AbstractBasicTest {
             // twice
             Exception exception = null;
             try {
-                c.preparePost(String.format("http://127.0.0.1:%d/foo/test", port2)).setBody(body).execute().get(TIMEOUT, TimeUnit.SECONDS);
+                c.preparePost(String.format("http://%s:%d/foo/test", TestUtils.getUnitTestIpAddress(), port2)).setBody(body).execute().get(TIMEOUT, TimeUnit.SECONDS);
                 fail("Should throw exception. Too many connections issued.");
             } catch (Exception ex) {
                 ex.printStackTrace();
@@ -265,7 +266,7 @@ public class ConnectionPoolTest extends AbstractBasicTest {
 
     @Test(groups = "standalone")
     public void testPooledEventsFired() throws Exception {
-        RequestBuilder request = get("http://127.0.0.1:" + port1 + "/Test");
+        RequestBuilder request = get(String.format("http://%s:%d/Test", TestUtils.getUnitTestIpAddress(), port1));
 
         try (AsyncHttpClient client = asyncHttpClient()) {
             EventCollectingHandler firstHandler = new EventCollectingHandler();

--- a/client/src/test/java/org/asynchttpclient/filter/FilterTest.java
+++ b/client/src/test/java/org/asynchttpclient/filter/FilterTest.java
@@ -32,6 +32,7 @@ import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.Request;
 import org.asynchttpclient.RequestBuilder;
 import org.asynchttpclient.Response;
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.testng.annotations.Test;
 
@@ -60,7 +61,7 @@ public class FilterTest extends AbstractBasicTest {
     }
 
     public String getTargetUrl() {
-        return String.format("http://127.0.0.1:%d/foo/test", port1);
+        return String.format("http://%s:%d/foo/test", TestUtils.getUnitTestIpAddress(), port1);
     }
 
     @Test(groups = "standalone")

--- a/client/src/test/java/org/asynchttpclient/handler/BodyDeferringAsyncHandlerTest.java
+++ b/client/src/test/java/org/asynchttpclient/handler/BodyDeferringAsyncHandlerTest.java
@@ -35,6 +35,7 @@ import org.asynchttpclient.AsyncHttpClientConfig;
 import org.asynchttpclient.BoundRequestBuilder;
 import org.asynchttpclient.Response;
 import org.asynchttpclient.handler.BodyDeferringAsyncHandler.BodyDeferringInputStream;
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.testng.annotations.Test;
@@ -112,7 +113,7 @@ public class BodyDeferringAsyncHandlerTest extends AbstractBasicTest {
     @Test(groups = "standalone")
     public void deferredSimple() throws IOException, ExecutionException, TimeoutException, InterruptedException {
         try (AsyncHttpClient client = asyncHttpClient(getAsyncHttpClientConfig())) {
-            BoundRequestBuilder r = client.prepareGet("http://127.0.0.1:" + port1 + "/deferredSimple");
+            BoundRequestBuilder r = client.prepareGet(String.format("http://%s:%d/deferredSimple", TestUtils.getUnitTestIpAddress(), port1));
 
             CountingOutputStream cos = new CountingOutputStream();
             BodyDeferringAsyncHandler bdah = new BodyDeferringAsyncHandler(cos);
@@ -136,7 +137,7 @@ public class BodyDeferringAsyncHandlerTest extends AbstractBasicTest {
     @Test(groups = "standalone", enabled = false)
     public void deferredSimpleWithFailure() throws IOException, ExecutionException, TimeoutException, InterruptedException {
         try (AsyncHttpClient client = asyncHttpClient(getAsyncHttpClientConfig())) {
-            BoundRequestBuilder r = client.prepareGet("http://127.0.0.1:" + port1 + "/deferredSimpleWithFailure").addHeader("X-FAIL-TRANSFER",
+            BoundRequestBuilder r = client.prepareGet(String.format("http://%s:%d/deferredSimpleWithFailure", TestUtils.getUnitTestIpAddress(), port1)).addHeader("X-FAIL-TRANSFER",
                     Boolean.TRUE.toString());
 
             CountingOutputStream cos = new CountingOutputStream();
@@ -166,7 +167,7 @@ public class BodyDeferringAsyncHandlerTest extends AbstractBasicTest {
     @Test(groups = "standalone")
     public void deferredInputStreamTrick() throws IOException, ExecutionException, TimeoutException, InterruptedException {
         try (AsyncHttpClient client = asyncHttpClient(getAsyncHttpClientConfig())) {
-            BoundRequestBuilder r = client.prepareGet("http://127.0.0.1:" + port1 + "/deferredInputStreamTrick");
+            BoundRequestBuilder r = client.prepareGet(String.format("http://%s:%d/deferredInputStreamTrick", TestUtils.getUnitTestIpAddress(), port1));
 
             PipedOutputStream pos = new PipedOutputStream();
             PipedInputStream pis = new PipedInputStream(pos);
@@ -199,7 +200,7 @@ public class BodyDeferringAsyncHandlerTest extends AbstractBasicTest {
     @Test(groups = "standalone")
     public void deferredInputStreamTrickWithFailure() throws IOException, ExecutionException, TimeoutException, InterruptedException {
         try (AsyncHttpClient client = asyncHttpClient(getAsyncHttpClientConfig())) {
-            BoundRequestBuilder r = client.prepareGet("http://127.0.0.1:" + port1 + "/deferredInputStreamTrickWithFailure").addHeader("X-FAIL-TRANSFER",
+            BoundRequestBuilder r = client.prepareGet(String.format("http://%s:%d/deferredInputStreamTrickWithFailure", TestUtils.getUnitTestIpAddress(), port1)).addHeader("X-FAIL-TRANSFER",
                     Boolean.TRUE.toString());
             PipedOutputStream pos = new PipedOutputStream();
             PipedInputStream pis = new PipedInputStream(pos);
@@ -233,7 +234,7 @@ public class BodyDeferringAsyncHandlerTest extends AbstractBasicTest {
     public void testConnectionRefused() throws IOException, ExecutionException, TimeoutException, InterruptedException {
         int newPortWithoutAnyoneListening = findFreePort();
         try (AsyncHttpClient client = asyncHttpClient(getAsyncHttpClientConfig())) {
-            BoundRequestBuilder r = client.prepareGet("http://127.0.0.1:" + newPortWithoutAnyoneListening + "/testConnectionRefused");
+            BoundRequestBuilder r = client.prepareGet(String.format("http://%s:%d/testConnectionRefused", TestUtils.getUnitTestIpAddress(), newPortWithoutAnyoneListening));
 
             CountingOutputStream cos = new CountingOutputStream();
             BodyDeferringAsyncHandler bdah = new BodyDeferringAsyncHandler(cos);

--- a/client/src/test/java/org/asynchttpclient/netty/RetryNonBlockingIssue.java
+++ b/client/src/test/java/org/asynchttpclient/netty/RetryNonBlockingIssue.java
@@ -36,6 +36,7 @@ import org.asynchttpclient.AsyncHttpClientConfig;
 import org.asynchttpclient.ListenableFuture;
 import org.asynchttpclient.RequestBuilder;
 import org.asynchttpclient.Response;
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.testng.annotations.BeforeClass;
@@ -58,7 +59,7 @@ public class RetryNonBlockingIssue extends AbstractBasicTest {
     }
 
     protected String getTargetUrl() {
-        return String.format("http://127.0.0.1:%d/", port1);
+        return String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), port1);
     }
 
     private ListenableFuture<Response> testMethodRequest(AsyncHttpClient client, int requests, String action, String id) throws IOException {

--- a/client/src/test/java/org/asynchttpclient/proxy/HttpsProxyTest.java
+++ b/client/src/test/java/org/asynchttpclient/proxy/HttpsProxyTest.java
@@ -29,6 +29,7 @@ import org.asynchttpclient.AsyncHttpClientConfig;
 import org.asynchttpclient.RequestBuilder;
 import org.asynchttpclient.Response;
 import org.asynchttpclient.test.EchoHandler;
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.proxy.ConnectHandler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -73,7 +74,7 @@ public class HttpsProxyTest extends AbstractBasicTest {
     public void testRequestProxy() throws IOException, InterruptedException, ExecutionException, TimeoutException {
 
         try (AsyncHttpClient asyncHttpClient = asyncHttpClient(config().setFollowRedirect(true).setAcceptAnyCertificate(true))) {
-            RequestBuilder rb = get(getTargetUrl2()).setProxyServer(proxyServer("127.0.0.1", port1));
+            RequestBuilder rb = get(getTargetUrl2()).setProxyServer(proxyServer(TestUtils.getUnitTestIpAddress(), port1));
             Future<Response> responseFuture = asyncHttpClient.executeRequest(rb.build(), new AsyncCompletionHandlerBase() {
 
                 public void onThrowable(Throwable t) {
@@ -96,7 +97,7 @@ public class HttpsProxyTest extends AbstractBasicTest {
     public void testConfigProxy() throws IOException, InterruptedException, ExecutionException, TimeoutException {
         AsyncHttpClientConfig config = config()//
                 .setFollowRedirect(true)//
-                .setProxyServer(proxyServer("127.0.0.1", port1).build())//
+                .setProxyServer(proxyServer(TestUtils.getUnitTestIpAddress(), port1).build())//
                 .setAcceptAnyCertificate(true)//
                 .build();
         try (AsyncHttpClient asyncHttpClient = asyncHttpClient(config)) {

--- a/client/src/test/java/org/asynchttpclient/proxy/NTLMProxyTest.java
+++ b/client/src/test/java/org/asynchttpclient/proxy/NTLMProxyTest.java
@@ -30,6 +30,7 @@ import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.Realm;
 import org.asynchttpclient.Request;
 import org.asynchttpclient.Response;
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.testng.Assert;
@@ -106,6 +107,6 @@ public class NTLMProxyTest extends AbstractBasicTest {
                 .setNtlmDomain("Ursa-Minor")//
                 .setNtlmHost("LightCity")//
                 .build();
-        return proxyServer("127.0.0.1", port2).setRealm(realm).build();
+        return proxyServer(TestUtils.getUnitTestIpAddress(), port2).setRealm(realm).build();
     }
 }

--- a/client/src/test/java/org/asynchttpclient/request/body/ZeroCopyFileTest.java
+++ b/client/src/test/java/org/asynchttpclient/request/body/ZeroCopyFileTest.java
@@ -38,6 +38,7 @@ import org.asynchttpclient.HttpResponseBodyPart;
 import org.asynchttpclient.HttpResponseHeaders;
 import org.asynchttpclient.HttpResponseStatus;
 import org.asynchttpclient.Response;
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.testng.annotations.Test;
@@ -71,7 +72,7 @@ public class ZeroCopyFileTest extends AbstractBasicTest {
             final AtomicBoolean headerSent = new AtomicBoolean(false);
             final AtomicBoolean operationCompleted = new AtomicBoolean(false);
 
-            Response resp = client.preparePost("http://127.0.0.1:" + port1 + "/").setBody(SIMPLE_TEXT_FILE).execute(new AsyncCompletionHandler<Response>() {
+            Response resp = client.preparePost(String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), port1)).setBody(SIMPLE_TEXT_FILE).execute(new AsyncCompletionHandler<Response>() {
 
                 public State onHeadersWritten() {
                     headerSent.set(true);
@@ -99,7 +100,7 @@ public class ZeroCopyFileTest extends AbstractBasicTest {
     @Test(groups = "standalone")
     public void zeroCopyPutTest() throws IOException, ExecutionException, TimeoutException, InterruptedException, URISyntaxException {
         try (AsyncHttpClient client = asyncHttpClient()) {
-            Future<Response> f = client.preparePut("http://127.0.0.1:" + port1 + "/").setBody(SIMPLE_TEXT_FILE).execute();
+            Future<Response> f = client.preparePut(String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), port1)).setBody(SIMPLE_TEXT_FILE).execute();
             Response resp = f.get();
             assertNotNull(resp);
             assertEquals(resp.getStatusCode(), HttpServletResponse.SC_OK);
@@ -118,7 +119,7 @@ public class ZeroCopyFileTest extends AbstractBasicTest {
         tmp.deleteOnExit();
         try (AsyncHttpClient client = asyncHttpClient()) {
             try (FileOutputStream stream = new FileOutputStream(tmp)) {
-                Response resp = client.preparePost("http://127.0.0.1:" + port1 + "/").setBody(SIMPLE_TEXT_FILE).execute(new AsyncHandler<Response>() {
+                Response resp = client.preparePost(String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), port1)).setBody(SIMPLE_TEXT_FILE).execute(new AsyncHandler<Response>() {
                     public void onThrowable(Throwable t) {
                     }
 
@@ -151,7 +152,7 @@ public class ZeroCopyFileTest extends AbstractBasicTest {
         tmp.deleteOnExit();
         try (AsyncHttpClient client = asyncHttpClient()) {
             try (FileOutputStream stream = new FileOutputStream(tmp)) {
-                Response resp = client.preparePost("http://127.0.0.1:" + port1 + "/").setBody(SIMPLE_TEXT_FILE).execute(new AsyncHandler<Response>() {
+                Response resp = client.preparePost(String.format("http://%s:%d/", TestUtils.getUnitTestIpAddress(), port1)).setBody(SIMPLE_TEXT_FILE).execute(new AsyncHandler<Response>() {
                     public void onThrowable(Throwable t) {
                     }
 

--- a/client/src/test/java/org/asynchttpclient/test/TestUtils.java
+++ b/client/src/test/java/org/asynchttpclient/test/TestUtils.java
@@ -340,4 +340,9 @@ public class TestUtils {
             throw new FileNotFoundException(file);
         }
     }
+
+    public static String getUnitTestIpAddress() {
+        return "127.0.0.1";
+    }
+    
 }

--- a/client/src/test/java/org/asynchttpclient/test/TestUtilsTest.java
+++ b/client/src/test/java/org/asynchttpclient/test/TestUtilsTest.java
@@ -1,0 +1,34 @@
+package org.asynchttpclient.test;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class TestUtilsTest {
+
+    @Test(groups = "fast")
+    public void testLocalhostIpAddress() {
+        /*
+         * Test formatted strings equality
+         */
+        
+        final int port1 = 1122;
+        final String protocol = "ws";
+        final String query = "testing";
+        
+        assertEquals(String.format("http://127.0.0.1:%d/foo/test", port1), String.format("http://%s:%d/foo/test", 
+                TestUtils.getUnitTestIpAddress(), port1));
+        
+        assertEquals("http://127.0.0.1:" + port1, String.format("http://%s:%d", TestUtils.getUnitTestIpAddress(), port1));
+        
+        assertEquals(String.format("%s://127.0.0.1:%d/", protocol, port1), String.format("%s://%s:%d/", protocol,
+                TestUtils.getUnitTestIpAddress(), port1));
+        
+        assertEquals(String.format("http://127.0.0.1:%d/foo/test/colon?q=%s", port1, query), 
+                String.format("http://%s:%d/foo/test/colon?q=%s", TestUtils.getUnitTestIpAddress(), port1, query));
+        
+        assertEquals("http://127.0.0.1:" + port1 + "/timeout/", String.format("http://%s:%d/timeout/", TestUtils.getUnitTestIpAddress(), port1));        
+
+    }
+
+}

--- a/client/src/test/java/org/asynchttpclient/webdav/WebDavBasicTest.java
+++ b/client/src/test/java/org/asynchttpclient/webdav/WebDavBasicTest.java
@@ -32,6 +32,7 @@ import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.Request;
 import org.asynchttpclient.RequestBuilder;
 import org.asynchttpclient.Response;
+import org.asynchttpclient.test.TestUtils;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -50,9 +51,9 @@ public class WebDavBasicTest extends AbstractBasicTest {
         embedded.setCatalinaHome(path);
 
         Engine engine = embedded.createEngine();
-        engine.setDefaultHost("127.0.0.1");
+        engine.setDefaultHost(TestUtils.getUnitTestIpAddress());
 
-        Host host = embedded.createHost("127.0.0.1", path);
+        Host host = embedded.createHost(TestUtils.getUnitTestIpAddress(), path);
         engine.addChild(host);
 
         Context c = embedded.createContext("/", path);
@@ -68,7 +69,7 @@ public class WebDavBasicTest extends AbstractBasicTest {
         c.addChild(w);
         host.addChild(c);
 
-        Connector connector = embedded.createConnector("127.0.0.1", port1, Http11NioProtocol.class.getName());
+        Connector connector = embedded.createConnector(TestUtils.getUnitTestIpAddress(), port1, Http11NioProtocol.class.getName());
         connector.setContainer(host);
         embedded.addEngine(engine);
         embedded.addConnector(connector);
@@ -81,7 +82,7 @@ public class WebDavBasicTest extends AbstractBasicTest {
     }
 
     protected String getTargetUrl() {
-        return String.format("http://127.0.0.1:%s/folder1", port1);
+        return String.format("http://%s:%d/folder1", TestUtils.getUnitTestIpAddress(), port1);
     }
 
     @AfterMethod(alwaysRun = true)
@@ -127,11 +128,11 @@ public class WebDavBasicTest extends AbstractBasicTest {
             Response response = c.executeRequest(mkcolRequest).get();
             assertEquals(response.getStatusCode(), 201);
 
-            Request putRequest = put(String.format("http://127.0.0.1:%s/folder1/Test.txt", port1)).setBody("this is a test").build();
+            Request putRequest = put(String.format("http://%s:%d/folder1/Test.txt", TestUtils.getUnitTestIpAddress(), port1)).setBody("this is a test").build();
             response = c.executeRequest(putRequest).get();
             assertEquals(response.getStatusCode(), 201);
 
-            Request propFindRequest = new RequestBuilder("PROPFIND").setUrl(String.format("http://127.0.0.1:%s/folder1/Test.txt", port1)).build();
+            Request propFindRequest = new RequestBuilder("PROPFIND").setUrl(String.format("http://%s:%d/folder1/Test.txt", TestUtils.getUnitTestIpAddress(), port1)).build();
             response = c.executeRequest(propFindRequest).get();
 
             assertEquals(response.getStatusCode(), 207);

--- a/client/src/test/java/org/asynchttpclient/ws/AbstractBasicTest.java
+++ b/client/src/test/java/org/asynchttpclient/ws/AbstractBasicTest.java
@@ -15,6 +15,7 @@ package org.asynchttpclient.ws;
 import static org.asynchttpclient.test.TestUtils.findFreePort;
 import static org.asynchttpclient.test.TestUtils.newJettyHttpServer;
 
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.websocket.server.WebSocketHandler;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -38,7 +39,7 @@ public abstract class AbstractBasicTest extends org.asynchttpclient.AbstractBasi
     }
 
     protected String getTargetUrl() {
-        return String.format("ws://127.0.0.1:%d/", port1);
+        return String.format("ws://%s:%d/", TestUtils.getUnitTestIpAddress(), port1);
     }
 
     public abstract WebSocketHandler getWebSocketHandler();

--- a/client/src/test/java/org/asynchttpclient/ws/ProxyTunnellingTest.java
+++ b/client/src/test/java/org/asynchttpclient/ws/ProxyTunnellingTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.proxy.ProxyServer;
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.proxy.ConnectHandler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.websocket.server.WebSocketHandler;
@@ -80,10 +81,10 @@ public class ProxyTunnellingTest extends AbstractBasicTest {
 
         setUpServers(secure);
 
-        String targetUrl = String.format("%s://127.0.0.1:%d/", secure ? "wss" : "ws", port2);
+        String targetUrl = String.format("%s://%s:%d/", secure ? "wss" : "ws", TestUtils.getUnitTestIpAddress(), port2);
 
         // CONNECT happens over HTTP, not HTTPS
-        ProxyServer ps = proxyServer("127.0.0.1", port1).build();
+        ProxyServer ps = proxyServer(TestUtils.getUnitTestIpAddress(), port1).build();
         try (AsyncHttpClient asyncHttpClient = asyncHttpClient(config().setProxyServer(ps).setAcceptAnyCertificate(true))) {
             final CountDownLatch latch = new CountDownLatch(1);
             final AtomicReference<String> text = new AtomicReference<>("");

--- a/client/src/test/java/org/asynchttpclient/ws/RedirectTest.java
+++ b/client/src/test/java/org/asynchttpclient/ws/RedirectTest.java
@@ -26,6 +26,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
@@ -104,6 +105,6 @@ public class RedirectTest extends AbstractBasicTest {
     }
 
     private String getRedirectURL() {
-        return String.format("ws://127.0.0.1:%d/", port2);
+        return String.format("ws://%s:%d/", TestUtils.getUnitTestIpAddress(), port2);
     }
 }

--- a/extras/simple/src/test/java/org/asynchttpclient/extras/simple/HttpsProxyTest.java
+++ b/extras/simple/src/test/java/org/asynchttpclient/extras/simple/HttpsProxyTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeoutException;
 import org.asynchttpclient.AbstractBasicTest;
 import org.asynchttpclient.Response;
 import org.asynchttpclient.test.EchoHandler;
+import org.asynchttpclient.test.TestUtils;
 import org.eclipse.jetty.proxy.ConnectHandler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -52,7 +53,7 @@ public class HttpsProxyTest extends AbstractBasicTest {
     public void testSimpleAHCConfigProxy() throws IOException, InterruptedException, ExecutionException, TimeoutException {
 
         try (SimpleAsyncHttpClient client = new SimpleAsyncHttpClient.Builder()//
-                .setProxyHost("127.0.0.1")//
+                .setProxyHost(TestUtils.getUnitTestIpAddress())//
                 .setProxyPort(port1)//
                 .setFollowRedirect(true)//
                 .setUrl(getTargetUrl2())//


### PR DESCRIPTION
Resolving occurrences of Sonar rule squid:S1313 - “IP addresses should not be hardcoded"
You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1313
We have replaced a bunch of references to 127.0.0.1 in the test code with a utility method to lookup the 
IP address to use for unit tests. This is useful because it leaves you with one place to maintain this constant and makes the code slightly more readable.

Please let me know if you have any questions.

Faisal.