### PR TITLE
Code quality fix - Strings literals should be placed on the left side when checking for equality

### DIFF
--- a/client/src/main/java/org/asynchttpclient/Realm.java
+++ b/client/src/main/java/org/asynchttpclient/Realm.java
@@ -323,12 +323,12 @@ public class Realm {
 
             // prefer auth over auth-int
             for (String rawServerSupportedQop : serverSupportedQops) {
-                if (rawServerSupportedQop.equals("auth"))
+                if ("auth".equals(rawServerSupportedQop))
                     return rawServerSupportedQop;
             }
 
             for (String rawServerSupportedQop : serverSupportedQops) {
-                if (rawServerSupportedQop.equals("auth-int"))
+                if ("auth-int".equals(rawServerSupportedQop))
                     return rawServerSupportedQop;
             }
 
@@ -407,7 +407,7 @@ public class Realm {
             sb.append(principal).append(':').append(realmName).append(':').append(password);
             byte[] ha1 = md5FromRecycledStringBuilder(sb, md);
 
-            if (algorithm == null || algorithm.equals("MD5")) {
+            if (algorithm == null || "MD5".equals(algorithm)) {
                 return ha1;
             } else if ("MD5-sess".equals(algorithm)) {
                 appendBase16(sb, ha1);
@@ -424,7 +424,7 @@ public class Realm {
             if ("auth-int".equals(qop)) {
                 sb.append(':').append(EMPTY_ENTITY_MD5);
 
-            } else if (qop != null && !qop.equals("auth")) {
+            } else if (qop != null && !"auth".equals(qop)) {
                 throw new UnsupportedOperationException("Digest qop not supported: " + qop);
             }
 

--- a/client/src/main/java/org/asynchttpclient/netty/NettyResponseFuture.java
+++ b/client/src/main/java/org/asynchttpclient/netty/NettyResponseFuture.java
@@ -439,7 +439,7 @@ public final class NettyResponseFuture<V> extends AbstractListenableFuture<V> {
      * @return true if that {@link Future} cannot be recovered.
      */
     public boolean canBeReplayed() {
-        return !isDone() && canRetry() && !(Channels.isChannelValid(channel) && !getUri().getScheme().equalsIgnoreCase("https")) && !inAuth.get() && !inProxyAuth.get();
+        return !isDone() && canRetry() && !(Channels.isChannelValid(channel) && !"https".equalsIgnoreCase(getUri().getScheme())) && !inAuth.get() && !inProxyAuth.get();
     }
 
     public long getStart() {

--- a/client/src/main/java/org/asynchttpclient/netty/handler/HttpProtocol.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/HttpProtocol.java
@@ -89,7 +89,7 @@ public final class HttpProtocol extends Protocol {
             Realm realm,//
             NettyResponseFuture<?> future) {
 
-        if (authenticateHeader.equals("NTLM")) {
+        if ("NTLM".equals(authenticateHeader)) {
             // server replied bare NTLM => we didn't preemptively sent Type1Msg
             String challengeHeader = NtlmEngine.INSTANCE.generateType1Msg();
             // FIXME we might want to filter current NTLM and add (leave other
@@ -112,7 +112,7 @@ public final class HttpProtocol extends Protocol {
             HttpHeaders headers,//
             NettyResponseFuture<?> future) {
 
-        if (authenticateHeader.equals("NTLM")) {
+        if ("NTLM".equals(authenticateHeader)) {
             // server replied bare NTLM => we didn't preemptively sent Type1Msg
             String challengeHeader = NtlmEngine.INSTANCE.generateType1Msg();
             // FIXME we might want to filter current NTLM and add (leave other

--- a/client/src/main/java/org/asynchttpclient/oauth/OAuthSignatureCalculator.java
+++ b/client/src/main/java/org/asynchttpclient/oauth/OAuthSignatureCalculator.java
@@ -99,10 +99,10 @@ public class OAuthSignatureCalculator implements SignatureCalculator {
         sb.append(scheme).append("://").append(uri.getHost());
         
         int port = uri.getPort();
-        if (scheme.equals("http")) {
+        if ("http".equals(scheme)) {
             if (port == 80)
                 port = -1;
-        } else if (scheme.equals("https")) {
+        } else if ("https".equals(scheme)) {
             if (port == 443)
                 port = -1;
         }

--- a/client/src/test/java/org/asynchttpclient/test/EchoHandler.java
+++ b/client/src/test/java/org/asynchttpclient/test/EchoHandler.java
@@ -26,7 +26,7 @@ public class EchoHandler extends AbstractHandler {
             httpResponse.setContentType(TestUtils.TEXT_HTML_CONTENT_TYPE_WITH_UTF_8_CHARSET);
         }
 
-        if (request.getMethod().equalsIgnoreCase("OPTIONS")) {
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
             httpResponse.addHeader("Allow", "GET,HEAD,POST,OPTIONS,TRACE");
         }
 

--- a/client/src/test/java/org/asynchttpclient/ws/EchoSocket.java
+++ b/client/src/test/java/org/asynchttpclient/ws/EchoSocket.java
@@ -38,7 +38,7 @@ public class EchoSocket extends WebSocketAdapter {
             return;
         }
         try {
-            if (message.equals("CLOSE"))
+            if ("CLOSE".equals(message))
                 getSession().close();
             else
                 getRemote().sendString(message);

--- a/extras/simple/src/main/java/org/asynchttpclient/extras/simple/SimpleAsyncHttpClient.java
+++ b/extras/simple/src/main/java/org/asynchttpclient/extras/simple/SimpleAsyncHttpClient.java
@@ -298,7 +298,7 @@ public class SimpleAsyncHttpClient implements Closeable {
         ProgressAsyncHandler<Response> handler = new BodyConsumerAsyncHandler(bodyConsumer, throwableHandler, errorDocumentBehaviour,
                 request.getUri(), listener);
 
-        if (resumeEnabled && request.getMethod().equals("GET") && bodyConsumer != null && bodyConsumer instanceof ResumableBodyConsumer) {
+        if (resumeEnabled && "GET".equals(request.getMethod()) && bodyConsumer != null && bodyConsumer instanceof ResumableBodyConsumer) {
             ResumableBodyConsumer fileBodyConsumer = (ResumableBodyConsumer) bodyConsumer;
             long length = fileBodyConsumer.getTransferredBytes();
             fileBodyConsumer.resume();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1132 - “Strings literals should be placed on the left side”. 
You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1132

Please let me know if you have any questions.

Faisal.