### PR TITLE
Cleanup IDE warnings

### DIFF
--- a/client/src/main/java/io/netty/util/internal/MacAddressUtil.java
+++ b/client/src/main/java/io/netty/util/internal/MacAddressUtil.java
@@ -53,7 +53,7 @@ public final class MacAddressUtil {
         InetAddress bestInetAddr = NetUtil.LOCALHOST4;
 
         // Retrieve the list of available network interfaces.
-        Map<NetworkInterface, InetAddress> ifaces = new LinkedHashMap<NetworkInterface, InetAddress>();
+        Map<NetworkInterface, InetAddress> ifaces = new LinkedHashMap<>();
         try {
             for (Enumeration<NetworkInterface> i = NetworkInterface.getNetworkInterfaces(); i.hasMoreElements();) {
                 NetworkInterface iface = i.nextElement();

--- a/client/src/main/java/org/asynchttpclient/Realm.java
+++ b/client/src/main/java/org/asynchttpclient/Realm.java
@@ -60,7 +60,7 @@ public class Realm {
 
     public enum AuthScheme {
 
-        BASIC, DIGEST, NTLM, SPNEGO, KERBEROS;
+        BASIC, DIGEST, NTLM, SPNEGO, KERBEROS
     }
 
     private Realm(AuthScheme scheme,//
@@ -475,9 +475,9 @@ public class Realm {
 
         private static String toHexString(byte[] data) {
             StringBuilder buffer = StringUtils.stringBuilder();
-            for (int i = 0; i < data.length; i++) {
-                buffer.append(Integer.toHexString((data[i] & 0xf0) >>> 4));
-                buffer.append(Integer.toHexString(data[i] & 0x0f));
+            for (byte aData : data) {
+                buffer.append(Integer.toHexString((aData & 0xf0) >>> 4));
+                buffer.append(Integer.toHexString(aData & 0x0f));
             }
             return buffer.toString();
         }

--- a/client/src/main/java/org/asynchttpclient/config/AsyncHttpClientConfigHelper.java
+++ b/client/src/main/java/org/asynchttpclient/config/AsyncHttpClientConfigHelper.java
@@ -33,7 +33,7 @@ public class AsyncHttpClientConfigHelper {
         public static final String DEFAULT_AHC_PROPERTIES = "ahc-default.properties";
         public static final String CUSTOM_AHC_PROPERTIES = "ahc.properties";
 
-        private final ConcurrentHashMap<String, String> propsCache = new ConcurrentHashMap<String, String>();
+        private final ConcurrentHashMap<String, String> propsCache = new ConcurrentHashMap<>();
         private final Properties defaultProperties = parsePropertiesFile(DEFAULT_AHC_PROPERTIES);
         private volatile Properties customProperties = parsePropertiesFile(CUSTOM_AHC_PROPERTIES);
 
@@ -65,9 +65,9 @@ public class AsyncHttpClientConfigHelper {
             return propsCache.computeIfAbsent(key, k -> {
                 String value = System.getProperty(k);
                 if (value == null)
-                    value = (String) customProperties.getProperty(k);
+                    value = customProperties.getProperty(k);
                 if (value == null)
-                    value = (String) defaultProperties.getProperty(k);
+                    value = defaultProperties.getProperty(k);
                 return value;
             });
         }

--- a/client/src/main/java/org/asynchttpclient/cookie/CookieEncoder.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/CookieEncoder.java
@@ -63,8 +63,7 @@ public final class CookieEncoder {
         } else {
             Cookie[] cookiesSorted = cookies.toArray(new Cookie[cookies.size()]);
             Arrays.sort(cookiesSorted, COOKIE_COMPARATOR);
-            for (int i = 0; i < cookiesSorted.length; i++) {
-                Cookie cookie = cookiesSorted[i];
+            for (Cookie cookie : cookiesSorted) {
                 if (cookie != null) {
                     add(sb, cookie.getName(), cookie.getValue(), cookie.isWrap());
                 }

--- a/client/src/main/java/org/asynchttpclient/netty/channel/DefaultChannelPool.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/DefaultChannelPool.java
@@ -78,7 +78,7 @@ public final class DefaultChannelPool implements ChannelPool {
             PoolLeaseStrategy poolLeaseStrategy,//
             Timer nettyTimer,//
             int cleanerPeriod) {
-        this.maxIdleTime = (int) maxIdleTime;
+        this.maxIdleTime = maxIdleTime;
         this.connectionTtl = connectionTtl;
         connectionTtlEnabled = connectionTtl > 0;
         channelId2Creation = connectionTtlEnabled ? new ConcurrentHashMap<>() : null;
@@ -165,7 +165,7 @@ public final class DefaultChannelPool implements ChannelPool {
             return idleTimeoutChannels != null ? idleTimeoutChannels : Collections.<IdleChannel> emptyList();
         }
 
-        private final List<IdleChannel> closeChannels(List<IdleChannel> candidates) {
+        private List<IdleChannel> closeChannels(List<IdleChannel> candidates) {
 
             // lazy create, only if we hit a non-closeable channel
             List<IdleChannel> closedChannels = null;

--- a/client/src/main/java/org/asynchttpclient/netty/handler/WebSocketHandler.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/WebSocketHandler.java
@@ -168,7 +168,7 @@ public final class WebSocketHandler extends AsyncHttpClientHandler {
                         } finally {
                             frame.release();
                         }
-                    };
+                    }
                 };
                 handler.bufferFrame(bufferedFrame);
             }

--- a/client/src/main/java/org/asynchttpclient/netty/ws/NettyWebSocket.java
+++ b/client/src/main/java/org/asynchttpclient/netty/ws/NettyWebSocket.java
@@ -59,7 +59,7 @@ public class NettyWebSocket implements WebSocket {
     private volatile boolean interestedInTextMessages;
 
     public NettyWebSocket(Channel channel, HttpHeaders upgradeHeaders, AsyncHttpClientConfig config) {
-        this(channel, upgradeHeaders, config, new ConcurrentLinkedQueue<WebSocketListener>());
+        this(channel, upgradeHeaders, config, new ConcurrentLinkedQueue<>());
     }
 
     public NettyWebSocket(Channel channel, HttpHeaders upgradeHeaders, AsyncHttpClientConfig config, Collection<WebSocketListener> listeners) {

--- a/client/src/main/java/org/asynchttpclient/proxy/ProxyServer.java
+++ b/client/src/main/java/org/asynchttpclient/proxy/ProxyServer.java
@@ -127,7 +127,7 @@ public class ProxyServer {
 
         public Builder setNonProxyHost(String nonProxyHost) {
             if (nonProxyHosts == null)
-                nonProxyHosts = new ArrayList<String>(1);
+                nonProxyHosts = new ArrayList<>(1);
             nonProxyHosts.add(nonProxyHost);
             return this;
         }

--- a/client/src/main/java/org/asynchttpclient/request/body/Body.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/Body.java
@@ -38,7 +38,7 @@ public interface Body extends Closeable {
         /**
          * There's nothing to read and input has to stop
          */
-        STOP;
+        STOP
     }
 
     /**

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/MultipartUtils.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/MultipartUtils.java
@@ -73,7 +73,7 @@ public class MultipartUtils {
     }
 
     public static List<MultipartPart<? extends Part>> generateMultipartParts(List<Part> parts, byte[] boundary) {
-        List<MultipartPart<? extends Part>> multipartParts = new ArrayList<MultipartPart<? extends Part>>(parts.size());
+        List<MultipartPart<? extends Part>> multipartParts = new ArrayList<>(parts.size());
         for (Part part : parts) {
             if (part instanceof FilePart) {
                 multipartParts.add(new FileMultipartPart((FilePart) part, boundary));

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/PartBase.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/PartBase.java
@@ -113,7 +113,7 @@ public abstract class PartBase implements Part {
 
     public void addCustomHeader(String name, String value) {
         if (customHeaders == null) {
-            customHeaders = new ArrayList<Param>(2);
+            customHeaders = new ArrayList<>(2);
         }
         customHeaders.add(new Param(name, value));
     }

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/part/MultipartPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/part/MultipartPart.java
@@ -205,7 +205,7 @@ public abstract class MultipartPart<T extends PartBase> implements Closeable {
 
         int transferred = 0;
         if (target instanceof GatheringByteChannel) {
-            transferred = source.readBytes((GatheringByteChannel) target, (int) source.readableBytes());
+            transferred = source.readBytes((GatheringByteChannel) target, source.readableBytes());
         } else {
             for (ByteBuffer byteBuffer : source.nioBuffers()) {
                 int len = byteBuffer.remaining();

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/part/MultipartState.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/part/MultipartState.java
@@ -21,5 +21,5 @@ public enum MultipartState {
 
     POST_CONTENT,
 
-    DONE;
+    DONE
 }

--- a/client/src/main/java/org/asynchttpclient/spnego/SpnegoEngine.java
+++ b/client/src/main/java/org/asynchttpclient/spnego/SpnegoEngine.java
@@ -81,7 +81,7 @@ public class SpnegoEngine {
     public String generateToken(String server) throws SpnegoEngineException {
         GSSContext gssContext = null;
         byte[] token = null; // base64 decoded challenge
-        Oid negotiationOid = null;
+        Oid negotiationOid;
 
         try {
             log.debug("init {}", server);
@@ -152,7 +152,7 @@ public class SpnegoEngine {
 
             gssContext.dispose();
 
-            String tokenstr = new String(Base64.encode(token));
+            String tokenstr = Base64.encode(token);
             log.debug("Sending response '{}' back to the server", tokenstr);
 
             return tokenstr;

--- a/client/src/main/java/org/asynchttpclient/util/HttpUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/HttpUtils.java
@@ -31,23 +31,23 @@ public class HttpUtils {
 
     public final static Charset DEFAULT_CHARSET = ISO_8859_1;
 
-    public static final void validateSupportedScheme(Uri uri) {
+    public static void validateSupportedScheme(Uri uri) {
         final String scheme = uri.getScheme();
         if (scheme == null || !scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https") && !scheme.equalsIgnoreCase("ws") && !scheme.equalsIgnoreCase("wss")) {
             throw new IllegalArgumentException("The URI scheme, of the URI " + uri + ", must be equal (ignoring case) to 'http', 'https', 'ws', or 'wss'");
         }
     }
 
-    public final static String getBaseUrl(Uri uri) {
+    public static String getBaseUrl(Uri uri) {
         // getAuthority duplicate but we don't want to re-concatenate
         return uri.getScheme() + "://" + uri.getHost() + ":" + uri.getExplicitPort();
     }
 
-    public final static String getAuthority(Uri uri) {
+    public static String getAuthority(Uri uri) {
         return uri.getHost() + ":" + uri.getExplicitPort();
     }
 
-    public final static boolean isSameBase(Uri uri1, Uri uri2) {
+    public static boolean isSameBase(Uri uri1, Uri uri2) {
         return uri1.getScheme().equals(uri2.getScheme()) && uri1.getHost().equals(uri2.getHost()) && uri1.getExplicitPort() == uri2.getExplicitPort();
     }
 
@@ -55,7 +55,7 @@ public class HttpUtils {
      * @param uri the uri
      * @return the raw path or "/" if it's null
      */
-    public final static String getNonEmptyPath(Uri uri) {
+    public static String getNonEmptyPath(Uri uri) {
         return isNonEmpty(uri.getPath()) ? uri.getPath() : "/";
     }
 
@@ -79,7 +79,7 @@ public class HttpUtils {
     }
 
     public static boolean followRedirect(AsyncHttpClientConfig config, Request request) {
-        return request.getFollowRedirect() != null ? request.getFollowRedirect().booleanValue() : config.isFollowRedirect();
+        return request.getFollowRedirect() != null ? request.getFollowRedirect() : config.isFollowRedirect();
     }
 
     private static StringBuilder urlEncodeFormParams0(List<Param> params) {

--- a/client/src/main/java/org/asynchttpclient/util/ProxyUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/ProxyUtils.java
@@ -120,7 +120,7 @@ public final class ProxyUtils {
 
             String nonProxyHosts = properties.getProperty(PROXY_NONPROXYHOSTS);
             if (nonProxyHosts != null) {
-                proxyServer.setNonProxyHosts(new ArrayList<String>(Arrays.asList(nonProxyHosts.split("\\|"))));
+                proxyServer.setNonProxyHosts(new ArrayList<>(Arrays.asList(nonProxyHosts.split("\\|"))));
             }
 
             return createProxyServerSelector(proxyServer.build());

--- a/client/src/main/java/org/asynchttpclient/util/StringUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/StringUtils.java
@@ -21,7 +21,7 @@ public final class StringUtils {
     private static final ThreadLocal<StringBuilder> STRING_BUILDERS = new ThreadLocal<StringBuilder>() {
         protected StringBuilder initialValue() {
             return new StringBuilder(512);
-        };
+        }
     };
 
     /**

--- a/client/src/main/java/org/asynchttpclient/util/UriEncoder.java
+++ b/client/src/main/java/org/asynchttpclient/util/UriEncoder.java
@@ -119,11 +119,11 @@ public enum UriEncoder {
 
     protected abstract String withoutQueryWithParams(final List<Param> queryParams);
 
-    private final String withQuery(final String query, final List<Param> queryParams) {
+    private String withQuery(final String query, final List<Param> queryParams) {
         return isNonEmpty(queryParams) ? withQueryWithParams(query, queryParams) : withQueryWithoutParams(query);
     }
 
-    private final String withoutQuery(final List<Param> queryParams) {
+    private String withoutQuery(final List<Param> queryParams) {
         return isNonEmpty(queryParams) ? withoutQueryWithParams(queryParams) : null;
     }
 
@@ -140,7 +140,7 @@ public enum UriEncoder {
 
     protected abstract String encodePath(String path);
 
-    private final String encodeQuery(final String query, final List<Param> queryParams) {
+    private String encodeQuery(final String query, final List<Param> queryParams) {
         return isNonEmpty(query) ? withQuery(query, queryParams) : withoutQuery(queryParams);
     }
 }

--- a/client/src/main/java/org/asynchttpclient/util/Utf8Reader.java
+++ b/client/src/main/java/org/asynchttpclient/util/Utf8Reader.java
@@ -91,7 +91,7 @@ public class Utf8Reader {
                     char3 = b.getByte(readerIndex + count - 1);
                     if (((char2 & 0xC0) != 0x80) || ((char3 & 0xC0) != 0x80))
                         throw new UTFDataFormatException("malformed input around byte " + (count - 1));
-                    chararr[chararr_count++] = (char) (((char1 & 0x0F) << 12) | ((char2 & 0x3F) << 6) | ((char3 & 0x3F) << 0));
+                    chararr[chararr_count++] = (char) (((char1 & 0x0F) << 12) | ((char2 & 0x3F) << 6) | (char3 & 0x3F));
                     break;
                 default:
                     /* 10xx xxxx, 1111 xxxx */

--- a/client/src/main/java/org/asynchttpclient/util/Utf8UrlEncoder.java
+++ b/client/src/main/java/org/asynchttpclient/util/Utf8UrlEncoder.java
@@ -192,7 +192,7 @@ public final class Utf8UrlEncoder {
         return sb;
     }
 
-    private final static void appendSingleByteEncoded(StringBuilder sb, int value, boolean encodeSpaceAsPlus) {
+    private static void appendSingleByteEncoded(StringBuilder sb, int value, boolean encodeSpaceAsPlus) {
 
         if (value == ' ' && encodeSpaceAsPlus) {
             sb.append('+');
@@ -204,7 +204,7 @@ public final class Utf8UrlEncoder {
         sb.append(HEX[value & 0xF]);
     }
 
-    private final static void appendMultiByteEncoded(StringBuilder sb, int value) {
+    private static void appendMultiByteEncoded(StringBuilder sb, int value) {
         if (value < 0x800) {
             appendSingleByteEncoded(sb, (0xc0 | (value >> 6)), false);
             appendSingleByteEncoded(sb, (0x80 | (value & 0x3f)), false);

--- a/client/src/main/java/org/asynchttpclient/webdav/WebDavCompletionHandlerBase.java
+++ b/client/src/main/java/org/asynchttpclient/webdav/WebDavCompletionHandlerBase.java
@@ -47,7 +47,7 @@ public abstract class WebDavCompletionHandlerBase<T> implements AsyncHandler<T> 
 
     private HttpResponseStatus status;
     private HttpResponseHeaders headers;
-    private final List<HttpResponseBodyPart> bodyParts = Collections.synchronizedList(new ArrayList<HttpResponseBodyPart>());
+    private final List<HttpResponseBodyPart> bodyParts = Collections.synchronizedList(new ArrayList<>());
 
     /**
      * {@inheritDoc}

--- a/client/src/test/java/org/asynchttpclient/BasicHttpTest.java
+++ b/client/src/test/java/org/asynchttpclient/BasicHttpTest.java
@@ -560,7 +560,7 @@ public class BasicHttpTest extends HttpTest {
         withClient().run(client -> {
             withServer(server).run(server -> {
                 final CountDownLatch latch = new CountDownLatch(1);
-                final AtomicReference<String> message = new AtomicReference<String>();
+                final AtomicReference<String> message = new AtomicReference<>();
 
                 server.enqueueOk();
                 client.prepareGet(getTargetUrl()).execute(new AsyncCompletionHandlerAdapter() {

--- a/client/src/test/java/org/asynchttpclient/ListenableFutureTest.java
+++ b/client/src/test/java/org/asynchttpclient/ListenableFutureTest.java
@@ -35,9 +35,7 @@ public class ListenableFutureTest extends AbstractBasicTest {
                 try {
                     statusCode.set(future.get().getStatusCode());
                     latch.countDown();
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                } catch (ExecutionException e) {
+                } catch (InterruptedException | ExecutionException e) {
                     e.printStackTrace();
                 }
             }, Executors.newFixedThreadPool(1));

--- a/client/src/test/java/org/asynchttpclient/channel/MaxConnectionsInThreads.java
+++ b/client/src/test/java/org/asynchttpclient/channel/MaxConnectionsInThreads.java
@@ -63,8 +63,7 @@ public class MaxConnectionsInThreads extends AbstractBasicTest {
         final AtomicInteger failedCount = new AtomicInteger();
 
         try (AsyncHttpClient client = asyncHttpClient(config)) {
-            for (int i = 0; i < urls.length; i++) {
-                final String url = urls[i];
+            for (final String url : urls) {
                 Thread t = new Thread() {
                     public void run() {
                         client.prepareGet(url).execute(new AsyncCompletionHandlerBase() {
@@ -93,8 +92,7 @@ public class MaxConnectionsInThreads extends AbstractBasicTest {
 
             final CountDownLatch notInThreadsLatch = new CountDownLatch(2);
             failedCount.set(0);
-            for (int i = 0; i < urls.length; i++) {
-                final String url = urls[i];
+            for (final String url : urls) {
                 client.prepareGet(url).execute(new AsyncCompletionHandlerBase() {
                     @Override
                     public Response onCompleted(Response response) throws Exception {

--- a/client/src/test/java/org/asynchttpclient/channel/MaxTotalConnectionTest.java
+++ b/client/src/test/java/org/asynchttpclient/channel/MaxTotalConnectionTest.java
@@ -49,8 +49,8 @@ public class MaxTotalConnectionTest extends AbstractBasicTest {
 
         try (AsyncHttpClient client = asyncHttpClient(config)) {
             List<ListenableFuture<Response>> futures = new ArrayList<>();
-            for (int i = 0; i < urls.length; i++) {
-                futures.add(client.prepareGet(urls[i]).execute());
+            for (String url : urls) {
+                futures.add(client.prepareGet(url).execute());
             }
 
             boolean caughtError = false;

--- a/client/src/test/java/org/asynchttpclient/netty/NettyRequestThrottleTimeoutTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/NettyRequestThrottleTimeoutTest.java
@@ -79,7 +79,7 @@ public class NettyRequestThrottleTimeoutTest extends AbstractBasicTest {
 
         try (AsyncHttpClient client = asyncHttpClient(config().setMaxConnections(1))) {
             final CountDownLatch latch = new CountDownLatch(samples);
-            final List<Exception> tooManyConnections = Collections.synchronizedList(new ArrayList<Exception>(2));
+            final List<Exception> tooManyConnections = Collections.synchronizedList(new ArrayList<>(2));
 
             for (int i = 0; i < samples; i++) {
                 new Thread(new Runnable() {

--- a/client/src/test/java/org/asynchttpclient/reactivestreams/ReactiveStreamsDownLoadTest.java
+++ b/client/src/test/java/org/asynchttpclient/reactivestreams/ReactiveStreamsDownLoadTest.java
@@ -71,7 +71,7 @@ public class ReactiveStreamsDownLoadTest {
         private final SimpleSubscriber<HttpResponseBodyPart> subscriber;
 
         public SimpleStreamedAsyncHandler() {
-            this(new SimpleSubscriber<HttpResponseBodyPart>());
+            this(new SimpleSubscriber<>());
         }
 
         public SimpleStreamedAsyncHandler(SimpleSubscriber<HttpResponseBodyPart> subscriber) {
@@ -128,7 +128,7 @@ public class ReactiveStreamsDownLoadTest {
     static protected class SimpleSubscriber<T> implements Subscriber<T> {
         private volatile Subscription subscription;
         private volatile Throwable error;
-        private final List<T> elements = Collections.synchronizedList(new ArrayList<T>());
+        private final List<T> elements = Collections.synchronizedList(new ArrayList<>());
         private final CountDownLatch latch = new CountDownLatch(1);
 
         @Override

--- a/client/src/test/java/org/asynchttpclient/reactivestreams/ReactiveStreamsTest.java
+++ b/client/src/test/java/org/asynchttpclient/reactivestreams/ReactiveStreamsTest.java
@@ -122,7 +122,7 @@ public class ReactiveStreamsTest extends AbstractBasicTest {
         private final SimpleSubscriber<HttpResponseBodyPart> subscriber;
 
         public SimpleStreamedAsyncHandler() {
-            this(new SimpleSubscriber<HttpResponseBodyPart>());
+            this(new SimpleSubscriber<>());
         }
 
         public SimpleStreamedAsyncHandler(SimpleSubscriber<HttpResponseBodyPart> subscriber) {
@@ -176,7 +176,7 @@ public class ReactiveStreamsTest extends AbstractBasicTest {
     static protected class SimpleSubscriber<T> implements Subscriber<T> {
         private volatile Subscription subscription;
         private volatile Throwable error;
-        private final List<T> elements = Collections.synchronizedList(new ArrayList<T>());
+        private final List<T> elements = Collections.synchronizedList(new ArrayList<>());
         private final CountDownLatch latch = new CountDownLatch(1);
 
         @Override
@@ -221,7 +221,7 @@ public class ReactiveStreamsTest extends AbstractBasicTest {
 
         @Override
         public State onStream(Publisher<HttpResponseBodyPart> publisher) {
-            publisher.subscribe(new CancellingSubscriber<HttpResponseBodyPart>(cancelAfter));
+            publisher.subscribe(new CancellingSubscriber<>(cancelAfter));
             return State.CONTINUE;
         }
 

--- a/client/src/test/java/org/asynchttpclient/testserver/HttpServer.java
+++ b/client/src/test/java/org/asynchttpclient/testserver/HttpServer.java
@@ -43,7 +43,7 @@ public class HttpServer implements Closeable {
     @FunctionalInterface
     public interface HttpServletResponseConsumer {
 
-        public void apply(HttpServletResponse response) throws IOException, ServletException;
+        void apply(HttpServletResponse response) throws IOException, ServletException;
     }
 
     public HttpServer() {
@@ -240,7 +240,7 @@ public class HttpServer implements Closeable {
             Enumeration<String> parameterNames = request.getParameterNames();
             StringBuilder requestBody = new StringBuilder();
             while (parameterNames.hasMoreElements()) {
-                String param = parameterNames.nextElement().toString();
+                String param = parameterNames.nextElement();
                 response.addHeader("X-" + param, request.getParameter(param));
                 requestBody.append(param);
                 requestBody.append("_");

--- a/extras/guava/src/main/java/org/asynchttpclient/extras/guava/RateLimitedThrottleRequestFilter.java
+++ b/extras/guava/src/main/java/org/asynchttpclient/extras/guava/RateLimitedThrottleRequestFilter.java
@@ -56,7 +56,7 @@ public class RateLimitedThrottleRequestFilter implements RequestFilter {
             throw new FilterException(String.format("Interrupted Request %s with AsyncHandler %s", ctx.getRequest(), ctx.getAsyncHandler()));
         }
 
-        return new FilterContext.FilterContextBuilder<>(ctx).asyncHandler(new AsyncHandlerWrapper<T>(ctx.getAsyncHandler(), available))
+        return new FilterContext.FilterContextBuilder<>(ctx).asyncHandler(new AsyncHandlerWrapper<>(ctx.getAsyncHandler(), available))
                 .build();
     }
 

--- a/extras/registry/src/main/java/org/asynchttpclient/extras/registry/AsyncHttpClientFactory.java
+++ b/extras/registry/src/main/java/org/asynchttpclient/extras/registry/AsyncHttpClientFactory.java
@@ -49,7 +49,7 @@ public class AsyncHttpClientFactory {
 
         try {
             if (attemptInstantiation())
-                return (AsyncHttpClient) asyncHttpClientImplClass.newInstance();
+                return asyncHttpClientImplClass.newInstance();
         } catch (InstantiationException e) {
             throw new AsyncHttpClientImplException("Unable to create the class specified by system property : "
                     + AsyncImplHelper.ASYNC_HTTP_CLIENT_IMPL_SYSTEM_PROPERTY, e);

--- a/extras/registry/src/main/java/org/asynchttpclient/extras/registry/AsyncHttpClientRegistryImpl.java
+++ b/extras/registry/src/main/java/org/asynchttpclient/extras/registry/AsyncHttpClientRegistryImpl.java
@@ -42,9 +42,7 @@ public class AsyncHttpClientRegistryImpl implements AsyncHttpClientRegistry {
                     else
                         _instance = new AsyncHttpClientRegistryImpl();
                 }
-            } catch (InstantiationException e) {
-                throw new AsyncHttpClientImplException("Couldn't instantiate AsyncHttpClientRegistry : " + e.getMessage(), e);
-            } catch (IllegalAccessException e) {
+            } catch (InstantiationException | IllegalAccessException e) {
                 throw new AsyncHttpClientImplException("Couldn't instantiate AsyncHttpClientRegistry : " + e.getMessage(), e);
             } finally {
                 lock.unlock();

--- a/extras/simple/src/main/java/org/asynchttpclient/extras/simple/SimpleAsyncHttpClient.java
+++ b/extras/simple/src/main/java/org/asynchttpclient/extras/simple/SimpleAsyncHttpClient.java
@@ -366,7 +366,7 @@ public class SimpleAsyncHttpClient implements Closeable {
          * Omit error documents. An error document will neither be available in
          * the response nor written via a {@link BodyConsumer}.
          */
-        OMIT;
+        OMIT
     }
 
     /**

--- a/extras/simple/src/test/java/org/asynchttpclient/extras/simple/SimpleAsyncHttpClientTest.java
+++ b/extras/simple/src/test/java/org/asynchttpclient/extras/simple/SimpleAsyncHttpClientTest.java
@@ -157,7 +157,7 @@ public class SimpleAsyncHttpClientTest extends AbstractBasicTest {
     @Test(groups = "standalone")
     public void testSimpleTransferListener() throws Exception {
 
-        final List<Error> errors = Collections.synchronizedList(new ArrayList<Error>());
+        final List<Error> errors = Collections.synchronizedList(new ArrayList<>());
 
         SimpleAHCTransferListener listener = new SimpleAHCTransferListener() {
 


### PR DESCRIPTION
Motivation : 

IDE highlights a lot of warnings, code hard to read with them.

Modifications : 

Removed unnecessary explicit type arguments, `final` for private methods, replaces `for` with `for each`.

Result : 

Cleaner code.