### PR TITLE
Fix proxy when using JDK provider

### DIFF
--- a/src/main/java/com/ning/http/client/providers/jdk/JDKAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/jdk/JDKAsyncHttpProvider.java
@@ -476,7 +476,6 @@ public class JDKAsyncHttpProvider implements AsyncHttpProvider {
             ProxyServer proxyServer = ProxyUtils.getProxyServer(config, request);
             boolean avoidProxy = ProxyUtils.avoidProxy(proxyServer, uri.getHost());
             if (!avoidProxy) {
-                urlConnection.setRequestProperty("Connection", ka);
                 if (proxyServer.getPrincipal() != null) {
                     urlConnection.setRequestProperty("Proxy-Authorization", AuthenticatorUtils.computeBasicAuthentication(proxyServer));
                 }


### PR DESCRIPTION
Right now it always throws an NPE if it's not bypassed. The culprit is the `ka` variable (that's in fact always null but hey). There is an `if` on the first call to `setRequestProxy`, but none on the 2nd, which is spurious anyway, so I removed it.