### PR TITLE
Fixes #1261 Grizzly Provider HttpTransactionContext.getAsyncHandler()…

### DIFF
--- a/src/main/java/com/ning/http/client/providers/grizzly/HttpTransactionContext.java
+++ b/src/main/java/com/ning/http/client/providers/grizzly/HttpTransactionContext.java
@@ -168,7 +168,7 @@ public final class HttpTransactionContext {
     }
     
     public AsyncHandler getAsyncHandler() {
-        return future.getAsyncHandler();
+        return future != null ? future.getAsyncHandler() : null;
     }
     
     Request getAhcRequest() {


### PR DESCRIPTION
… does not handle situation where future is null.
