### PR TITLE
Less logging for DefaultChannelPool

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/channel/DefaultChannelPool.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/DefaultChannelPool.java
@@ -229,9 +229,9 @@ public final class DefaultChannelPool implements ChannelPool {
                 }
             }
 
-            if (LOGGER.isDebugEnabled()) {
+            if (LOGGER.isTraceEnabled()) {
                 long duration = unpreciseMillisTime() - start;
-                LOGGER.debug("Closed {} connections out of {} in {} ms", closedCount, totalCount, duration);
+                LOGGER.trace("Closed {} connections out of {} in {} ms", closedCount, totalCount, duration);
             }
 
             scheduleNewIdleChannelDetector(timeout.task());


### PR DESCRIPTION
After recent update to `2.1.0-alpha2` my logs were spammed with message:

`DEBUG- Closed 0 connections out of 0 in 0 ms`

I decreased level of logging to `trace` as debug is used often on QA envirnoments and every second prints makes logs really huge on long run.