### PR TITLE
Fix. retry is incremented by twice

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/NettyResponseFuture.java
+++ b/client/src/main/java/org/asynchttpclient/netty/NettyResponseFuture.java
@@ -425,7 +425,7 @@ public final class NettyResponseFuture<V> extends AbstractListenableFuture<V> {
         return reuseChannel;
     }
 
-    public boolean canRetry() {
+    public boolean incRetryAndCheck() {
         return maxRetry > 0 && CURRENT_RETRY_UPDATER.incrementAndGet(this) <= maxRetry;
     }
 
@@ -444,7 +444,7 @@ public final class NettyResponseFuture<V> extends AbstractListenableFuture<V> {
      * @return true if that {@link Future} cannot be recovered.
      */
     public boolean canBeReplayed() {
-        return !isDone() && canRetry() && !(Channels.isChannelValid(channel) && !getUri().getScheme().equalsIgnoreCase("https")) && !inAuth.get() && !inProxyAuth.get();
+        return !isDone() && !(Channels.isChannelValid(channel) && !getUri().getScheme().equalsIgnoreCase("https")) && !inAuth.get() && !inProxyAuth.get();
     }
 
     public long getStart() {

--- a/client/src/main/java/org/asynchttpclient/netty/channel/NettyConnectListener.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/NettyConnectListener.java
@@ -120,7 +120,7 @@ public final class NettyConnectListener<T> extends SimpleChannelFutureListener {
         //beware, channel can be null
         abortChannelPreemption();
 
-        boolean canRetry = future.canRetry();
+        boolean canRetry = future.incRetryAndCheck();
         LOGGER.debug("Trying to recover from failing to connect channel {} with a retry value of {} ", channel, canRetry);
         if (canRetry//
                 && cause != null // FIXME when can we have a null cause?

--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
@@ -396,7 +396,7 @@ public final class NettyRequestSender {
     public void handleUnexpectedClosedChannel(Channel channel, NettyResponseFuture<?> future) {
         if (future.isDone()) {
             channelManager.closeChannel(channel);
-        } else if (retry(future)) {
+        } else if (future.incRetryAndCheck() && retry(future)) {
             future.pendingException = null;
         } else {
             abort(channel, future, future.pendingException != null ? future.pendingException : RemotelyClosedException.INSTANCE);
@@ -447,7 +447,7 @@ public final class NettyRequestSender {
             }
         }
 
-        if (fc.replayRequest() && future.canBeReplayed()) {
+        if (fc.replayRequest() && future.canBeReplayed() && future.incRetryAndCheck()) {
             replayRequest(future, fc, channel);
             replayed = true;
         }


### PR DESCRIPTION
There is a code defect in counting retry.

There are two places which can increment the counter.
_NettyResponseFuture.java_
```java
    public boolean canRetry() {
        return maxRetry > 0 && CURRENT_RETRY_UPDATER.incrementAndGet(this) <= maxRetry;
    }
    public boolean canBeReplayed() {
        return !isDone() && canRetry() && !(Channels.isChannelValid(channel) && !getUri().getScheme().equalsIgnoreCase("https")) && !inAuth.get() && !inProxyAuth.get();
    }
```

_NettyConnectListener.java_
```java
        boolean canRetry = future.canRetry(); //Add retry counter here
        LOGGER.debug("Trying to recover from failing to connect channel {} with a retry value of {} ", channel, canRetry);
        if (canRetry//
                && cause != null 
                && (future.getChannelState() != ChannelState.NEW || StackTraceInspector.recoverOnNettyDisconnectException(cause))) {

            if (requestSender.retry(future)) { //Add retry counter here either, since canBeReplayed will be called
                return;
            }
        }
```
The retry counter is added in `future.canRetry()` and `requestSender.retry(future)`
This PR fixed the problem and rename the method from `canRetry` to `incRetryAndCheck` for better naming convention
