### PR TITLE
Fix inherited netty dependency version to 4.0.36.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,11 @@
 				<artifactId>netty-transport</artifactId>
 				<version>${netty.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-handler</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 	<dependencies>


### PR DESCRIPTION
Suggested patch for Issue #1156 