### PR TITLE
Fix broken Head302Test

### DIFF
--- a/client/src/test/java/org/asynchttpclient/Head302Test.java
+++ b/client/src/test/java/org/asynchttpclient/Head302Test.java
@@ -16,6 +16,7 @@
 package org.asynchttpclient;
 
 import static org.asynchttpclient.Dsl.*;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 import java.io.IOException;
@@ -54,6 +55,8 @@ public class Head302Test extends AbstractBasicTest {
             } else { // this handler is to handle HEAD request
                 response.setStatus(HttpServletResponse.SC_FORBIDDEN);
             }
+
+            r.setHandled(true);
         }
     }
 
@@ -64,11 +67,12 @@ public class Head302Test extends AbstractBasicTest {
 
     @Test(groups = "standalone")
     public void testHEAD302() throws IOException, BrokenBarrierException, InterruptedException, ExecutionException, TimeoutException {
-        try (AsyncHttpClient client = asyncHttpClient()) {
+        AsyncHttpClientConfig clientConfig = new DefaultAsyncHttpClientConfig.Builder().setFollowRedirect(true).build();
+        try (AsyncHttpClient client = asyncHttpClient(clientConfig)) {
             final CountDownLatch l = new CountDownLatch(1);
             Request request = head("http://localhost:" + port1 + "/Test").build();
 
-            client.executeRequest(request, new AsyncCompletionHandlerBase() {
+            Response response = client.executeRequest(request, new AsyncCompletionHandlerBase() {
                 @Override
                 public Response onCompleted(Response response) throws Exception {
                     l.countDown();
@@ -79,6 +83,8 @@ public class Head302Test extends AbstractBasicTest {
             if (!l.await(TIMEOUT, TimeUnit.SECONDS)) {
                 fail("Timeout out");
             }
+
+            assertEquals(response.getStatusCode(), HttpServletResponse.SC_OK);
         }
     }
 }


### PR DESCRIPTION
I was originally going to report a bug that my HEAD requests were being switched to GET upon a 301 redirect.  Then I came across #989 and learned that this behavior is by design. :smile:

However, before I discovered that issue, I was playing around with `Head302Test` because it seemed to confirm my impression that the HEAD method should be preserved upon a redirect.  It was at this time that I discovered this test was falsely passing.

I first updated the test to demonstrate that it actually fails.  Then I modified it to conform to the behavior described in #989 so that it now passes.  This PR captures both of these changes.