### PR TITLE
Make HttpTransactionContext#getAsyncHandler public

### DIFF
--- a/src/main/java/com/ning/http/client/providers/grizzly/HttpTransactionContext.java
+++ b/src/main/java/com/ning/http/client/providers/grizzly/HttpTransactionContext.java
@@ -183,7 +183,7 @@ public final class HttpTransactionContext {
         return connection;
     }
     
-    AsyncHandler getAsyncHandler() {
+    public AsyncHandler getAsyncHandler() {
         return future.getAsyncHandler();
     }
     


### PR DESCRIPTION
In our application, we need to access the work manager, since we are using a custom implementation of *org.glassfish.grizzly.strategies.AbstractIOStrategy* to get the Executor we need.

Making this method public allows us to properly implement that.