### PR TITLE
#1130: Diagnostics/debug info for AsyncHttpClient

### DIFF
--- a/client/src/main/java/org/asynchttpclient/AsyncHttpClient.java
+++ b/client/src/main/java/org/asynchttpclient/AsyncHttpClient.java
@@ -266,4 +266,11 @@ public interface AsyncHttpClient extends Closeable {
      * @return a {@link Future} of type Response
      */
     ListenableFuture<Response> executeRequest(RequestBuilder requestBuilder);
+
+    /***
+     * Return details about pooled connections.
+     *
+     * @return a {@link ClientStats}
+     */
+    ClientStats getClientStats();
 }

--- a/client/src/main/java/org/asynchttpclient/ClientStats.java
+++ b/client/src/main/java/org/asynchttpclient/ClientStats.java
@@ -1,18 +1,15 @@
 /*
- * Copyright 2010 Ning, Inc.
+ * Copyright (c) 2014 AsyncHttpClient Project. All rights reserved.
  *
- * This program is licensed to you under the Apache License, version 2.0
- * (the "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at:
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
- *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
 package org.asynchttpclient;
 
@@ -26,8 +23,8 @@ public class ClientStats {
     private final long activeConnectionCount;
     private final long idleConnectionCount;
 
-    public ClientStats(final long activeConnectionCount,
-                       final long idleConnectionCount) {
+    public ClientStats(long activeConnectionCount,
+                       long idleConnectionCount) {
         this.activeConnectionCount = activeConnectionCount;
         this.idleConnectionCount = idleConnectionCount;
     }

--- a/client/src/main/java/org/asynchttpclient/ClientStats.java
+++ b/client/src/main/java/org/asynchttpclient/ClientStats.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2010 Ning, Inc.
+ *
+ * This program is licensed to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.asynchttpclient;
+
+import java.util.Objects;
+
+/**
+ * A record class representing the state of an (@link org.asynchttpclient.AsyncHttpClient)
+ */
+public class ClientStats {
+
+    private final long activeConnectionCount;
+    private final long idleConnectionCount;
+
+    public ClientStats(final long activeConnectionCount,
+                       final long idleConnectionCount) {
+        this.activeConnectionCount = activeConnectionCount;
+        this.idleConnectionCount = idleConnectionCount;
+    }
+
+    /**
+     * @return The sum of {@link #getActiveConnectionCount()} and {@link #getIdleConnectionCount()},
+     * a long representing the total number of connections in the connection pool.
+     */
+    public long getTotalConnectionCount() {
+        return activeConnectionCount + idleConnectionCount;
+    }
+
+    /**
+     * @return A long representing the number of active connection in the connection pool.
+     */
+    public long getActiveConnectionCount() {
+        return activeConnectionCount;
+    }
+
+    /**
+     *
+     * @return A long representing the number of idle connections in the connection pool.
+     */
+    public long getIdleConnectionCount() {
+        return idleConnectionCount;
+    }
+
+    @Override
+    public String toString() {
+        return "There are " + getTotalConnectionCount() +
+                " total connections, " + getActiveConnectionCount() +
+                " are active and " + getIdleConnectionCount() + " are idle.";
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final ClientStats that = (ClientStats) o;
+        return activeConnectionCount == that.activeConnectionCount &&
+                idleConnectionCount == that.idleConnectionCount;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(activeConnectionCount, idleConnectionCount);
+    }
+}

--- a/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClient.java
+++ b/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClient.java
@@ -255,6 +255,11 @@ public class DefaultAsyncHttpClient implements AsyncHttpClient {
         return channelManager.getEventLoopGroup();
     }
 
+    @Override
+    public ClientStats getClientStats() {
+        return channelManager.getClientStats();
+    }
+
     protected BoundRequestBuilder requestBuilder(String method, String url) {
         return new BoundRequestBuilder(this, method, config.isDisableUrlEncodingForBoundRequests()).setUrl(url).setSignatureCalculator(signatureCalculator);
     }

--- a/client/src/main/java/org/asynchttpclient/HostStats.java
+++ b/client/src/main/java/org/asynchttpclient/HostStats.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2014 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient;
+
+import java.util.Objects;
+
+/**
+ * A record class representing the status of connections to some host.
+ */
+public class HostStats {
+
+    private final long activeConnectionCount;
+    private final long idleConnectionCount;
+
+    public HostStats(long activeConnectionCount,
+                     long idleConnectionCount) {
+        this.activeConnectionCount = activeConnectionCount;
+        this.idleConnectionCount = idleConnectionCount;
+    }
+
+    /**
+     * @return The sum of {@link #getHostActiveConnectionCount()} and {@link #getHostIdleConnectionCount()},
+     * a long representing the total number of connections to this host.
+     */
+    public long getHostConnectionCount() {
+        return activeConnectionCount + idleConnectionCount;
+    }
+
+    /**
+     * @return A long representing the number of active connections to the host.
+     */
+    public long getHostActiveConnectionCount() {
+        return activeConnectionCount;
+    }
+
+    /**
+     * @return A long representing the number of idle connections in the connection pool.
+     */
+    public long getHostIdleConnectionCount() {
+        return idleConnectionCount;
+    }
+
+    @Override
+    public String toString() {
+        return "There are " + getHostConnectionCount() +
+                " total connections, " + getHostActiveConnectionCount() +
+                " are active and " + getHostIdleConnectionCount() + " are idle.";
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final HostStats hostStats = (HostStats) o;
+        return activeConnectionCount == hostStats.activeConnectionCount &&
+                idleConnectionCount == hostStats.idleConnectionCount;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(activeConnectionCount, idleConnectionCount);
+    }
+}

--- a/client/src/main/java/org/asynchttpclient/channel/ChannelPool.java
+++ b/client/src/main/java/org/asynchttpclient/channel/ChannelPool.java
@@ -70,4 +70,9 @@ public interface ChannelPool {
      * @param selector the selector
      */
     void flushPartitions(ChannelPoolPartitionSelector selector);
+
+    /**
+     * @return The number of idle channels.
+     */
+    long getIdleChannelCount();
 }

--- a/client/src/main/java/org/asynchttpclient/channel/ChannelPool.java
+++ b/client/src/main/java/org/asynchttpclient/channel/ChannelPool.java
@@ -13,6 +13,8 @@
  */
 package org.asynchttpclient.channel;
 
+import java.util.Map;
+
 import io.netty.channel.Channel;
 
 public interface ChannelPool {
@@ -72,7 +74,7 @@ public interface ChannelPool {
     void flushPartitions(ChannelPoolPartitionSelector selector);
 
     /**
-     * @return The number of idle channels.
+     * @return The number of idle channels per host.
      */
-    long getIdleChannelCount();
+    Map<String, Long> getIdleChannelCountPerHost();
 }

--- a/client/src/main/java/org/asynchttpclient/channel/NoopChannelPool.java
+++ b/client/src/main/java/org/asynchttpclient/channel/NoopChannelPool.java
@@ -50,4 +50,11 @@ public enum NoopChannelPool implements ChannelPool {
     @Override
     public void flushPartitions(ChannelPoolPartitionSelector selector) {
     }
+
+    @Override
+    public long getIdleChannelCount() {
+        return 0;
+    }
+
+
 }

--- a/client/src/main/java/org/asynchttpclient/channel/NoopChannelPool.java
+++ b/client/src/main/java/org/asynchttpclient/channel/NoopChannelPool.java
@@ -13,6 +13,9 @@
  */
 package org.asynchttpclient.channel;
 
+import java.util.Collections;
+import java.util.Map;
+
 import io.netty.channel.Channel;
 
 public enum NoopChannelPool implements ChannelPool {
@@ -52,7 +55,7 @@ public enum NoopChannelPool implements ChannelPool {
     }
 
     @Override
-    public long getIdleChannelCount() {
-        return 0;
+    public Map<String, Long> getIdleChannelCountPerHost() {
+        return Collections.emptyMap();
     }
 }

--- a/client/src/main/java/org/asynchttpclient/channel/NoopChannelPool.java
+++ b/client/src/main/java/org/asynchttpclient/channel/NoopChannelPool.java
@@ -55,6 +55,4 @@ public enum NoopChannelPool implements ChannelPool {
     public long getIdleChannelCount() {
         return 0;
     }
-
-
 }

--- a/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
@@ -51,6 +51,7 @@ import javax.net.ssl.SSLException;
 
 import org.asynchttpclient.AsyncHandler;
 import org.asynchttpclient.AsyncHttpClientConfig;
+import org.asynchttpclient.ClientStats;
 import org.asynchttpclient.SslEngineFactory;
 import org.asynchttpclient.channel.ChannelPool;
 import org.asynchttpclient.channel.ChannelPoolPartitioning;
@@ -487,5 +488,12 @@ public class ChannelManager {
 
     public EventLoopGroup getEventLoopGroup() {
         return eventLoopGroup;
+    }
+
+    public ClientStats getClientStats() {
+        final long totalConnectionCount = openChannels.size();
+        final long idleConnectionCount = channelPool.getIdleChannelCount();
+        final long activeConnectionCount = totalConnectionCount - idleConnectionCount;
+        return new ClientStats(activeConnectionCount, idleConnectionCount);
     }
 }

--- a/client/src/main/java/org/asynchttpclient/netty/channel/DefaultChannelPool.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/DefaultChannelPool.java
@@ -358,12 +358,7 @@ public final class DefaultChannelPool implements ChannelPool {
 
     @Override
     public long getIdleChannelCount() {
-        return partitions.reduceValuesToLong(
-                Long.MAX_VALUE,
-                ConcurrentLinkedDeque::size,
-                0,
-                (left, right) -> left + right
-        );
+        return partitions.values().stream().mapToLong(ConcurrentLinkedDeque::size).sum();
     }
 
     public enum PoolLeaseStrategy {

--- a/client/src/main/java/org/asynchttpclient/netty/channel/DefaultChannelPool.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/DefaultChannelPool.java
@@ -21,11 +21,14 @@ import io.netty.util.Timeout;
 import io.netty.util.Timer;
 import io.netty.util.TimerTask;
 
+import java.net.InetSocketAddress;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.asynchttpclient.AsyncHttpClientConfig;
 import org.asynchttpclient.channel.ChannelPool;
@@ -118,6 +121,10 @@ public final class DefaultChannelPool implements ChannelPool {
 
         public boolean takeOwnership() {
             return owned.compareAndSet(false, true);
+        }
+
+        public Channel getChannel() {
+            return channel;
         }
 
         @Override
@@ -357,8 +364,16 @@ public final class DefaultChannelPool implements ChannelPool {
     }
 
     @Override
-    public long getIdleChannelCount() {
-        return partitions.values().stream().mapToLong(ConcurrentLinkedDeque::size).sum();
+    public Map<String, Long> getIdleChannelCountPerHost() {
+        return partitions
+                .values()
+                .stream()
+                .flatMap(ConcurrentLinkedDeque::stream)
+                .map(idle -> idle.getChannel().remoteAddress())
+                .filter(a -> a.getClass() == InetSocketAddress.class)
+                .map(a -> (InetSocketAddress) a)
+                .map(InetSocketAddress::getHostName)
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
     }
 
     public enum PoolLeaseStrategy {

--- a/client/src/main/java/org/asynchttpclient/netty/channel/DefaultChannelPool.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/DefaultChannelPool.java
@@ -356,6 +356,16 @@ public final class DefaultChannelPool implements ChannelPool {
         }
     }
 
+    @Override
+    public long getIdleChannelCount() {
+        return partitions.reduceValuesToLong(
+                Long.MAX_VALUE,
+                ConcurrentLinkedDeque::size,
+                0,
+                (left, right) -> left + right
+        );
+    }
+
     public enum PoolLeaseStrategy {
         LIFO {
             public <E> E lease(Deque<E> d) {

--- a/client/src/test/java/org/asynchttpclient/ClientStatsTest.java
+++ b/client/src/test/java/org/asynchttpclient/ClientStatsTest.java
@@ -16,10 +16,9 @@ package org.asynchttpclient;
 import static org.asynchttpclient.Dsl.asyncHttpClient;
 import static org.asynchttpclient.Dsl.config;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -30,6 +29,8 @@ import org.testng.annotations.Test;
  */
 public class ClientStatsTest extends AbstractBasicTest {
 
+    private final static String hostname = "localhost";
+
     @Test(groups = "standalone")
     public void testClientStatus() throws Throwable {
         try (final AsyncHttpClient client = asyncHttpClient(config().setKeepAlive(true).setPooledConnectionIdleTimeout(5000))) {
@@ -38,9 +39,10 @@ public class ClientStatsTest extends AbstractBasicTest {
             final ClientStats emptyStats = client.getClientStats();
 
             assertEquals(emptyStats.toString(), "There are 0 total connections, 0 are active and 0 are idle.");
-            assertEquals(emptyStats.getActiveConnectionCount(), 0);
-            assertEquals(emptyStats.getIdleConnectionCount(), 0);
+            assertEquals(emptyStats.getTotalActiveConnectionCount(), 0);
+            assertEquals(emptyStats.getTotalIdleConnectionCount(), 0);
             assertEquals(emptyStats.getTotalConnectionCount(), 0);
+            assertNull(emptyStats.getStatsPerHost().get(hostname));
 
             final List<ListenableFuture<Response>> futures =
                     Stream.generate(() -> client.prepareGet(url).setHeader("LockThread","6").execute())
@@ -52,9 +54,10 @@ public class ClientStatsTest extends AbstractBasicTest {
             final ClientStats activeStats = client.getClientStats();
 
             assertEquals(activeStats.toString(), "There are 5 total connections, 5 are active and 0 are idle.");
-            assertEquals(activeStats.getActiveConnectionCount(), 5);
-            assertEquals(activeStats.getIdleConnectionCount(), 0);
+            assertEquals(activeStats.getTotalActiveConnectionCount(), 5);
+            assertEquals(activeStats.getTotalIdleConnectionCount(), 0);
             assertEquals(activeStats.getTotalConnectionCount(), 5);
+            assertEquals(activeStats.getStatsPerHost().get(hostname).getHostConnectionCount(), 5);
 
             futures.forEach(future -> future.toCompletableFuture().join());
 
@@ -63,9 +66,10 @@ public class ClientStatsTest extends AbstractBasicTest {
             final ClientStats idleStats = client.getClientStats();
 
             assertEquals(idleStats.toString(), "There are 5 total connections, 0 are active and 5 are idle.");
-            assertEquals(idleStats.getActiveConnectionCount(), 0);
-            assertEquals(idleStats.getIdleConnectionCount(), 5);
+            assertEquals(idleStats.getTotalActiveConnectionCount(), 0);
+            assertEquals(idleStats.getTotalIdleConnectionCount(), 5);
             assertEquals(idleStats.getTotalConnectionCount(), 5);
+            assertEquals(idleStats.getStatsPerHost().get(hostname).getHostConnectionCount(), 5);
 
             // Let's make sure the active count is correct when reusing cached connections.
 
@@ -79,9 +83,10 @@ public class ClientStatsTest extends AbstractBasicTest {
             final ClientStats activeCachedStats = client.getClientStats();
 
             assertEquals(activeCachedStats.toString(), "There are 5 total connections, 3 are active and 2 are idle.");
-            assertEquals(activeCachedStats.getActiveConnectionCount(), 3);
-            assertEquals(activeCachedStats.getIdleConnectionCount(), 2);
+            assertEquals(activeCachedStats.getTotalActiveConnectionCount(), 3);
+            assertEquals(activeCachedStats.getTotalIdleConnectionCount(), 2);
             assertEquals(activeCachedStats.getTotalConnectionCount(), 5);
+            assertEquals(activeCachedStats.getStatsPerHost().get(hostname).getHostConnectionCount(), 5);
 
             repeatedFutures.forEach(future -> future.toCompletableFuture().join());
 
@@ -90,18 +95,20 @@ public class ClientStatsTest extends AbstractBasicTest {
             final ClientStats idleCachedStats = client.getClientStats();
 
             assertEquals(idleCachedStats.toString(), "There are 3 total connections, 0 are active and 3 are idle.");
-            assertEquals(idleCachedStats.getActiveConnectionCount(), 0);
-            assertEquals(idleCachedStats.getIdleConnectionCount(), 3);
+            assertEquals(idleCachedStats.getTotalActiveConnectionCount(), 0);
+            assertEquals(idleCachedStats.getTotalIdleConnectionCount(), 3);
             assertEquals(idleCachedStats.getTotalConnectionCount(), 3);
+            assertEquals(idleCachedStats.getStatsPerHost().get(hostname).getHostConnectionCount(), 3);
 
             Thread.sleep(5000);
 
             final ClientStats timeoutStats = client.getClientStats();
 
             assertEquals(timeoutStats.toString(), "There are 0 total connections, 0 are active and 0 are idle.");
-            assertEquals(timeoutStats.getActiveConnectionCount(), 0);
-            assertEquals(timeoutStats.getIdleConnectionCount(), 0);
+            assertEquals(timeoutStats.getTotalActiveConnectionCount(), 0);
+            assertEquals(timeoutStats.getTotalIdleConnectionCount(), 0);
             assertEquals(timeoutStats.getTotalConnectionCount(), 0);
+            assertNull(timeoutStats.getStatsPerHost().get(hostname));
         }
     }
 
@@ -113,9 +120,10 @@ public class ClientStatsTest extends AbstractBasicTest {
             final ClientStats emptyStats = client.getClientStats();
 
             assertEquals(emptyStats.toString(), "There are 0 total connections, 0 are active and 0 are idle.");
-            assertEquals(emptyStats.getActiveConnectionCount(), 0);
-            assertEquals(emptyStats.getIdleConnectionCount(), 0);
+            assertEquals(emptyStats.getTotalActiveConnectionCount(), 0);
+            assertEquals(emptyStats.getTotalIdleConnectionCount(), 0);
             assertEquals(emptyStats.getTotalConnectionCount(), 0);
+            assertNull(emptyStats.getStatsPerHost().get(hostname));
 
             final List<ListenableFuture<Response>> futures =
                     Stream.generate(() -> client.prepareGet(url).setHeader("LockThread","6").execute())
@@ -127,9 +135,10 @@ public class ClientStatsTest extends AbstractBasicTest {
             final ClientStats activeStats = client.getClientStats();
 
             assertEquals(activeStats.toString(), "There are 5 total connections, 5 are active and 0 are idle.");
-            assertEquals(activeStats.getActiveConnectionCount(), 5);
-            assertEquals(activeStats.getIdleConnectionCount(), 0);
+            assertEquals(activeStats.getTotalActiveConnectionCount(), 5);
+            assertEquals(activeStats.getTotalIdleConnectionCount(), 0);
             assertEquals(activeStats.getTotalConnectionCount(), 5);
+            assertEquals(activeStats.getStatsPerHost().get(hostname).getHostConnectionCount(), 5);
 
             futures.forEach(future -> future.toCompletableFuture().join());
 
@@ -138,9 +147,10 @@ public class ClientStatsTest extends AbstractBasicTest {
             final ClientStats idleStats = client.getClientStats();
 
             assertEquals(idleStats.toString(), "There are 0 total connections, 0 are active and 0 are idle.");
-            assertEquals(idleStats.getActiveConnectionCount(), 0);
-            assertEquals(idleStats.getIdleConnectionCount(), 0);
+            assertEquals(idleStats.getTotalActiveConnectionCount(), 0);
+            assertEquals(idleStats.getTotalIdleConnectionCount(), 0);
             assertEquals(idleStats.getTotalConnectionCount(), 0);
+            assertNull(idleStats.getStatsPerHost().get(hostname));
 
             // Let's make sure the active count is correct when reusing cached connections.
 
@@ -154,9 +164,10 @@ public class ClientStatsTest extends AbstractBasicTest {
             final ClientStats activeCachedStats = client.getClientStats();
 
             assertEquals(activeCachedStats.toString(), "There are 3 total connections, 3 are active and 0 are idle.");
-            assertEquals(activeCachedStats.getActiveConnectionCount(), 3);
-            assertEquals(activeCachedStats.getIdleConnectionCount(), 0);
+            assertEquals(activeCachedStats.getTotalActiveConnectionCount(), 3);
+            assertEquals(activeCachedStats.getTotalIdleConnectionCount(), 0);
             assertEquals(activeCachedStats.getTotalConnectionCount(), 3);
+            assertEquals(activeCachedStats.getStatsPerHost().get(hostname).getHostConnectionCount(), 3);
 
             repeatedFutures.forEach(future -> future.toCompletableFuture().join());
 
@@ -165,9 +176,10 @@ public class ClientStatsTest extends AbstractBasicTest {
             final ClientStats idleCachedStats = client.getClientStats();
 
             assertEquals(idleCachedStats.toString(), "There are 0 total connections, 0 are active and 0 are idle.");
-            assertEquals(idleCachedStats.getActiveConnectionCount(), 0);
-            assertEquals(idleCachedStats.getIdleConnectionCount(), 0);
+            assertEquals(idleCachedStats.getTotalActiveConnectionCount(), 0);
+            assertEquals(idleCachedStats.getTotalIdleConnectionCount(), 0);
             assertEquals(idleCachedStats.getTotalConnectionCount(), 0);
+            assertNull(idleCachedStats.getStatsPerHost().get(hostname));
         }
     }
 }

--- a/client/src/test/java/org/asynchttpclient/ClientStatsTest.java
+++ b/client/src/test/java/org/asynchttpclient/ClientStatsTest.java
@@ -1,0 +1,169 @@
+package org.asynchttpclient;
+
+import static org.asynchttpclient.Dsl.asyncHttpClient;
+import static org.asynchttpclient.Dsl.config;
+import static org.testng.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+/**
+ * Created by grenville on 9/25/16.
+ */
+public class ClientStatsTest extends AbstractBasicTest {
+
+    @Test(groups = "standalone")
+    public void testClientStatus() throws Throwable {
+        try (final DefaultAsyncHttpClient client = (DefaultAsyncHttpClient) asyncHttpClient(config().setKeepAlive(true).setPooledConnectionIdleTimeout(5000))) {
+            final String url = getTargetUrl();
+
+            final ClientStats emptyStats = client.getClientStats();
+
+            assertEquals(emptyStats.toString(), "There are 0 total connections, 0 are active and 0 are idle.");
+            assertEquals(emptyStats.getActiveConnectionCount(), 0);
+            assertEquals(emptyStats.getIdleConnectionCount(), 0);
+            assertEquals(emptyStats.getTotalConnectionCount(), 0);
+
+            final List<ListenableFuture<Response>> futures = new ArrayList<>();
+            for (int i = 0; i < 5; i++) {
+                logger.info("{} requesting url [{}]...", i, url);
+                futures.add(client.prepareGet(url).setHeader("LockThread", "6").execute());
+            }
+
+            Thread.sleep(2000);
+
+            final ClientStats activeStats = client.getClientStats();
+
+            assertEquals(activeStats.toString(), "There are 5 total connections, 5 are active and 0 are idle.");
+            assertEquals(activeStats.getActiveConnectionCount(), 5);
+            assertEquals(activeStats.getIdleConnectionCount(), 0);
+            assertEquals(activeStats.getTotalConnectionCount(), 5);
+
+            for (final ListenableFuture<Response> future : futures) {
+                future.get();
+            }
+
+            Thread.sleep(1000);
+
+            final ClientStats idleStats = client.getClientStats();
+
+            assertEquals(idleStats.toString(), "There are 5 total connections, 0 are active and 5 are idle.");
+            assertEquals(idleStats.getActiveConnectionCount(), 0);
+            assertEquals(idleStats.getIdleConnectionCount(), 5);
+            assertEquals(idleStats.getTotalConnectionCount(), 5);
+
+            // Let's make sure the active count is correct when reusing cached connections.
+
+            final List<ListenableFuture<Response>> repeatedFutures = new ArrayList<>();
+            for (int i = 0; i < 3; i++) {
+                logger.info("{} requesting url [{}]...", i, url);
+                repeatedFutures.add(client.prepareGet(url).setHeader("LockThread", "6").execute());
+            }
+
+            Thread.sleep(2000);
+
+            final ClientStats activeCachedStats = client.getClientStats();
+
+            assertEquals(activeCachedStats.toString(), "There are 5 total connections, 3 are active and 2 are idle.");
+            assertEquals(activeCachedStats.getActiveConnectionCount(), 3);
+            assertEquals(activeCachedStats.getIdleConnectionCount(), 2);
+            assertEquals(activeCachedStats.getTotalConnectionCount(), 5);
+
+            for (final ListenableFuture<Response> future : repeatedFutures) {
+                future.get();
+            }
+
+            Thread.sleep(1000);
+
+            final ClientStats idleCachedStats = client.getClientStats();
+
+            assertEquals(idleCachedStats.toString(), "There are 3 total connections, 0 are active and 3 are idle.");
+            assertEquals(idleCachedStats.getActiveConnectionCount(), 0);
+            assertEquals(idleCachedStats.getIdleConnectionCount(), 3);
+            assertEquals(idleCachedStats.getTotalConnectionCount(), 3);
+
+            Thread.sleep(5000);
+
+            final ClientStats timeoutStats = client.getClientStats();
+
+            assertEquals(timeoutStats.toString(), "There are 0 total connections, 0 are active and 0 are idle.");
+            assertEquals(timeoutStats.getActiveConnectionCount(), 0);
+            assertEquals(timeoutStats.getIdleConnectionCount(), 0);
+            assertEquals(timeoutStats.getTotalConnectionCount(), 0);
+        }
+    }
+
+    @Test(groups = "standalone")
+    public void testClientStatusNoKeepalive() throws Throwable {
+        try (final DefaultAsyncHttpClient client = (DefaultAsyncHttpClient) asyncHttpClient(config().setKeepAlive(false))) {
+            final String url = getTargetUrl();
+
+            final ClientStats emptyStats = client.getClientStats();
+
+            assertEquals(emptyStats.toString(), "There are 0 total connections, 0 are active and 0 are idle.");
+            assertEquals(emptyStats.getActiveConnectionCount(), 0);
+            assertEquals(emptyStats.getIdleConnectionCount(), 0);
+            assertEquals(emptyStats.getTotalConnectionCount(), 0);
+
+            final List<ListenableFuture<Response>> futures = new ArrayList<>();
+            for (int i = 0; i < 5; i++) {
+                logger.info("{} requesting url [{}]...", i, url);
+                futures.add(client.prepareGet(url).setHeader("LockThread", "6").execute());
+            }
+
+            Thread.sleep(2000);
+
+            final ClientStats activeStats = client.getClientStats();
+
+            assertEquals(activeStats.toString(), "There are 5 total connections, 5 are active and 0 are idle.");
+            assertEquals(activeStats.getActiveConnectionCount(), 5);
+            assertEquals(activeStats.getIdleConnectionCount(), 0);
+            assertEquals(activeStats.getTotalConnectionCount(), 5);
+
+            for (final ListenableFuture<Response> future : futures) {
+                future.get();
+            }
+
+            Thread.sleep(1000);
+
+            final ClientStats idleStats = client.getClientStats();
+
+            assertEquals(idleStats.toString(), "There are 0 total connections, 0 are active and 0 are idle.");
+            assertEquals(idleStats.getActiveConnectionCount(), 0);
+            assertEquals(idleStats.getIdleConnectionCount(), 0);
+            assertEquals(idleStats.getTotalConnectionCount(), 0);
+
+            // Let's make sure the active count is correct when reusing cached connections.
+
+            final List<ListenableFuture<Response>> repeatedFutures = new ArrayList<>();
+            for (int i = 0; i < 3; i++) {
+                logger.info("{} requesting url [{}]...", i, url);
+                repeatedFutures.add(client.prepareGet(url).setHeader("LockThread", "6").execute());
+            }
+
+            Thread.sleep(2000);
+
+            final ClientStats activeCachedStats = client.getClientStats();
+
+            assertEquals(activeCachedStats.toString(), "There are 3 total connections, 3 are active and 0 are idle.");
+            assertEquals(activeCachedStats.getActiveConnectionCount(), 3);
+            assertEquals(activeCachedStats.getIdleConnectionCount(), 0);
+            assertEquals(activeCachedStats.getTotalConnectionCount(), 3);
+
+            for (final ListenableFuture<Response> future : repeatedFutures) {
+                future.get();
+            }
+
+            Thread.sleep(1000);
+
+            final ClientStats idleCachedStats = client.getClientStats();
+
+            assertEquals(idleCachedStats.toString(), "There are 0 total connections, 0 are active and 0 are idle.");
+            assertEquals(idleCachedStats.getActiveConnectionCount(), 0);
+            assertEquals(idleCachedStats.getIdleConnectionCount(), 0);
+            assertEquals(idleCachedStats.getTotalConnectionCount(), 0);
+        }
+    }
+}

--- a/client/src/test/java/org/asynchttpclient/test/EchoHandler.java
+++ b/client/src/test/java/org/asynchttpclient/test/EchoHandler.java
@@ -55,8 +55,9 @@ public class EchoHandler extends AbstractHandler {
             param = e.nextElement().toString();
 
             if (param.startsWith("LockThread")) {
+                final int sleepTime = httpRequest.getIntHeader(param);
                 try {
-                    Thread.sleep(40 * 1000);
+                    Thread.sleep(sleepTime == -1 ? 40 : sleepTime * 1000);
                 } catch (InterruptedException ex) {
                 }
             }

--- a/extras/registry/src/test/java/org/asynchttpclient/extras/registry/BadAsyncHttpClient.java
+++ b/extras/registry/src/test/java/org/asynchttpclient/extras/registry/BadAsyncHttpClient.java
@@ -15,6 +15,7 @@ package org.asynchttpclient.extras.registry;
 import org.asynchttpclient.AsyncHandler;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.BoundRequestBuilder;
+import org.asynchttpclient.ClientStats;
 import org.asynchttpclient.AsyncHttpClientConfig;
 import org.asynchttpclient.ListenableFuture;
 import org.asynchttpclient.Request;

--- a/extras/registry/src/test/java/org/asynchttpclient/extras/registry/BadAsyncHttpClient.java
+++ b/extras/registry/src/test/java/org/asynchttpclient/extras/registry/BadAsyncHttpClient.java
@@ -129,6 +129,6 @@ public class BadAsyncHttpClient implements AsyncHttpClient {
 
     @Override
     public ClientStats getClientStats() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 }

--- a/extras/registry/src/test/java/org/asynchttpclient/extras/registry/BadAsyncHttpClient.java
+++ b/extras/registry/src/test/java/org/asynchttpclient/extras/registry/BadAsyncHttpClient.java
@@ -125,4 +125,9 @@ public class BadAsyncHttpClient implements AsyncHttpClient {
     public ListenableFuture<Response> executeRequest(RequestBuilder requestBuilder) {
         return null;
     }
+
+    @Override
+    public ClientStats getClientStats() {
+        return null;
+    }
 }

--- a/extras/registry/src/test/java/org/asynchttpclient/extras/registry/TestAsyncHttpClient.java
+++ b/extras/registry/src/test/java/org/asynchttpclient/extras/registry/TestAsyncHttpClient.java
@@ -125,6 +125,6 @@ public class TestAsyncHttpClient implements AsyncHttpClient {
 
     @Override
     public ClientStats getClientStats() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 }

--- a/extras/registry/src/test/java/org/asynchttpclient/extras/registry/TestAsyncHttpClient.java
+++ b/extras/registry/src/test/java/org/asynchttpclient/extras/registry/TestAsyncHttpClient.java
@@ -15,6 +15,7 @@ package org.asynchttpclient.extras.registry;
 import org.asynchttpclient.AsyncHandler;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.BoundRequestBuilder;
+import org.asynchttpclient.ClientStats;
 import org.asynchttpclient.AsyncHttpClientConfig;
 import org.asynchttpclient.ListenableFuture;
 import org.asynchttpclient.Request;

--- a/extras/registry/src/test/java/org/asynchttpclient/extras/registry/TestAsyncHttpClient.java
+++ b/extras/registry/src/test/java/org/asynchttpclient/extras/registry/TestAsyncHttpClient.java
@@ -122,4 +122,8 @@ public class TestAsyncHttpClient implements AsyncHttpClient {
         return null;
     }
 
+    @Override
+    public ClientStats getClientStats() {
+        return null;
+    }
 }


### PR DESCRIPTION
This is a first crack at addressing that issue, with only information on the total number of connections and how many are active or idle. At the very least, it'd be nice to also see the same data on a per host basis, but I thought I'd get what I've done so far looked at first.
