### PR TITLE
HTTPS requests over HTTP CONNECT proxies should send relative URI

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestFactory.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestFactory.java
@@ -212,7 +212,7 @@ public final class NettyRequestFactory {
             // proxy tunnelling, connect need host and explicit port
             return getAuthority(uri);
 
-        else if (proxyServer != null)
+        else if (proxyServer != null && !uri.isSecured())
             // proxy over HTTP, need full url
             return uri.toUrl();
 


### PR DESCRIPTION
If we're sending a HTTPS request and using a proxy, we must be sending over a CONNECT tunnel. In that case, we only need to send the relative URI, not the full URI.

With this change, if I have a proxy configured and want to GET

https://some-url.com/the-path

the server behind some-url.com sees: 

```
GET /the-path
```

Prior to this change the server will see: 

```
GET https://some-url.com/the-path
```

The new behavior matches other clients (e.g. curl).