### PR TITLE
Use percent encoding in OAuth according to rfc 5849 section 3.6

### DIFF
--- a/client/src/main/java/org/asynchttpclient/oauth/OAuthSignatureCalculator.java
+++ b/client/src/main/java/org/asynchttpclient/oauth/OAuthSignatureCalculator.java
@@ -182,7 +182,7 @@ public class OAuthSignatureCalculator implements SignatureCalculator {
         return Base64.encode(rawSignature);
     }
 
-    private String constructAuthHeader(String signature, String nonce, long oauthTimestamp) {
+    String constructAuthHeader(String signature, String nonce, long oauthTimestamp) {
         StringBuilder sb = StringUtils.stringBuilder();
         sb.append("OAuth ");
         sb.append(KEY_OAUTH_CONSUMER_KEY).append("=\"").append(consumerAuth.getKey()).append("\", ");
@@ -205,11 +205,11 @@ public class OAuthSignatureCalculator implements SignatureCalculator {
         return sb.toString();
     }
 
-    protected long generateTimestamp() {
+    long generateTimestamp() {
         return System.currentTimeMillis() / 1000L;
     }
 
-    protected String generateNonce() {
+    String generateNonce() {
         byte[] nonceBuffer = NONCE_BUFFER.get();
         ThreadLocalRandom.current().nextBytes(nonceBuffer);
         // let's use base64 encoding over hex, slightly more compact than hex or decimals

--- a/client/src/main/java/org/asynchttpclient/oauth/OAuthSignatureCalculator.java
+++ b/client/src/main/java/org/asynchttpclient/oauth/OAuthSignatureCalculator.java
@@ -92,19 +92,19 @@ public class OAuthSignatureCalculator implements SignatureCalculator {
         OAuthParameterSet allParameters = new OAuthParameterSet(allParametersSize);
 
         // start with standard OAuth parameters we need
-        allParameters.add(KEY_OAUTH_CONSUMER_KEY, Utf8UrlEncoder.encodeQueryElement(consumerAuth.getKey()));
-        allParameters.add(KEY_OAUTH_NONCE, Utf8UrlEncoder.encodeQueryElement(nonce));
+        allParameters.add(KEY_OAUTH_CONSUMER_KEY, Utf8UrlEncoder.percentEncodeQueryElement(consumerAuth.getKey()));
+        allParameters.add(KEY_OAUTH_NONCE, Utf8UrlEncoder.percentEncodeQueryElement(nonce));
         allParameters.add(KEY_OAUTH_SIGNATURE_METHOD, OAUTH_SIGNATURE_METHOD);
         allParameters.add(KEY_OAUTH_TIMESTAMP, String.valueOf(oauthTimestamp));
         if (userAuth.getKey() != null) {
-            allParameters.add(KEY_OAUTH_TOKEN, Utf8UrlEncoder.encodeQueryElement(userAuth.getKey()));
+            allParameters.add(KEY_OAUTH_TOKEN, Utf8UrlEncoder.percentEncodeQueryElement(userAuth.getKey()));
         }
         allParameters.add(KEY_OAUTH_VERSION, OAUTH_VERSION_1_0);
 
         if (formParams != null) {
             for (Param param : formParams) {
                 // formParams are not already encoded
-                allParameters.add(Utf8UrlEncoder.encodeQueryElement(param.getName()), Utf8UrlEncoder.encodeQueryElement(param.getValue()));
+                allParameters.add(Utf8UrlEncoder.percentEncodeQueryElement(param.getName()), Utf8UrlEncoder.percentEncodeQueryElement(param.getValue()));
             }
         }
         if (queryParams != null) {
@@ -164,11 +164,11 @@ public class OAuthSignatureCalculator implements SignatureCalculator {
         StringBuilder sb = StringUtils.stringBuilder();
         sb.append(request.getMethod()); // POST / GET etc (nothing to URL encode)
         sb.append('&');
-        Utf8UrlEncoder.encodeAndAppendQueryElement(sb, baseUrl);
+        Utf8UrlEncoder.encodeAndAppendPercentEncoded(sb, baseUrl);
 
         // and all that needs to be URL encoded (... again!)
         sb.append('&');
-        Utf8UrlEncoder.encodeAndAppendQueryElement(sb, encodedParams);
+        Utf8UrlEncoder.encodeAndAppendPercentEncoded(sb, encodedParams);
         return sb;
     }
 
@@ -193,12 +193,12 @@ public class OAuthSignatureCalculator implements SignatureCalculator {
 
         // careful: base64 has chars that need URL encoding:
         sb.append(KEY_OAUTH_SIGNATURE).append("=\"");
-        Utf8UrlEncoder.encodeAndAppendQueryElement(sb, signature).append("\", ");
+        Utf8UrlEncoder.encodeAndAppendPercentEncoded(sb, signature).append("\", ");
         sb.append(KEY_OAUTH_TIMESTAMP).append("=\"").append(oauthTimestamp).append("\", ");
 
         // also: nonce may contain things that need URL encoding (esp. when using base64):
         sb.append(KEY_OAUTH_NONCE).append("=\"");
-        Utf8UrlEncoder.encodeAndAppendQueryElement(sb, nonce);
+        Utf8UrlEncoder.encodeAndAppendPercentEncoded(sb, nonce);
         sb.append("\", ");
 
         sb.append(KEY_OAUTH_VERSION).append("=\"").append(OAUTH_VERSION_1_0).append("\"");

--- a/client/src/main/java/org/asynchttpclient/util/Utf8UrlEncoder.java
+++ b/client/src/main/java/org/asynchttpclient/util/Utf8UrlEncoder.java
@@ -142,6 +142,16 @@ public final class Utf8UrlEncoder {
         return appendEncoded(sb, input, FORM_URL_ENCODED_SAFE_CHARS, true);
     }
 
+    public static String percentEncodeQueryElement(String input) {
+        StringBuilder sb = new StringBuilder(input.length() + 6);
+        encodeAndAppendPercentEncoded(sb, input);
+        return sb.toString();
+    }
+
+    public static StringBuilder encodeAndAppendPercentEncoded(StringBuilder sb, CharSequence input) {
+        return appendEncoded(sb, input, RFC3986_UNRESERVED_CHARS, false);
+    }
+
     private static StringBuilder lazyInitStringBuilder(CharSequence input, int firstNonUsAsciiPosition) {
         StringBuilder sb = new StringBuilder(input.length() + 6);
         for (int i = 0; i < firstNonUsAsciiPosition; i++) {

--- a/client/src/test/java/org/asynchttpclient/oauth/OAuthSignatureCalculatorTest.java
+++ b/client/src/test/java/org/asynchttpclient/oauth/OAuthSignatureCalculatorTest.java
@@ -309,4 +309,26 @@ public class OAuthSignatureCalculatorTest {
                 + "oauth_version%3D1.0%26"//
                 + "testvalue%3D%252A");
     }
+
+    @Test
+    public void testWithAsteriskInPath() {
+        ConsumerKey consumer = new ConsumerKey("key", "secret");
+        RequestToken user = new RequestToken(null, null);
+        OAuthSignatureCalculator calc = new OAuthSignatureCalculator(consumer, user);
+
+        final Request request = get("http://term.ie/oauth/example/*testpathwithasterisk").build();
+
+        String signatureBaseString = calc.signatureBaseString(//
+                request,//
+                1469019732,//
+                "ZLc92RAkooZcIO/0cctl0Q==").toString();
+
+        assertEquals(signatureBaseString, "GET&" +
+                "http%3A%2F%2Fterm.ie%2Foauth%2Fexample%2F%2Atestpathwithasterisk&" +
+                "oauth_consumer_key%3Dkey%26" +
+                "oauth_nonce%3DZLc92RAkooZcIO%252F0cctl0Q%253D%253D%26" +
+                "oauth_signature_method%3DHMAC-SHA1%26" +
+                "oauth_timestamp%3D1469019732%26" +
+                "oauth_version%3D1.0");
+    }
 }

--- a/client/src/test/java/org/asynchttpclient/oauth/OAuthSignatureCalculatorTest.java
+++ b/client/src/test/java/org/asynchttpclient/oauth/OAuthSignatureCalculatorTest.java
@@ -311,24 +311,20 @@ public class OAuthSignatureCalculatorTest {
     }
 
     @Test
-    public void testWithAsteriskInPath() {
+    public void testSignatureGenerationWithAsteriskInPath() {
         ConsumerKey consumer = new ConsumerKey("key", "secret");
-        RequestToken user = new RequestToken(null, null);
-        OAuthSignatureCalculator calc = new OAuthSignatureCalculator(consumer, user);
+        String someNonce = "6ad17f97334700f3ec2df0631d5b7511";
+        long someTimestamp = 1469019732;
+        String urlWithAsterisksInPath = "http://example.com/oauth/example/*path/wi*th/asterisks*";
 
-        final Request request = get("http://term.ie/oauth/example/*testpathwithasterisk").build();
+        OAuthSignatureCalculator calc = new OAuthSignatureCalculator(consumer, new RequestToken(null, null));
+        final Request request = get(urlWithAsterisksInPath).build();
 
-        String signatureBaseString = calc.signatureBaseString(//
-                request,//
-                1469019732,//
-                "ZLc92RAkooZcIO/0cctl0Q==").toString();
+        String expectedSignature = "cswi/v3ZqhVkTyy5MGqW841BxDA=";
+        String actualSignature = calc.calculateSignature(request, someTimestamp, someNonce);
+        assertEquals(actualSignature, expectedSignature);
 
-        assertEquals(signatureBaseString, "GET&" +
-                "http%3A%2F%2Fterm.ie%2Foauth%2Fexample%2F%2Atestpathwithasterisk&" +
-                "oauth_consumer_key%3Dkey%26" +
-                "oauth_nonce%3DZLc92RAkooZcIO%252F0cctl0Q%253D%253D%26" +
-                "oauth_signature_method%3DHMAC-SHA1%26" +
-                "oauth_timestamp%3D1469019732%26" +
-                "oauth_version%3D1.0");
+        String generatedAuthHeader = calc.constructAuthHeader(actualSignature, someNonce, someTimestamp);
+        assertTrue(generatedAuthHeader.contains("oauth_signature=\"cswi%2Fv3ZqhVkTyy5MGqW841BxDA%3D\""));
     }
 }

--- a/client/src/test/java/org/asynchttpclient/util/TestUTF8UrlCodec.java
+++ b/client/src/test/java/org/asynchttpclient/util/TestUTF8UrlCodec.java
@@ -26,4 +26,12 @@ public class TestUTF8UrlCodec {
         assertEquals(Utf8UrlEncoder.encodeQueryElement("a&b"), "a%26b");
         assertEquals(Utf8UrlEncoder.encodeQueryElement("a+b"), "a%2Bb");
     }
+
+    @Test(groups = "standalone")
+    public void testPercentageEncoding() {
+        assertEquals(Utf8UrlEncoder.percentEncodeQueryElement("foobar"), "foobar");
+        assertEquals(Utf8UrlEncoder.percentEncodeQueryElement("foo*bar"), "foo%2Abar");
+        assertEquals(Utf8UrlEncoder.percentEncodeQueryElement("foo~b_ar"), "foo~b_ar");
+    }
+
 }


### PR DESCRIPTION
The current OAuth signature calculator does not encode path elements with an asterisk correctly.

Eg. the path

/foo/*bar

should be encoded as

/foo/%2Abar

However, the current calculator uses the reserved form charset in its calculation and does not encode asterisks at all. This results in an invalid signature.

This request uses percent encoding according to RFC 5849 section 3.6  for OAuth signature generation in order to to support url paths such as foo/*bar/