### PR TITLE
always create a mutable collection for the request

### DIFF
--- a/client/src/main/java/org/asynchttpclient/RequestBuilderBase.java
+++ b/client/src/main/java/org/asynchttpclient/RequestBuilderBase.java
@@ -527,7 +527,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
         Charset finalCharset = rb.computeCharset();
 
         // make copies of mutable internal collections
-        List<Cookie> cookiesCopy = rb.cookies == null ? Collections.emptyList() : new ArrayList<>(rb.cookies);
+        List<Cookie> cookiesCopy = rb.cookies == null ? new ArrayList<>() : new ArrayList<>(rb.cookies);
         List<Param> formParamsCopy = rb.formParams == null ? Collections.emptyList() : new ArrayList<>(rb.formParams);
         List<Part> bodyPartsCopy = rb.bodyParts == null ? Collections.emptyList() : new ArrayList<>(rb.bodyParts);
 

--- a/client/src/test/java/org/asynchttpclient/filter/FilterTest.java
+++ b/client/src/test/java/org/asynchttpclient/filter/FilterTest.java
@@ -32,6 +32,7 @@ import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.Request;
 import org.asynchttpclient.RequestBuilder;
 import org.asynchttpclient.Response;
+import org.asynchttpclient.cookie.Cookie;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.testng.annotations.Test;
 
@@ -66,6 +67,21 @@ public class FilterTest extends AbstractBasicTest {
     @Test(groups = "standalone")
     public void basicTest() throws Exception {
         try (AsyncHttpClient c = asyncHttpClient(config().addRequestFilter(new ThrottleRequestFilter(100)))) {
+            Response response = c.preparePost(getTargetUrl()).execute().get();
+            assertNotNull(response);
+            assertEquals(response.getStatusCode(), 200);
+        }
+    }
+
+    @Test(groups = "standalone")
+    public void addCookieTest() throws Exception {
+        try (AsyncHttpClient c = asyncHttpClient(config().addRequestFilter(new RequestFilter() {
+            @Override
+            public <T> FilterContext<T> filter(FilterContext<T> ctx) throws FilterException {
+                ctx.getRequest().getCookies().add(Cookie.newValidCookie("test","x",false,null,null,500000,false,true));
+                return ctx;
+            }
+        }))) {
             Response response = c.preparePost(getTargetUrl()).execute().get();
             assertNotNull(response);
             assertEquals(response.getStatusCode(), 200);


### PR DESCRIPTION
I'm not sure if the cookies of a request are meant to be modified from within a filter. But if one wants to modify cookies from within a filter it is not possible right now because the emptyList() is immutable.

Please decide if this is a desired behaviour or a bug. I'm happy to check the other lists also then.