### PR TITLE
getPort should work with uppercase scheme

### DIFF
--- a/src/main/java/com/ning/http/util/AsyncHttpProviderUtils.java
+++ b/src/main/java/com/ning/http/util/AsyncHttpProviderUtils.java
@@ -174,7 +174,7 @@ public class AsyncHttpProviderUtils {
     public final static int getPort(URI uri) {
         int port = uri.getPort();
         if (port == -1)
-            port = uri.getScheme().equals("http") || uri.getScheme().equals("ws") ? 80 : 443;
+            port = uri.getScheme().equalsIgnoreCase("http") || uri.getScheme().equalsIgnoreCase("ws") ? 80 : 443;
         return port;
     }
 

--- a/src/test/java/com/ning/http/util/AsyncHttpProviderUtilsTest.java
+++ b/src/test/java/com/ning/http/util/AsyncHttpProviderUtilsTest.java
@@ -42,4 +42,12 @@ public class AsyncHttpProviderUtilsTest {
         URI uri = AsyncHttpProviderUtils.getRedirectUri(URI.create("http://www.ebay.de"), url);
         Assert.assertEquals("http://www.ebay.de/sch/sis.html;jsessionid=92D73F80262E3EBED7E115ED01035DDA?_nkw=FSC%20Lifebook%20E8310%20Core2Duo%20T8100%202%201GHz%204GB%20DVD%20RW&_itemId=150731406505", uri.toString());
     }
+
+    @Test(groups = "fast")
+    public void getPortShouldHandleAnyCaseScheme() {
+        Assert.assertEquals(AsyncHttpProviderUtils.getPort(URI.create("HTTP://WWW.URI.COM")), 80);
+        Assert.assertEquals(AsyncHttpProviderUtils.getPort(URI.create("http://www.uri.com")), 80);
+        Assert.assertEquals(AsyncHttpProviderUtils.getPort(URI.create("HTTPS://WWW.URI.COM")), 443);
+        Assert.assertEquals(AsyncHttpProviderUtils.getPort(URI.create("https://www.uri.com")), 443);
+    }
 }


### PR DESCRIPTION
Fixes AsyncHttpClient/async-http-client#1111

It appears that the 1.8.x branch:
* Only builds under JDK7
* Has a bunch of flakey tests (like *RemoteSiteTest)