### PR TITLE
Fix NullPointerException in NTLM auth

### DIFF
--- a/client/src/main/java/org/asynchttpclient/ntlm/NtlmEngine.java
+++ b/client/src/main/java/org/asynchttpclient/ntlm/NtlmEngine.java
@@ -150,12 +150,12 @@ public final class NtlmEngine {
 
     /** Convert host to standard form */
     private static String convertHost(final String host) {
-        return stripDotSuffix(host).toUpperCase();
+        return host != null ? stripDotSuffix(host).toUpperCase() : null;
     }
 
     /** Convert domain to standard form */
     private static String convertDomain(final String domain) {
-        return stripDotSuffix(domain).toUpperCase();
+        return domain != null ? stripDotSuffix(domain).toUpperCase() : null;
     }
 
     private static int readULong(final byte[] src, final int index) throws NtlmEngineException {


### PR DESCRIPTION
I'm getting an NPE after upgrading to version 2.0.24.

Workaround is to set the system property `http.auth.ntlm.domain` to a valid domain, or even empty string.

Introduced by #1185.
```
java.lang.NullPointerException: null
    at org.asynchttpclient.ntlm.NtlmEngine.convertDomain(NtlmEngine.java:158)
    at org.asynchttpclient.ntlm.NtlmEngine.access$1800(NtlmEngine.java:52)
    at org.asynchttpclient.ntlm.NtlmEngine$Type3Message.<init>(NtlmEngine.java:1079)
    at org.asynchttpclient.ntlm.NtlmEngine.getType3Message(NtlmEngine.java:136)
    at org.asynchttpclient.ntlm.NtlmEngine.generateType3Msg(NtlmEngine.java:1529)
    at org.asynchttpclient.netty.handler.intercept.Unauthorized401Interceptor.ntlmChallenge(Unauthorized401Interceptor.java:202)
    at org.asynchttpclient.netty.handler.intercept.Unauthorized401Interceptor.exitAfterHandling401(Unauthorized401Interceptor.java:133)
    at org.asynchttpclient.netty.handler.intercept.Interceptors.exitAfterIntercept(Interceptors.java:77)
    at org.asynchttpclient.netty.handler.HttpHandler.handleHttpResponse(HttpHandler.java:130)
    at org.asynchttpclient.netty.handler.HttpHandler.handleRead(HttpHandler.java:184)
    at org.asynchttpclient.netty.handler.AsyncHttpClientHandler.channelRead(AsyncHttpClientHandler.java:76)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:367)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:353)
    at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:346)
    at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:86)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:367)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:353)
    at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:346)
    at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:102)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:367)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:353)
    at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:346)
    at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:435)
    at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:293)
    at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:280)
    at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:396)
    at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:248)
    at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:250)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:367)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:353)
    at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:346)
    at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1294)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:367)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:353)
    at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:911)
    at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:131)
    at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:652)
    at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:575)
    at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:489)
    at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:451)
    at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:140)
    at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:144)
    at java.lang.Thread.run(Thread.java:745)
```