### PR TITLE
Tie connection counter to the future/channel

### DIFF
--- a/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClient.java
+++ b/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClient.java
@@ -30,6 +30,7 @@ import org.asynchttpclient.filter.FilterException;
 import org.asynchttpclient.filter.RequestFilter;
 import org.asynchttpclient.handler.resumable.ResumableAsyncHandler;
 import org.asynchttpclient.netty.channel.ChannelManager;
+import org.asynchttpclient.netty.channel.ConnectionSemaphore;
 import org.asynchttpclient.netty.request.NettyRequestSender;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +44,7 @@ public class DefaultAsyncHttpClient implements AsyncHttpClient {
     private final AsyncHttpClientConfig config;
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final ChannelManager channelManager;
+    private final ConnectionSemaphore connectionSemaphore;
     private final NettyRequestSender requestSender;
     private final boolean allowStopNettyTimer;
     private final Timer nettyTimer;
@@ -84,7 +86,8 @@ public class DefaultAsyncHttpClient implements AsyncHttpClient {
         nettyTimer = allowStopNettyTimer ? newNettyTimer() : config.getNettyTimer();
 
         channelManager = new ChannelManager(config, nettyTimer);
-        requestSender = new NettyRequestSender(config, channelManager, nettyTimer, new AsyncHttpClientState(closed));
+        connectionSemaphore = new ConnectionSemaphore(config);
+        requestSender = new NettyRequestSender(config, channelManager, connectionSemaphore, nettyTimer, new AsyncHttpClientState(closed));
         channelManager.configureBootstraps(requestSender);
     }
 

--- a/client/src/main/java/org/asynchttpclient/netty/channel/ConnectionSemaphore.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/ConnectionSemaphore.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2017 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.netty.channel;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.asynchttpclient.AsyncHttpClientConfig;
+import org.asynchttpclient.exception.PoolAlreadyClosedException;
+import org.asynchttpclient.exception.TooManyConnectionsException;
+import org.asynchttpclient.exception.TooManyConnectionsPerHostException;
+
+import static io.netty.util.internal.ThrowableUtil.unknownStackTrace;
+
+/**
+ * Max connections and max-per-host connections limiter.
+ *
+ * @author Stepan Koltsov
+ */
+public class ConnectionSemaphore {
+
+    private final int maxTotalConnections;
+    private final NonBlockingSemaphoreLike freeChannels;
+    private final int maxConnectionsPerHost;
+    private final ConcurrentHashMap<Object, NonBlockingSemaphore> freeChannelsPerHost = new ConcurrentHashMap<>();
+
+    private final IOException tooManyConnections;
+    private final IOException tooManyConnectionsPerHost;
+
+    public ConnectionSemaphore(AsyncHttpClientConfig config) {
+        tooManyConnections = unknownStackTrace(new TooManyConnectionsException(config.getMaxConnections()), ConnectionSemaphore.class, "acquireChannelLock");
+        tooManyConnectionsPerHost = unknownStackTrace(new TooManyConnectionsPerHostException(config.getMaxConnectionsPerHost()), ConnectionSemaphore.class, "acquireChannelLock");
+        maxTotalConnections = config.getMaxConnections();
+        maxConnectionsPerHost = config.getMaxConnectionsPerHost();
+
+        freeChannels = maxTotalConnections > 0 ?
+                new NonBlockingSemaphore(config.getMaxConnections()) :
+                NonBlockingSemaphoreInfinite.INSTANCE;
+    }
+
+    private boolean tryAcquireGlobal() {
+        return freeChannels.tryAcquire();
+    }
+
+    private NonBlockingSemaphoreLike getFreeConnectionsForHost(Object partitionKey) {
+        return maxConnectionsPerHost > 0 ?
+                freeChannelsPerHost.computeIfAbsent(partitionKey, pk -> new NonBlockingSemaphore(maxConnectionsPerHost)) :
+                NonBlockingSemaphoreInfinite.INSTANCE;
+    }
+
+    private boolean tryAcquirePerHost(Object partitionKey) {
+        return getFreeConnectionsForHost(partitionKey).tryAcquire();
+    }
+
+    public void acquireChannelLock(Object partitionKey) throws IOException {
+        if (!tryAcquireGlobal())
+            throw tooManyConnections;
+        if (!tryAcquirePerHost(partitionKey)) {
+            freeChannels.release();
+
+            throw tooManyConnectionsPerHost;
+        }
+    }
+
+    public void releaseChannelLock(Object partitionKey) {
+        freeChannels.release();
+        getFreeConnectionsForHost(partitionKey).release();
+    }
+}

--- a/client/src/test/java/org/asynchttpclient/netty/NettyResponseFutureTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/NettyResponseFutureTest.java
@@ -28,7 +28,7 @@ public class NettyResponseFutureTest {
     @Test
     public void testCancel() {
         AsyncHandler<?> asyncHandler = mock(AsyncHandler.class);
-        NettyResponseFuture<?> nettyResponseFuture = new NettyResponseFuture<>(null, asyncHandler, null, 3, null, null);
+        NettyResponseFuture<?> nettyResponseFuture = new NettyResponseFuture<>(null, asyncHandler, null, 3, null, null, null);
         boolean result = nettyResponseFuture.cancel(false);
         verify(asyncHandler).onThrowable(anyObject());
         assertTrue(result, "Cancel should return true if the Future was cancelled successfully");
@@ -38,7 +38,7 @@ public class NettyResponseFutureTest {
     @Test
     public void testCancelOnAlreadyCancelled() {
         AsyncHandler<?> asyncHandler = mock(AsyncHandler.class);
-        NettyResponseFuture<?> nettyResponseFuture = new NettyResponseFuture<>(null, asyncHandler, null, 3, null, null);
+        NettyResponseFuture<?> nettyResponseFuture = new NettyResponseFuture<>(null, asyncHandler, null, 3, null, null, null);
         nettyResponseFuture.cancel(false);
         boolean result = nettyResponseFuture.cancel(false);
         assertFalse(result, "cancel should return false for an already cancelled Future");
@@ -48,7 +48,7 @@ public class NettyResponseFutureTest {
     @Test(expectedExceptions = CancellationException.class)
     public void testGetContentThrowsCancellationExceptionIfCancelled() throws InterruptedException, ExecutionException {
         AsyncHandler<?> asyncHandler = mock(AsyncHandler.class);
-        NettyResponseFuture<?> nettyResponseFuture = new NettyResponseFuture<>(null, asyncHandler, null, 3, null, null);
+        NettyResponseFuture<?> nettyResponseFuture = new NettyResponseFuture<>(null, asyncHandler, null, 3, null, null, null);
         nettyResponseFuture.cancel(false);
         nettyResponseFuture.get();
         fail("A CancellationException must have occurred by now as 'cancel' was called before 'get'");
@@ -60,7 +60,7 @@ public class NettyResponseFutureTest {
         AsyncHandler<Object> asyncHandler = mock(AsyncHandler.class);
         Object value = new Object();
         when(asyncHandler.onCompleted()).thenReturn(value);
-        NettyResponseFuture<?> nettyResponseFuture = new NettyResponseFuture<>(null, asyncHandler, null, 3, null, null);
+        NettyResponseFuture<?> nettyResponseFuture = new NettyResponseFuture<>(null, asyncHandler, null, 3, null, null, null);
         nettyResponseFuture.done();
         Object result = nettyResponseFuture.get();
         assertEquals(result, value, "The Future should return the value given by asyncHandler#onCompleted");
@@ -70,7 +70,7 @@ public class NettyResponseFutureTest {
     public void testGetThrowsExceptionThrownByAsyncHandler() throws Exception {
         AsyncHandler<?> asyncHandler = mock(AsyncHandler.class);
         when(asyncHandler.onCompleted()).thenThrow(new RuntimeException());
-        NettyResponseFuture<?> nettyResponseFuture = new NettyResponseFuture<>(null, asyncHandler, null, 3, null, null);
+        NettyResponseFuture<?> nettyResponseFuture = new NettyResponseFuture<>(null, asyncHandler, null, 3, null, null, null);
         nettyResponseFuture.done();
         nettyResponseFuture.get();
         fail("An ExecutionException must have occurred by now as asyncHandler threw an exception in 'onCompleted'");
@@ -79,7 +79,7 @@ public class NettyResponseFutureTest {
     @Test(expectedExceptions = ExecutionException.class)
     public void testGetThrowsExceptionOnAbort() throws InterruptedException, ExecutionException {
         AsyncHandler<?> asyncHandler = mock(AsyncHandler.class);
-        NettyResponseFuture<?> nettyResponseFuture = new NettyResponseFuture<>(null, asyncHandler, null, 3, null, null);
+        NettyResponseFuture<?> nettyResponseFuture = new NettyResponseFuture<>(null, asyncHandler, null, 3, null, null, null);
         nettyResponseFuture.abort(new RuntimeException());
         nettyResponseFuture.get();
         fail("An ExecutionException must have occurred by now as 'abort' was called before 'get'");


### PR DESCRIPTION
Instead of manually tracking where connection counter should be
released, just do it when future becomes done or connection becomes
closed.

I believe, code is safer against leaks this way.