### PR TITLE
Allow DefaultSslEngineFactory subclass customization of the SslContext

### DIFF
--- a/client/src/main/java/org/asynchttpclient/SslEngineFactory.java
+++ b/client/src/main/java/org/asynchttpclient/SslEngineFactory.java
@@ -14,6 +14,7 @@
 package org.asynchttpclient;
 
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
 
 public interface SslEngineFactory {
 
@@ -26,4 +27,16 @@ public interface SslEngineFactory {
      * @return new engine
      */
     SSLEngine newSslEngine(AsyncHttpClientConfig config, String peerHost, int peerPort);
+
+    /**
+     * Perform any necessary one-time configuration. This will be called just once before {@code newSslEngine} is called
+     * for the first time.
+     *
+     * @param config the client config
+     * @throws SSLException if initialization fails. If an exception is thrown, the instance will not be used as client
+     *                      creation will fail.
+     */
+    default void init(AsyncHttpClientConfig config) throws SSLException {
+        // no op
+    }
 }

--- a/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
@@ -111,10 +111,11 @@ public class ChannelManager {
     public ChannelManager(final AsyncHttpClientConfig config, Timer nettyTimer) {
 
         this.config = config;
+        this.sslEngineFactory = config.getSslEngineFactory() != null ? config.getSslEngineFactory() : new DefaultSslEngineFactory();
         try {
-            this.sslEngineFactory = config.getSslEngineFactory() != null ? config.getSslEngineFactory() : new DefaultSslEngineFactory(config);
+            this.sslEngineFactory.init(config);
         } catch (SSLException e) {
-            throw new ExceptionInInitializerError(e);
+            throw new RuntimeException("Could not initialize sslEngineFactory", e);
         }
 
         ChannelPool channelPool = config.getChannelPool();


### PR DESCRIPTION
See #1170 for context.

If you have ideas for how to usefully test this, I'm happy to write them up, but it wasn't obvious to me how to usefully test this change. 