### PR TITLE
Enable asynchronous cancellation of AsyncHttpSingle

### DIFF
--- a/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/UnsubscribedException.java
+++ b/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/UnsubscribedException.java
@@ -12,16 +12,18 @@
  */
 package org.asynchttpclient.extras.rxjava;
 
+import java.util.concurrent.CancellationException;
+
 /**
  * Indicates that an {@code Observer} unsubscribed during the processing of a HTTP request.
  */
 @SuppressWarnings("serial")
-public class UnsubscribedException extends RuntimeException {
+public class UnsubscribedException extends CancellationException {
 
     public UnsubscribedException() {
     }
 
     public UnsubscribedException(final Throwable cause) {
-        super(cause);
+        initCause(cause);
     }
 }


### PR DESCRIPTION
AsyncHttpSingle is currently not forwarding an unsubscription to AsyncHttpClient, it just aborts request processing when an AsyncHandler callback method is invoked. To actually eagerly cancel a request on unsubscription, use the request future to actually forward the cancellation to AsyncHttpClient.