### PR TITLE
Closing non keep-alive connections mustn't throw exceptions

### DIFF
--- a/src/main/java/com/ning/http/client/providers/grizzly/AhcEventFilter.java
+++ b/src/main/java/com/ning/http/client/providers/grizzly/AhcEventFilter.java
@@ -450,11 +450,7 @@ final class AhcEventFilter extends HttpClientFilter {
                 if (!context.isReuseConnection()) {
                     final Connection c = (Connection) httpContext.getCloseable();
                     if (!httpContext.getRequest().getProcessingState().isStayAlive()) {
-                        if (notKeepAliveReason == null) {
-                            notKeepAliveReason
-                                    = new IOException("HTTP keep-alive was disabled for this connection");
-                        }
-                        c.closeWithReason(notKeepAliveReason);
+                        c.closeSilently();
                     } else {
                         final ConnectionManager cm = context.provider.getConnectionManager();
                         cm.returnConnection(c);

--- a/src/main/java/com/ning/http/client/providers/grizzly/HttpTransactionContext.java
+++ b/src/main/java/com/ning/http/client/providers/grizzly/HttpTransactionContext.java
@@ -102,7 +102,7 @@ public final class HttpTransactionContext {
                         new GracefulCloseEvent(HttpTransactionContext.this), null);
             } else if (CloseType.REMOTELY.equals(type)) {
                 abort(AsyncHttpProviderUtils.REMOTELY_CLOSED_EXCEPTION);
-            } else {
+            } else if (!CloseType.LOCALLY.equals(type)) {
                 try {
                     closeable.assertOpen();
                 } catch (IOException ioe) {


### PR DESCRIPTION
In *AhcEventFilter* line 454, a close reason for the connection is being set that will later result in an exception (TCPNIOConnection#assertOpen), but not wanting a keep-alive connection shouldn't be a reason to throw an exception.

![screen shot 2016-04-06 at 2 17 00 pm](https://cloud.githubusercontent.com/assets/8010105/14325999/5f9317ec-fc02-11e5-9115-99dc6b0dcdb6.png)

This issue was already reported/discussed in https://github.com/AsyncHttpClient/async-http-client/pull/863 and https://groups.google.com/forum/#!topic/asynchttpclient/ct-6ztpTGiw

This change avoids the exception being thrown for this case.