### PR TITLE
Fix NPE at getClass().getClassLoader()

### DIFF
--- a/client/src/main/java/org/asynchttpclient/config/AsyncHttpClientConfigHelper.java
+++ b/client/src/main/java/org/asynchttpclient/config/AsyncHttpClientConfigHelper.java
@@ -49,9 +49,12 @@ public class AsyncHttpClientConfigHelper {
                     props.load(is);
                 } else {
                    //Try loading from this class classloader instead, e.g. for OSGi environments.
-                    try(InputStream is2 = this.getClass().getClassLoader().getResourceAsStream(file)) {
-                        if (is2 != null) {
-                            props.load(is2);
+                    ClassLoader classLoader = this.getClass().getClassLoader();
+                    if(classLoader != null) {
+                        try(InputStream is2 = classLoader.getResourceAsStream(file)) {
+                            if (is2 != null) {
+                                props.load(is2);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
I've tried to play with async-http-client in jcstress, but AFAIU it uses bootstrap classloader and creating async-http-client fails with NPE.