### PR TITLE
Using .equals for String comparison in validateWebSocketRequest

### DIFF
--- a/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
+++ b/src/main/java/com/ning/http/client/providers/netty/NettyAsyncHttpProvider.java
@@ -1954,7 +1954,7 @@ public class NettyAsyncHttpProvider extends SimpleChannelUpstreamHandler impleme
     }
 
     private static final boolean validateWebSocketRequest(Request request, AsyncHandler<?> asyncHandler) {
-        if (request.getMethod() != "GET" || !(asyncHandler instanceof WebSocketUpgradeHandler)) {
+        if (!("GET".equals(request.getMethod())) || !(asyncHandler instanceof WebSocketUpgradeHandler)) {
             return false;
         }
         return true;


### PR DESCRIPTION
Hi, fixing an issue where string comparison is done using "!=" which can cause erratic problems.