### PR TITLE
fixed NPE that occured when setting query params before url was set

### DIFF
--- a/client/src/main/java/org/asynchttpclient/RequestBuilderBase.java
+++ b/client/src/main/java/org/asynchttpclient/RequestBuilderBase.java
@@ -252,7 +252,8 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
 
     public void resetQuery() {
         queryParams = null;
-        this.uri = this.uri.withNewQuery(null);
+        if (this.uri != null)
+            this.uri = this.uri.withNewQuery(null);
     }
 
     public void resetFormParams() {
@@ -344,7 +345,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
 
     public T setQueryParams(List<Param> params) {
         // reset existing query
-        if (isNonEmpty(this.uri.getQuery()))
+        if (this.uri != null && isNonEmpty(this.uri.getQuery()))
             this.uri = this.uri.withNewQuery(null);
         queryParams = params;
         return asDerivedType();

--- a/client/src/test/java/org/asynchttpclient/RequestBuilderTest.java
+++ b/client/src/test/java/org/asynchttpclient/RequestBuilderTest.java
@@ -16,17 +16,14 @@
 package org.asynchttpclient;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.singletonList;
 import static org.asynchttpclient.Dsl.get;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 
 import org.asynchttpclient.cookie.Cookie;
@@ -150,5 +147,14 @@ public class RequestBuilderTest {
         Cookie cookie3 = new Cookie("name", "value", false, "google.com", "/", 1000, true, true);
         requestBuilder.addOrReplaceCookie(cookie3);
         assertEquals(requestBuilder.cookies.size(), 2, "cookie size must be 2 after adding 1 more cookie i.e. cookie3");
+    }
+
+    @Test
+    public void testSettingQueryParamsBeforeUrlShouldNotProduceNPE() {
+        RequestBuilder requestBuilder = new RequestBuilder();
+        requestBuilder.setQueryParams(singletonList(new Param("key", "value")));
+        requestBuilder.setUrl("http://localhost");
+        Request request = requestBuilder.build();
+        assertEquals(request.getUrl(), "http://localhost?key=value");
     }
 }


### PR DESCRIPTION
Hello!
I have some cases with RequestBuilder when query parameters are set before setting uri. Current builder implementation produces NullPointerException in those scenarios. I've made little fix.