### PR TITLE
#1369 Support null executor in NettyResponseFuture#addListener

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/NettyResponseFuture.java
+++ b/client/src/main/java/org/asynchttpclient/netty/NettyResponseFuture.java
@@ -256,6 +256,9 @@ public final class NettyResponseFuture<V> implements ListenableFuture<V> {
 
     @Override
     public ListenableFuture<V> addListener(Runnable listener, Executor exec) {
+        if (exec == null) {
+            exec = Runnable::run;
+        }
         future.whenCompleteAsync((r, v) -> listener.run(), exec);
         return this;
     }


### PR DESCRIPTION
Resolves issue #1369 

This is basically the same implementation as Guava's `MoreExecutors#directExecutor`.
