### PR TITLE
RxJava Tests: Check for errors before checking for completion.

### DIFF
--- a/extras/rxjava/src/test/java/org/asynchttpclient/extras/rxjava/AsyncHttpObservableTest.java
+++ b/extras/rxjava/src/test/java/org/asynchttpclient/extras/rxjava/AsyncHttpObservableTest.java
@@ -35,8 +35,8 @@ public class AsyncHttpObservableTest {
             o1.subscribe(tester);
             tester.awaitTerminalEvent();
             tester.assertTerminalEvent();
-            tester.assertCompleted();
             tester.assertNoErrors();
+            tester.assertCompleted();
             List<Response> responses = tester.getOnNextEvents();
             assertNotNull(responses);
             assertEquals(responses.size(), 1);
@@ -55,8 +55,8 @@ public class AsyncHttpObservableTest {
             o1.subscribe(tester);
             tester.awaitTerminalEvent();
             tester.assertTerminalEvent();
-            tester.assertCompleted();
             tester.assertNoErrors();
+            tester.assertCompleted();
             List<Response> responses = tester.getOnNextEvents();
             assertNotNull(responses);
             assertEquals(responses.size(), 1);
@@ -75,8 +75,8 @@ public class AsyncHttpObservableTest {
             o1.subscribe(tester);
             tester.awaitTerminalEvent();
             tester.assertTerminalEvent();
-            tester.assertCompleted();
             tester.assertNoErrors();
+            tester.assertCompleted();
             List<Response> responses = tester.getOnNextEvents();
             assertNotNull(responses);
             assertEquals(responses.size(), 1);
@@ -95,8 +95,8 @@ public class AsyncHttpObservableTest {
             o1.subscribe(tester);
             tester.awaitTerminalEvent();
             tester.assertTerminalEvent();
-            tester.assertCompleted();
             tester.assertNoErrors();
+            tester.assertCompleted();
             List<Response> responses = tester.getOnNextEvents();
             assertNotNull(responses);
             assertEquals(responses.size(), 1);
@@ -118,8 +118,8 @@ public class AsyncHttpObservableTest {
             all.subscribe(tester);
             tester.awaitTerminalEvent();
             tester.assertTerminalEvent();
-            tester.assertCompleted();
             tester.assertNoErrors();
+            tester.assertCompleted();
             List<Response> responses = tester.getOnNextEvents();
             assertNotNull(responses);
             assertEquals(responses.size(), 3);

--- a/extras/rxjava/src/test/java/org/asynchttpclient/extras/rxjava/single/AsyncHttpSingleTest.java
+++ b/extras/rxjava/src/test/java/org/asynchttpclient/extras/rxjava/single/AsyncHttpSingleTest.java
@@ -44,7 +44,6 @@ import org.testng.annotations.Test;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import rx.Single;
@@ -99,8 +98,8 @@ public class AsyncHttpSingleTest {
 
         subscriber.awaitTerminalEvent();
         subscriber.assertTerminalEvent();
-        subscriber.assertCompleted();
         subscriber.assertNoErrors();
+        subscriber.assertCompleted();
         subscriber.assertValue(handler);
     }
 
@@ -152,8 +151,8 @@ public class AsyncHttpSingleTest {
 
         subscriber.awaitTerminalEvent();
         subscriber.assertTerminalEvent();
-        subscriber.assertCompleted();
         subscriber.assertNoErrors();
+        subscriber.assertCompleted();
         subscriber.assertValue(handler);
     }
 
@@ -289,13 +288,14 @@ public class AsyncHttpSingleTest {
                             return State.ABORT;
                         }
                     });
+
             underTest.subscribe(subscriber);
-            subscriber.awaitTerminalEvent(30, TimeUnit.SECONDS);
+            subscriber.awaitTerminalEvent();
         }
 
         subscriber.assertTerminalEvent();
-        subscriber.assertCompleted();
         subscriber.assertNoErrors();
+        subscriber.assertCompleted();
         subscriber.assertValue(null);
     }
 


### PR DESCRIPTION
Fixes #1292. All the failing tests make requests to actual websites. Most probably timeouts happened, but since the tests check for completion first, any exceptions produced by the tests didn't show up. By changing the assertion order to check for no errors first, and then for completion, any errors that
are emitted by the tests will be propagated, and not suppressed.