### PR TITLE
Demote log level on trivial 401 intercept

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ProxyUnauthorized407Interceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ProxyUnauthorized407Interceptor.java
@@ -68,7 +68,7 @@ public class ProxyUnauthorized407Interceptor {
         Realm proxyRealm = future.getProxyRealm();
 
         if (proxyRealm == null) {
-            LOGGER.info("Can't handle 407 as there's no proxyRealm");
+            LOGGER.debug("Can't handle 407 as there's no proxyRealm");
             return false;
         }
 

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Unauthorized401Interceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Unauthorized401Interceptor.java
@@ -64,7 +64,7 @@ public class Unauthorized401Interceptor {
             HttpRequest httpRequest) {
 
         if (realm == null) {
-            LOGGER.info("Can't handle 401 as there's no realm");
+            LOGGER.debug("Can't handle 401 as there's no realm");
             return false;
         }
 


### PR DESCRIPTION
The `Unauthorized401Interceptor` calls the noisy `LOGGER.info()` where trivial 401 responses are involved, i.e. no cause for the interceptor to kick in.

Demotes that particular log message to `debug`, keeping the remaining messages at `info` to retain diagnostic value.
