### PR TITLE
Introduce AsyncHttpSingle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,12 @@ after_success: |
 
 sudo: false
 
+# https://github.com/travis-ci/travis-ci/issues/3259
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+
 # Cache settings
 cache:
   directories:

--- a/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/UnsubscribedException.java
+++ b/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/UnsubscribedException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.extras.rxjava;
+
+/**
+ * Indicates that an {@code Observer} unsubscribed during the processing of a
+ * HTTP request.
+ */
+public class UnsubscribedException extends RuntimeException {
+
+    public UnsubscribedException() {
+        super();
+    }
+
+    public UnsubscribedException(final Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/single/AbstractProgressSingleSubscriberBridge.java
+++ b/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/single/AbstractProgressSingleSubscriberBridge.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.extras.rxjava.single;
+
+import org.asynchttpclient.handler.ProgressAsyncHandler;
+
+import rx.SingleSubscriber;
+
+abstract class AbstractProgressSingleSubscriberBridge<T> extends AbstractSingleSubscriberBridge<T> implements ProgressAsyncHandler<Void> {
+
+    protected AbstractProgressSingleSubscriberBridge(SingleSubscriber<T> subscriber) {
+        super(subscriber);
+    }
+
+    @Override
+    public State onHeadersWritten() {
+        return subscriber.isUnsubscribed() ? abort() : delegate().onHeadersWritten();
+    }
+
+    @Override
+    public State onContentWritten() {
+        return subscriber.isUnsubscribed() ? abort() : delegate().onContentWritten();
+    }
+
+    @Override
+    public State onContentWriteProgress(long amount, long current, long total) {
+        return subscriber.isUnsubscribed() ? abort() : delegate().onContentWriteProgress(amount, current, total);
+    }
+
+    @Override
+    protected abstract ProgressAsyncHandler<? extends T> delegate();
+
+}

--- a/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/single/AbstractSingleSubscriberBridge.java
+++ b/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/single/AbstractSingleSubscriberBridge.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.extras.rxjava.single;
+
+import static java.util.Objects.requireNonNull;
+
+import org.asynchttpclient.AsyncHandler;
+import org.asynchttpclient.HttpResponseBodyPart;
+import org.asynchttpclient.HttpResponseHeaders;
+import org.asynchttpclient.HttpResponseStatus;
+import org.asynchttpclient.extras.rxjava.UnsubscribedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import rx.SingleSubscriber;
+import rx.exceptions.CompositeException;
+import rx.exceptions.Exceptions;
+
+abstract class AbstractSingleSubscriberBridge<T> implements AsyncHandler<Void> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractSingleSubscriberBridge.class);
+
+    protected final SingleSubscriber<T> subscriber;
+
+    private final AtomicBoolean delegateTerminated = new AtomicBoolean();
+
+    protected AbstractSingleSubscriberBridge(SingleSubscriber<T> subscriber) {
+        this.subscriber = requireNonNull(subscriber);
+    }
+
+    @Override
+    public State onBodyPartReceived(HttpResponseBodyPart content) throws Exception {
+        return subscriber.isUnsubscribed() ? abort() : delegate().onBodyPartReceived(content);
+    }
+
+    @Override
+    public State onStatusReceived(HttpResponseStatus status) throws Exception {
+        return subscriber.isUnsubscribed() ? abort() : delegate().onStatusReceived(status);
+    }
+
+    @Override
+    public State onHeadersReceived(HttpResponseHeaders headers) throws Exception {
+        return subscriber.isUnsubscribed() ? abort() : delegate().onHeadersReceived(headers);
+    }
+
+    @Override
+    public Void onCompleted() {
+        if (delegateTerminated.getAndSet(true)) {
+            return null;
+        }
+
+        final T result;
+        try {
+            result = delegate().onCompleted();
+        } catch (final Throwable t) {
+            emitOnError(t);
+            return null;
+        }
+
+        if (!subscriber.isUnsubscribed()) {
+            subscriber.onSuccess(result);
+        }
+
+        return null;
+    }
+
+    @Override
+    public void onThrowable(Throwable t) {
+        if (delegateTerminated.getAndSet(true)) {
+            return;
+        }
+
+        Throwable error = t;
+        try {
+            delegate().onThrowable(t);
+        } catch (final Throwable x) {
+            error = new CompositeException(Arrays.asList(t, x));
+        }
+
+        emitOnError(error);
+    }
+
+    protected AsyncHandler.State abort() {
+        if (!delegateTerminated.getAndSet(true)) {
+            // send a terminal event to the delegate
+            // e.g. to trigger cleanup logic
+            delegate().onThrowable(new UnsubscribedException());
+        }
+
+        return State.ABORT;
+    }
+
+    protected abstract AsyncHandler<? extends T> delegate();
+
+    private void emitOnError(Throwable error) {
+        Exceptions.throwIfFatal(error);
+        if (!subscriber.isUnsubscribed()) {
+            subscriber.onError(error);
+        } else {
+            LOGGER.debug("Not propagating onError after unsubscription: {}", error.getMessage(), error);
+        }
+    }
+}

--- a/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/single/AsyncHttpSingle.java
+++ b/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/single/AsyncHttpSingle.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.extras.rxjava.single;
+
+import static java.util.Objects.requireNonNull;
+
+import org.asynchttpclient.AsyncCompletionHandlerBase;
+import org.asynchttpclient.AsyncHandler;
+import org.asynchttpclient.BoundRequestBuilder;
+import org.asynchttpclient.Response;
+import org.asynchttpclient.handler.ProgressAsyncHandler;
+
+import rx.Single;
+import rx.SingleSubscriber;
+import rx.functions.Action1;
+import rx.functions.Func0;
+
+/**
+ * Wraps HTTP requests into RxJava {@code Single} instances.
+ *
+ * @see <a href="https://github.com/ReactiveX/RxJava">https://github.com/
+ *      ReactiveX/RxJava</a>
+ */
+public final class AsyncHttpSingle {
+
+    /**
+     * Emits the responses to HTTP requests obtained from {@code builder}.
+     *
+     * @param builder used to build the HTTP request that is to be executed
+     * @return a {@code Single} that executes new requests on subscription
+     *         obtained from {@code builder} on subscription and that emits the
+     *         response
+     *
+     * @throws NullPointerException if {@code builder} is {@code null}
+     */
+    public static Single<Response> create(BoundRequestBuilder builder) {
+        requireNonNull(builder);
+        return create(builder::execute, AsyncCompletionHandlerBase::new);
+    }
+
+    /**
+     * Emits the responses to HTTP requests obtained by calling
+     * {@code requestTemplate}.
+     *
+     * @param requestTemplate called to start the HTTP request with an
+     *            {@code AysncHandler} that builds the HTTP response and
+     *            propagates results to the returned {@code Single}
+     *
+     * @return a {@code Single} that executes new requests on subscription by
+     *         calling {@code requestTemplate} and that emits the response
+     *
+     * @throws NullPointerException if {@code requestTemplate} is {@code null}
+     */
+    public static Single<Response> create(Action1<? super AsyncHandler<?>> requestTemplate) {
+        return create(requestTemplate, AsyncCompletionHandlerBase::new);
+    }
+
+    /**
+     * Emits the results of {@code AsyncHandlers} obtained from
+     * {@code handlerSupplier} for HTTP requests obtained from {@code builder}.
+     *
+     * @param builder used to build the HTTP request that is to be executed
+     * @param handlerSupplier supplies the desired {@code AsyncHandler}
+     *            instances that are used to produce results
+     *
+     * @return a {@code Single} that executes new requests on subscription
+     *         obtained from {@code builder} and that emits the result of the
+     *         {@code AsyncHandler} obtained from {@code handlerSupplier}
+     *
+     * @throws NullPointerException if at least one of the parameters is
+     *             {@code null}
+     */
+    public static <T> Single<T> create(BoundRequestBuilder builder, Func0<? extends AsyncHandler<? extends T>> handlerSupplier) {
+        requireNonNull(builder);
+        return create(builder::execute, handlerSupplier);
+    }
+
+    /**
+     * Emits the results of {@code AsyncHandlers} obtained from
+     * {@code handlerSupplier} for HTTP requests obtained obtained by calling
+     * {@code requestTemplate}.
+     *
+     * @param requestTemplate called to start the HTTP request with an
+     *            {@code AysncHandler} that builds the HTTP response and
+     *            propagates results to the returned {@code Single}
+     * @param handlerSupplier supplies the desired {@code AsyncHandler}
+     *            instances that are used to produce results
+     *
+     * @return a {@code Single} that executes new requests on subscription by
+     *         calling {@code requestTemplate} and that emits the results
+     *         produced by the {@code AsyncHandlers} supplied by
+     *         {@code handlerSupplier}
+     *
+     * @throws NullPointerException if at least one of the parameters is
+     *             {@code null}
+     */
+    public static <T> Single<T> create(Action1<? super AsyncHandler<?>> requestTemplate,
+            Func0<? extends AsyncHandler<? extends T>> handlerSupplier) {
+
+        requireNonNull(requestTemplate);
+        requireNonNull(handlerSupplier);
+
+        return Single.create(subscriber -> requestTemplate.call(createBridge(subscriber, handlerSupplier.call())));
+    }
+
+    static <T> AsyncHandler<?> createBridge(SingleSubscriber<? super T> subscriber, AsyncHandler<? extends T> handler) {
+
+        if (handler instanceof ProgressAsyncHandler) {
+            return new ProgressAsyncSingleSubscriberBridge<>(subscriber, (ProgressAsyncHandler<? extends T>) handler);
+        }
+
+        return new AsyncSingleSubscriberBridge<>(subscriber, handler);
+    }
+
+    private AsyncHttpSingle() {
+        throw new AssertionError("No instances for you!");
+    }
+}

--- a/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/single/AsyncSingleSubscriberBridge.java
+++ b/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/single/AsyncSingleSubscriberBridge.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.extras.rxjava.single;
+
+import static java.util.Objects.requireNonNull;
+
+import org.asynchttpclient.AsyncHandler;
+
+import rx.SingleSubscriber;
+
+final class AsyncSingleSubscriberBridge<T> extends AbstractSingleSubscriberBridge<T> {
+
+    private final AsyncHandler<? extends T> delegate;
+
+    public AsyncSingleSubscriberBridge(SingleSubscriber<T> subscriber, AsyncHandler<? extends T> delegate) {
+        super(subscriber);
+        this.delegate = requireNonNull(delegate);
+    }
+
+    @Override
+    protected AsyncHandler<? extends T> delegate() {
+        return delegate;
+    }
+
+}

--- a/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/single/ProgressAsyncSingleSubscriberBridge.java
+++ b/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/single/ProgressAsyncSingleSubscriberBridge.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2015 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.extras.rxjava.single;
+
+import static java.util.Objects.requireNonNull;
+
+import org.asynchttpclient.handler.ProgressAsyncHandler;
+
+import rx.SingleSubscriber;
+
+final class ProgressAsyncSingleSubscriberBridge<T> extends AbstractProgressSingleSubscriberBridge<T> {
+
+    private final ProgressAsyncHandler<? extends T> delegate;
+
+    public ProgressAsyncSingleSubscriberBridge(SingleSubscriber<T> subscriber, ProgressAsyncHandler<? extends T> delegate) {
+        super(subscriber);
+        this.delegate = requireNonNull(delegate);
+    }
+
+    @Override
+    protected ProgressAsyncHandler<? extends T> delegate() {
+        return delegate;
+    }
+
+}


### PR DESCRIPTION
Since `AsyncHandlers` only produce a single value, it seems appropriate to use RxJava's `Single<T>` instead of `Observable<T>`. This PR introduces new factory methods for `Single` comparable to those offered by `AsyncHttpObservable`.

In addition to that, the `Single` instances created by `AsyncHttpSingle` honor the subscription state, so if a subscriber unsubscribed from the `Single` during request execution, this will be forwarded to AHC as `State.ABORT` in the next call to one of the `onXXX` methods. Besides `AsyncCompletionHandlerBase`, arbitrary `AsyncHandlers` can be used for request processing, too.
