### PR TITLE
Replace AtomicBoolean with AtomicFieldUpdater

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ProxyUnauthorized407Interceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ProxyUnauthorized407Interceptor.java
@@ -60,7 +60,7 @@ public class ProxyUnauthorized407Interceptor {
             ProxyServer proxyServer,//
             HttpRequest httpRequest) {
 
-        if (future.getInProxyAuth().getAndSet(true)) {
+        if (future.getAndSetInProxyAuth(true)) {
             LOGGER.info("Can't handle 407 as auth was already performed");
             return false;
         }
@@ -210,7 +210,7 @@ public class ProxyUnauthorized407Interceptor {
             // FIXME we might want to filter current NTLM and add (leave other
             // Authorization headers untouched)
             requestHeaders.set(HttpHeaders.Names.PROXY_AUTHORIZATION, "NTLM " + challengeHeader);
-            future.getInProxyAuth().set(false);
+            future.setInProxyAuth(false);
 
         } else {
             String serverChallenge = authenticateHeader.substring("NTLM ".length()).trim();

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Redirect30xInterceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Redirect30xInterceptor.java
@@ -79,8 +79,8 @@ public class Redirect30xInterceptor {
 
             } else {
                 // We must allow auth handling again.
-                future.getInAuth().set(false);
-                future.getInProxyAuth().set(false);
+                future.setInAuth(false);
+                future.setInProxyAuth(false);
 
                 String originalMethod = request.getMethod();
                 boolean switchToGet = !originalMethod.equals(GET)

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Unauthorized401Interceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Unauthorized401Interceptor.java
@@ -68,7 +68,7 @@ public class Unauthorized401Interceptor {
             return false;
         }
 
-        if (future.getInAuth().getAndSet(true)) {
+        if (future.getAndSetInAuth(true)) {
             LOGGER.info("Can't handle 401 as auth was already performed");
             return false;
         }
@@ -195,7 +195,7 @@ public class Unauthorized401Interceptor {
             // FIXME we might want to filter current NTLM and add (leave other
             // Authorization headers untouched)
             requestHeaders.set(AUTHORIZATION, "NTLM " + challengeHeader);
-            future.getInAuth().set(false);
+            future.setInAuth(false);
 
         } else {
             String serverChallenge = authenticateHeader.substring("NTLM ".length()).trim();

--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
@@ -253,8 +253,8 @@ public final class NettyRequestSender {
         requestFactory.addAuthorizationHeader(headers, perConnectionAuthorizationHeader(request, proxy, realm));
         requestFactory.setProxyAuthorizationHeader(headers, perConnectionProxyAuthorizationHeader(request, proxyRealm));
 
-        future.getInAuth().set(realm != null && realm.isUsePreemptiveAuth() && realm.getScheme() != AuthScheme.NTLM);
-        future.getInProxyAuth().set(proxyRealm != null && proxyRealm.isUsePreemptiveAuth() && proxyRealm.getScheme() != AuthScheme.NTLM);
+        future.setInAuth(realm != null && realm.isUsePreemptiveAuth() && realm.getScheme() != AuthScheme.NTLM);
+        future.setInProxyAuth(proxyRealm != null && proxyRealm.isUsePreemptiveAuth() && proxyRealm.getScheme() != AuthScheme.NTLM);
 
         // Do not throw an exception when we need an extra connection for a redirect
         // FIXME why? This violate the max connection per host handling, right?

--- a/client/src/main/java/org/asynchttpclient/netty/request/WriteListener.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/WriteListener.java
@@ -67,7 +67,7 @@ public abstract class WriteListener {
              * We need to make sure we aren't in the middle of an authorization process before publishing events as we will re-publish again the same event after the authorization,
              * causing unpredictable behavior.
              */
-            boolean startPublishing = !future.getInAuth().get() && !future.getInProxyAuth().get();
+            boolean startPublishing = !future.getInAuth() && !future.getInProxyAuth();
             if (startPublishing) {
                 
                 if (notifyHeaders) {


### PR DESCRIPTION
Avoid unnecessary heap allocations.

Currently in my app I have 100K `AtomicBoolean` objects with 50K more created per second in async-http-client futures. Probably it is not a big deal, but it is better not to allocate anyway.