### PR TITLE
Add some useful API methods

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -59,5 +59,9 @@
 			<artifactId>javassist</artifactId>
 			<version>3.21.0-GA</version>
 		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/client/src/main/java/org/asynchttpclient/RequestBuilderBase.java
+++ b/client/src/main/java/org/asynchttpclient/RequestBuilderBase.java
@@ -15,13 +15,22 @@
  */
 package org.asynchttpclient;
 
-import static org.asynchttpclient.util.HttpUtils.*;
-import static org.asynchttpclient.util.MiscUtils.isNonEmpty;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.resolver.DefaultNameResolver;
 import io.netty.resolver.NameResolver;
 import io.netty.util.concurrent.ImmediateEventExecutor;
+import org.asynchttpclient.channel.ChannelPoolPartitioning;
+import org.asynchttpclient.cookie.Cookie;
+import org.asynchttpclient.proxy.ProxyServer;
+import org.asynchttpclient.request.body.generator.BodyGenerator;
+import org.asynchttpclient.request.body.generator.ReactiveStreamsBodyGenerator;
+import org.asynchttpclient.request.body.multipart.Part;
+import org.asynchttpclient.uri.Uri;
+import org.asynchttpclient.util.UriEncoder;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.InputStream;
@@ -34,17 +43,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.asynchttpclient.channel.ChannelPoolPartitioning;
-import org.asynchttpclient.cookie.Cookie;
-import org.asynchttpclient.proxy.ProxyServer;
-import org.asynchttpclient.request.body.generator.BodyGenerator;
-import org.asynchttpclient.request.body.generator.ReactiveStreamsBodyGenerator;
-import org.asynchttpclient.request.body.multipart.Part;
-import org.asynchttpclient.uri.Uri;
-import org.asynchttpclient.util.UriEncoder;
-import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.asynchttpclient.util.HttpUtils.parseCharset;
+import static org.asynchttpclient.util.HttpUtils.validateSupportedScheme;
+import static org.asynchttpclient.util.MiscUtils.isNonEmpty;
 
 /**
  * Builder for {@link Request}
@@ -194,11 +195,14 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
     public T setHeaders(Map<String, Collection<String>> headers) {
         this.headers.clear();
         if (headers != null) {
-            for (Map.Entry<String, Collection<String>> entry : headers.entrySet()) {
-                String headerName = entry.getKey();
-                this.headers.add(headerName, entry.getValue());
-            }
+            headers.forEach((name, values) -> this.headers.add(name, values));
         }
+        return asDerivedType();
+    }
+
+    public T setSingleHeaders(Map<String, String> headers) {
+        this.headers.clear();
+        headers.forEach((name, value) -> this.headers.add(name, value));
         return asDerivedType();
     }
 

--- a/client/src/main/java/org/asynchttpclient/cookie/Cookie.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/Cookie.java
@@ -12,9 +12,55 @@
  */
 package org.asynchttpclient.cookie;
 
-import static org.asynchttpclient.cookie.CookieUtil.*;
+import static org.asynchttpclient.cookie.CookieUtil.validateCookieAttribute;
+import static org.asynchttpclient.cookie.CookieUtil.validateCookieName;
+import static org.asynchttpclient.cookie.CookieUtil.validateCookieValue;
 
 public class Cookie {
+
+    /**
+     * Method to get a {@link org.asynchttpclient.cookie.Cookie} from {@code javax.servlet} package's {@link javax.servlet.http.Cookie}
+     *
+     * @param cookie base entity to convert
+     * @param wrap true if the value of this {@link Cookie} is to be wrapped with double quotes.
+     * @return converted {@link Cookie}
+     */
+    public static Cookie newCookie(javax.servlet.http.Cookie cookie, boolean wrap) {
+        return new Cookie(cookie.getName(), cookie.getValue(), wrap, cookie.getDomain(), cookie.getPath(), cookie.getMaxAge(), cookie.getSecure(), cookie.isHttpOnly());
+    }
+
+    /**
+     * Method to get a valid {@link org.asynchttpclient.cookie.Cookie} from {@code javax.servlet} package's {@link javax.servlet.http.Cookie}
+     *
+     * @param cookie base entity to convert
+     * @param wrap true if the value of this {@link Cookie} is to be wrapped with double quotes.
+     * @return converted {@link Cookie}
+     * @throws IllegalArgumentException if any part of {@code cookie} is invalid
+     */
+    public static Cookie newValidCookie(javax.servlet.http.Cookie cookie, boolean wrap) {
+        return new Cookie(validateCookieName(cookie.getName()), validateCookieValue(cookie.getValue()), wrap, validateCookieAttribute("domain", cookie.getDomain()), validateCookieAttribute("path", cookie.getPath()), cookie.getMaxAge(), cookie.getSecure(), cookie.isHttpOnly());
+    }
+
+    /**
+     * Method to get a {@link org.asynchttpclient.cookie.Cookie} from Netty's {@link io.netty.handler.codec.http.cookie.Cookie}
+     *
+     * @param cookie base entity to convert
+     * @return converted {@link Cookie}
+     */
+    public static Cookie newCookie(io.netty.handler.codec.http.cookie.Cookie cookie) {
+        return new Cookie(cookie.name(), cookie.value(), cookie.wrap(), cookie.domain(), cookie.path(), cookie.maxAge(), cookie.isSecure(), cookie.isHttpOnly());
+    }
+
+    /**
+     * Method to get a valid {@link org.asynchttpclient.cookie.Cookie} from Netty's {@link io.netty.handler.codec.http.cookie.Cookie}
+     *
+     * @param cookie base entity to convert
+     * @return converted {@link Cookie}
+     * @throws IllegalArgumentException if any part of {@code cookie} is invalid
+     */
+    public static Cookie newValidCookie(io.netty.handler.codec.http.cookie.Cookie cookie) {
+        return new Cookie(validateCookieName(cookie.name()), validateCookieValue(cookie.value()), cookie.wrap(), validateCookieAttribute("domain", cookie.domain()), validateCookieAttribute("path", cookie.path()), cookie.maxAge(), cookie.isSecure(), cookie.isHttpOnly());
+    }
 
     public static Cookie newValidCookie(String name, String value, boolean wrap, String domain, String path, long maxAge, boolean secure, boolean httpOnly) {
         return new Cookie(validateCookieName(name), validateCookieValue(value), wrap, validateCookieAttribute("domain", domain), validateCookieAttribute("path", path), maxAge, secure, httpOnly);
@@ -22,6 +68,9 @@ public class Cookie {
 
     private final String name;
     private final String value;
+    /**
+     * If value should be wrapped with double quotes during serialization
+     */
     private final boolean wrap;
     private final String domain;
     private final String path;
@@ -52,6 +101,9 @@ public class Cookie {
         return value;
     }
 
+    /**
+     * @return true if the value of this {@link Cookie} is to be wrapped with double quotes.
+     */
     public boolean isWrap() {
         return wrap;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,12 @@
 				<version>${netty.version}</version>
 				<optional>true</optional>
 			</dependency>
+			<dependency>
+				<groupId>javax.servlet</groupId>
+				<artifactId>javax.servlet-api</artifactId>
+				<version>${javax.servlet-api.version}</version>
+				<optional>true</optional>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 	<dependencies>
@@ -375,6 +381,7 @@
 		<source.property>1.8</source.property>
 		<target.property>1.8</target.property>
 		<netty.version>4.0.42.Final</netty.version>
+		<javax.servlet-api.version>3.1.0</javax.servlet-api.version>
 		<slf4j.version>1.7.21</slf4j.version>
 		<logback.version>1.1.7</logback.version>
 		<testng.version>6.9.10</testng.version>


### PR DESCRIPTION
Motivation and proposals:

1) Method ```setHeaders(Map<String, Collection<String>> headers)``` is general, but in most cases applications use headers with only one value, so it's good to have a simple method to set them without converting ```Map<String, String>``` to ```Map<String, Collections.singletonList<String>>```.
2) Now if you already have Cookies in some entities from another API's it's a bit annoying to convert them to ```org.asynchttpclient.Cookie``` manually. Expose two helper factory methods set for Netty's and standard ```javax.servlet``` entities.

These methods were implemented as static utils for async-http-client in my project, I think it would be handy to have them out of the box.