### PR TITLE
Add built-in support for InputStream body with defined Content-Length

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestFactory.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestFactory.java
@@ -103,7 +103,8 @@ public final class NettyRequestFactory {
                 nettyBody = new NettyFileBody(fileBodyGenerator.getFile(), fileBodyGenerator.getRegionSeek(), fileBodyGenerator.getRegionLength(), config);
 
             } else if (request.getBodyGenerator() instanceof InputStreamBodyGenerator) {
-                nettyBody = new NettyInputStreamBody(InputStreamBodyGenerator.class.cast(request.getBodyGenerator()).getInputStream());
+                InputStreamBodyGenerator inStreamGenerator = InputStreamBodyGenerator.class.cast(request.getBodyGenerator());
+                nettyBody = new NettyInputStreamBody(inStreamGenerator.getInputStream(), inStreamGenerator.getContentLength());
 
             } else if (request.getBodyGenerator() instanceof ReactiveStreamsBodyGenerator) {
                 ReactiveStreamsBodyGenerator reactiveStreamsBodyGenerator = (ReactiveStreamsBodyGenerator)request.getBodyGenerator();

--- a/client/src/main/java/org/asynchttpclient/netty/request/body/NettyInputStreamBody.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/body/NettyInputStreamBody.java
@@ -33,9 +33,15 @@ public class NettyInputStreamBody implements NettyBody {
     private static final Logger LOGGER = LoggerFactory.getLogger(NettyInputStreamBody.class);
 
     private final InputStream inputStream;
+    private final long contentLength;
 
     public NettyInputStreamBody(InputStream inputStream) {
+        this(inputStream, -1L);
+    }
+
+    public NettyInputStreamBody(InputStream inputStream, long contentLength) {
         this.inputStream = inputStream;
+        this.contentLength = contentLength;
     }
 
     public InputStream getInputStream() {
@@ -44,7 +50,7 @@ public class NettyInputStreamBody implements NettyBody {
 
     @Override
     public long getContentLength() {
-        return -1L;
+        return contentLength;
     }
 
     @Override

--- a/client/src/main/java/org/asynchttpclient/request/body/generator/InputStreamBodyGenerator.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/generator/InputStreamBodyGenerator.java
@@ -32,13 +32,23 @@ public final class InputStreamBodyGenerator implements BodyGenerator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(InputStreamBody.class);
     private final InputStream inputStream;
+    private final long contentLength;
 
     public InputStreamBodyGenerator(InputStream inputStream) {
+        this(inputStream, -1L);
+    }
+
+    public InputStreamBodyGenerator(InputStream inputStream, long contentLength) {
         this.inputStream = inputStream;
+        this.contentLength = contentLength;
     }
 
     public InputStream getInputStream() {
         return inputStream;
+    }
+
+    public long getContentLength() {
+        return contentLength;
     }
 
     /**
@@ -46,20 +56,22 @@ public final class InputStreamBodyGenerator implements BodyGenerator {
      */
     @Override
     public Body createBody() {
-        return new InputStreamBody(inputStream);
+        return new InputStreamBody(inputStream, contentLength);
     }
 
     private class InputStreamBody implements Body {
 
         private final InputStream inputStream;
+        private final long contentLength;
         private byte[] chunk;
 
-        private InputStreamBody(InputStream inputStream) {
+        private InputStreamBody(InputStream inputStream, long contentLength) {
             this.inputStream = inputStream;
+            this.contentLength = contentLength;
         }
 
         public long getContentLength() {
-            return -1L;
+            return contentLength;
         }
 
         public BodyState transferTo(ByteBuf target) throws IOException {


### PR DESCRIPTION
Current state:
Hi, now if you pass ```InputStream``` as a body source - you always get request with chunked encoding.

Motivation:
Provide built-in ability to send requests with static ```Content-Length``` if we have fully in-memory ```InputStream``` (like ```ByteArrayInputStream```) + length.

Changes:
Added ```streamContentLength``` field to ```RequestBuilder```s and ```Request``` interface. This field could be used to support requests with ```Content-Length``` for any dynamic lengthed bodies in the future. Added optional field ```contentLength``` to ```NettyInputStreamBody```.
