### PR TITLE
Add setter for 'usePooledMemory' parameter at DefaultAsyncHttpClientConfig.Builder

### DIFF
--- a/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClientConfig.java
+++ b/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClientConfig.java
@@ -941,6 +941,11 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
             return this;
         }
 
+        public Builder setUsePooledMemory(boolean usePooledMemory) {
+            this.usePooledMemory = usePooledMemory;
+            return this;
+        }
+
         public Builder setNettyTimer(Timer nettyTimer) {
             this.nettyTimer = nettyTimer;
             return this;


### PR DESCRIPTION
I've added setter for 'usePooledMemory' parameter at DefaultAsyncHttpClientConfig.Builder