### PR TITLE
Property loading fix for OSGi

### DIFF
--- a/client/src/main/java/org/asynchttpclient/config/AsyncHttpClientConfigHelper.java
+++ b/client/src/main/java/org/asynchttpclient/config/AsyncHttpClientConfigHelper.java
@@ -47,6 +47,13 @@ public class AsyncHttpClientConfigHelper {
             try (InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(file)) {
                 if (is != null) {
                     props.load(is);
+                } else {
+                   //Try loading from this class classloader instead, e.g. for OSGi environments.
+                    try(InputStream is2 = this.getClass().getClassLoader().getResourceAsStream(file)) {
+                        if (is2 != null) {
+                            props.load(is2);
+                        }
+                    }
                 }
             } catch (IOException e) {
                 throw new IllegalArgumentException("Can't parse file", e);


### PR DESCRIPTION
In an OSGi environment, the ContextClassLoader is not by default set to a classloader that will read the property files from the bundle. Instead, the classloader of the bundle should be used.

It is possible to work around this issue by setting the ContextClassLoader explicitly, but that's confusing (unless someone really understand the classloader model in OSGi). This PR is an easy workaround for the issue.