### PR TITLE
Allow null executor in ListenableFuture

### DIFF
--- a/client/src/main/java/org/asynchttpclient/ListenableFuture.java
+++ b/client/src/main/java/org/asynchttpclient/ListenableFuture.java
@@ -67,6 +67,9 @@ public interface ListenableFuture<V> extends Future<V> {
      * to the executor} for execution when the {@code Future}'s computation is
      * {@linkplain Future#isDone() complete}.
      * <br>
+     * Executor can be <code>null</code>, in that case executor will be executed
+     * in the thread where completion happens.
+     * <br>
      * There is no guaranteed ordering of execution of listeners, they may get
      * called in the order they were added and they may get called out of order,
      * but any listener added through this method is guaranteed to be called once
@@ -131,7 +134,11 @@ public interface ListenableFuture<V> extends Future<V> {
 
         @Override
         public ListenableFuture<T> addListener(Runnable listener, Executor exec) {
-            exec.execute(listener);
+            if (exec != null) {
+                exec.execute(listener);
+            } else {
+                listener.run();
+            }
             return this;
         }
         

--- a/client/src/main/java/org/asynchttpclient/future/ExecutionList.java
+++ b/client/src/main/java/org/asynchttpclient/future/ExecutionList.java
@@ -56,7 +56,6 @@ public final class ExecutionList {
         // Fail fast on a null. We throw NPE here because the contract of Executor states that it
         // throws NPE on null listener, so we propagate that contract up into the add method as well.
         assertNotNull(runnable, "runnable");
-        assertNotNull(executor, "executor");
 
         // Lock while we check state. We must maintain the lock while adding the new pair so that
         // another thread can't run the list out from under us. We only add to the list if we have not
@@ -122,7 +121,11 @@ public final class ExecutionList {
      */
     private static void executeListener(Runnable runnable, Executor executor) {
         try {
-            executor.execute(runnable);
+            if (executor != null) {
+                executor.execute(runnable);
+            } else {
+                runnable.run();
+            }
         } catch (RuntimeException e) {
             // Log it and keep going, bad runnable and/or executor. Don't punish the other runnables if
             // we're given a bad one. We only catch RuntimeException because we want Errors to propagate

--- a/client/src/main/java/org/asynchttpclient/netty/NettyResponseFuture.java
+++ b/client/src/main/java/org/asynchttpclient/netty/NettyResponseFuture.java
@@ -271,12 +271,7 @@ public final class NettyResponseFuture<V> extends AbstractListenableFuture<V> {
                     completable.complete((V) CONTENT_UPDATER.get(NettyResponseFuture.this));
             }
 
-        }, new Executor() {
-            @Override
-            public void execute(Runnable command) {
-                command.run();
-            }
-        });
+        }, null);
 
         return completable;
     }


### PR DESCRIPTION
It allows execution of future callback in completion thread, and
makes `ListenableFuture` closer to `CompletableFuture` (which allows
`null` executor).

It also saves a little memory in `toCompletableFuture` implementation.