### PR TITLE
Specify a version for javadoc plugin to appease Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,14 @@
 				</executions>
 			</plugin>
 		</plugins>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<artifactId>maven-javadoc-plugin</artifactId>
+					<version>2.10.3</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 	<profiles>
 		<profile>


### PR DESCRIPTION
I got tired of seeing the warning messages every build. This is the most recent version, and it only appears to be used in `netty-bp`.