### PR TITLE
Simplify semaphore logic in ChannelManager

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/channel/NonBlockingSemaphore.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/NonBlockingSemaphore.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.netty.channel;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Semaphore-like API, but without blocking.
+ *
+ * @author Stepan Koltsov
+ */
+class NonBlockingSemaphore implements NonBlockingSemaphoreLike {
+
+    private final AtomicInteger permits;
+
+    public NonBlockingSemaphore(int permits) {
+        this.permits = new AtomicInteger(permits);
+    }
+
+    @Override
+    public void release() {
+        permits.incrementAndGet();
+    }
+
+    @Override
+    public boolean tryAcquire() {
+        for (;;) {
+            int count = permits.get();
+            if (count <= 0) {
+                return false;
+            }
+            if (permits.compareAndSet(count, count - 1)) {
+                return true;
+            }
+        }
+    }
+}

--- a/client/src/main/java/org/asynchttpclient/netty/channel/NonBlockingSemaphoreInfinite.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/NonBlockingSemaphoreInfinite.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2017 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.netty.channel;
+
+/**
+ * Non-blocking semaphore-like object with infinite permits.
+ *
+ * So try-acquire always succeeds.
+ *
+ * @author Stepan Koltsov
+ */
+enum NonBlockingSemaphoreInfinite implements NonBlockingSemaphoreLike {
+    INSTANCE;
+
+    @Override
+    public void release() {
+    }
+
+    @Override
+    public boolean tryAcquire() {
+        return true;
+    }
+}

--- a/client/src/main/java/org/asynchttpclient/netty/channel/NonBlockingSemaphoreLike.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/NonBlockingSemaphoreLike.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2017 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.netty.channel;
+
+/**
+ * Non-blocking semaphore API.
+ *
+ * @author Stepan Koltsov
+ */
+interface NonBlockingSemaphoreLike {
+    void release();
+
+    boolean tryAcquire();
+}

--- a/client/src/test/java/org/asynchttpclient/netty/channel/NonBlockingSemaphoreTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/channel/NonBlockingSemaphoreTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2017 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.netty.channel;
+
+import java.util.concurrent.Semaphore;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+/**
+ * @author Stepan Koltsov
+ */
+public class NonBlockingSemaphoreTest {
+
+    private static class Mirror {
+        private final Semaphore real;
+        private final NonBlockingSemaphore nonBlocking;
+
+        public Mirror(int permits) {
+            real = new Semaphore(permits);
+            nonBlocking = new NonBlockingSemaphore(permits);
+        }
+
+        public boolean tryAcquire() {
+            boolean a = real.tryAcquire();
+            boolean b = nonBlocking.tryAcquire();
+            assertEquals(a, b);
+            return a;
+        }
+
+        public void release() {
+            real.release();
+            nonBlocking.release();
+        }
+    }
+
+    @Test
+    public void test0() {
+        Mirror mirror = new Mirror(0);
+        assertFalse(mirror.tryAcquire());
+    }
+
+    @Test
+    public void three() {
+        Mirror mirror = new Mirror(3);
+        for (int i = 0; i < 3; ++i) {
+            assertTrue(mirror.tryAcquire());
+        }
+        assertFalse(mirror.tryAcquire());
+        mirror.release();
+        assertTrue(mirror.tryAcquire());
+    }
+
+    @Test
+    public void negative() {
+        Mirror mirror = new Mirror(-1);
+        assertFalse(mirror.tryAcquire());
+        mirror.release();
+        assertFalse(mirror.tryAcquire());
+        mirror.release();
+        assertTrue(mirror.tryAcquire());
+    }
+
+}


### PR DESCRIPTION
* avoid using `java.util.concurrent.Semaphore` which is blocking,
  and its blocking part is not used, which is confusing.
* Use `NonBlockingSemaphoreInfinite` to avoid nulls and ifs
  when connection count is not limited.