### PR TITLE
fixed an integer overflow bug

### DIFF
--- a/src/main/java/com/ning/http/client/multipart/FilePart.java
+++ b/src/main/java/com/ning/http/client/multipart/FilePart.java
@@ -101,7 +101,7 @@ public class FilePart extends AbstractFilePart {
 
         handler.start();
 
-        int length = 0;
+        long length = 0;
 
         length += MultipartUtils.writeBytesToChannel(target, generateFileStart(boundary));
 


### PR DESCRIPTION
when writing large files > 2147483648 bytes, the overflow bug due to the use of an integer instead of a long, causes an exception to be thrown by the caller