### PR TITLE
Prevent Netty connection pool from killing active connections

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
@@ -306,9 +306,13 @@ public class ChannelManager {
             Channels.setDiscard(channel);
             if (asyncHandler instanceof AsyncHandlerExtensions)
                 AsyncHandlerExtensions.class.cast(asyncHandler).onConnectionOffer(channel);
-            channelPool.offer(channel, partitionKey);
-            if (maxConnectionsPerHostEnabled)
-                channelId2PartitionKey.putIfAbsent(channel, partitionKey);
+            if (channelPool.offer(channel, partitionKey)) {
+                if (maxConnectionsPerHostEnabled)
+                    channelId2PartitionKey.putIfAbsent(channel, partitionKey);
+            } else {
+                // rejected by pool
+                closeChannel(channel);
+            }
         } else {
             // not offered
             closeChannel(channel);

--- a/client/src/test/java/org/asynchttpclient/netty/TimeToLiveIssue.java
+++ b/client/src/test/java/org/asynchttpclient/netty/TimeToLiveIssue.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2010-2012 Sonatype, Inc. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.netty;
+
+import org.asynchttpclient.*;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertEquals;
+
+public class TimeToLiveIssue extends AbstractBasicTest
+{
+    @Test(groups = "standalone", enabled = false, description = "https://github.com/AsyncHttpClient/async-http-client/issues/1113")
+    public void testTTLBug() throws Throwable
+    {
+        // The purpose of this test is to reproduce two issues:
+        // 1) Connections that are rejected by the pool are not closed and eventually use all available sockets.
+        // 2) It is possible for a connection to be closed while active by the timer task that checks for expired connections.
+
+        DefaultAsyncHttpClientConfig.Builder config = new DefaultAsyncHttpClientConfig.Builder();
+        config.setKeepAlive(true);
+        config.setConnectionTtl(1);
+        config.setPooledConnectionIdleTimeout(1);
+
+        AsyncHttpClient client = new DefaultAsyncHttpClient(config.build());
+
+        for (int i = 0; i < 200000; ++i) {
+            Request request = new RequestBuilder().setUrl(String.format("http://localhost:%d/", port1)).build();
+
+            Future<Response> future = client.executeRequest(request);
+            future.get(5, TimeUnit.SECONDS);
+
+            // This is to give a chance to the timer task that removes expired connection
+            // from sometimes winning over poll for the ownership of a connection.
+            if (System.currentTimeMillis() % 100 == 0) {
+                Thread.sleep(5);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This fixes the issue https://github.com/AsyncHttpClient/async-http-client/issues/1113 I reported previously by ensuring that a channel can't be both allocated to a caller and expired by the timer task. It uses a simple atomic boolean to grant "ownership" of the channel to one or another.

While testing I also found another issue: channels that are rejected by the pool are not closed properly by `ChannelManager`. This is particularly impactful on the test I wrote to reproduce the initial issue, as it quickly leads to all available sockets to be exhausted.

And finally, the code that does check for TTL is broken in 2.0 because the creation time for a channel is never put into the map due to the wrong map being used when checking if the partition exists. I'm pretty sure the change I made is correct although I haven't researched this part yet (my initial fix was made on top of 1.9.33 which doesn't have this issue).

I added a test that can be used to reproduce the initial problem (`TimeToLiveIssue`) but now works OK once the fix is made.
