### PR TITLE
Handle onTrailingHeadersReceived in AHC extras for RxJava 1 and 2

### DIFF
--- a/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/single/AbstractSingleSubscriberBridge.java
+++ b/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/single/AbstractSingleSubscriberBridge.java
@@ -57,6 +57,11 @@ abstract class AbstractSingleSubscriberBridge<T> implements AsyncHandler<Void> {
     }
 
     @Override
+    public State onTrailingHeadersReceived(HttpHeaders headers) throws Exception {
+        return subscriber.isUnsubscribed() ? abort() : delegate().onTrailingHeadersReceived(headers);
+    }
+
+    @Override
     public Void onCompleted() {
         if (delegateTerminated.getAndSet(true)) {
             return null;

--- a/extras/rxjava/src/test/java/org/asynchttpclient/extras/rxjava/single/AsyncHttpSingleTest.java
+++ b/extras/rxjava/src/test/java/org/asynchttpclient/extras/rxjava/single/AsyncHttpSingleTest.java
@@ -82,6 +82,9 @@ public class AsyncHttpSingleTest {
                 bridge.onBodyPartReceived(null);
                 verify(handler).onBodyPartReceived(null);
 
+                bridge.onTrailingHeadersReceived(null);
+                verify(handler).onTrailingHeadersReceived(null);
+
                 bridge.onCompleted();
                 verify(handler).onCompleted();
             } catch (final Throwable t) {
@@ -134,6 +137,9 @@ public class AsyncHttpSingleTest {
 
                 progressBridge.onBodyPartReceived(null);
                 inOrder.verify(handler).onBodyPartReceived(null);
+
+                bridge.onTrailingHeadersReceived(null);
+                verify(handler).onTrailingHeadersReceived(null);
 
                 progressBridge.onCompleted();
                 inOrder.verify(handler).onCompleted();

--- a/extras/rxjava2/src/main/java/org/asynchttpclient/extras/rxjava2/maybe/AbstractMaybeAsyncHandlerBridge.java
+++ b/extras/rxjava2/src/main/java/org/asynchttpclient/extras/rxjava2/maybe/AbstractMaybeAsyncHandlerBridge.java
@@ -81,6 +81,11 @@ public abstract class AbstractMaybeAsyncHandlerBridge<T> implements AsyncHandler
         return emitter.isDisposed() ? disposed() : delegate().onHeadersReceived(headers);
     }
 
+    @Override
+    public State onTrailingHeadersReceived(HttpHeaders headers) throws Exception {
+        return emitter.isDisposed() ? disposed() : delegate().onTrailingHeadersReceived(headers);
+    }
+
     /**
      * {@inheritDoc}
      *

--- a/extras/rxjava2/src/test/java/org/asynchttpclient/extras/rxjava2/maybe/AbstractMaybeAsyncHandlerBridgeTest.java
+++ b/extras/rxjava2/src/test/java/org/asynchttpclient/extras/rxjava2/maybe/AbstractMaybeAsyncHandlerBridgeTest.java
@@ -92,6 +92,9 @@ public class AbstractMaybeAsyncHandlerBridgeTest {
         /* when */ underTest.onBodyPartReceived(bodyPart);
         then(delegate).should(times(2)).onBodyPartReceived(bodyPart);
 
+        /* when */ underTest.onTrailingHeadersReceived(headers);
+        then(delegate).should().onTrailingHeadersReceived(headers);
+
         /* when */ underTest.onCompleted();
         then(delegate).should().onCompleted();
         then(emitter).should().onSuccess(this);
@@ -199,6 +202,7 @@ public class AbstractMaybeAsyncHandlerBridgeTest {
                 { named("onStatusReceived", () -> underTest.onStatusReceived(status)) }, //
                 { named("onHeadersReceived", () -> underTest.onHeadersReceived(headers)) }, //
                 { named("onBodyPartReceived", () -> underTest.onBodyPartReceived(bodyPart)) }, //
+                { named("onTrailingHeadersReceived", () -> underTest.onTrailingHeadersReceived(headers)) }, //
         };
     }
 


### PR DESCRIPTION
Override default implementation and forward it to delegates, add tests.