### PR TITLE
Allow SSLEngineFactory to be customized at the request level

### DIFF
--- a/client/src/main/java/org/asynchttpclient/DefaultRequest.java
+++ b/client/src/main/java/org/asynchttpclient/DefaultRequest.java
@@ -61,6 +61,7 @@ public class DefaultRequest implements Request {
     private final Charset charset;
     private final ChannelPoolPartitioning channelPoolPartitioning;
     private final NameResolver<InetAddress> nameResolver;
+    private final SslEngineFactory sslEngineFactory;
     // lazily loaded
     private List<Param> queryParams;
 
@@ -88,7 +89,8 @@ public class DefaultRequest implements Request {
             long rangeOffset,//
             Charset charset,//
             ChannelPoolPartitioning channelPoolPartitioning,//
-            NameResolver<InetAddress> nameResolver) {
+            NameResolver<InetAddress> nameResolver,
+            SslEngineFactory sslEngineFactory) {
         this.method = method;
         this.uri = uri;
         this.address = address;
@@ -114,6 +116,7 @@ public class DefaultRequest implements Request {
         this.charset = charset;
         this.channelPoolPartitioning = channelPoolPartitioning;
         this.nameResolver = nameResolver;
+        this.sslEngineFactory = sslEngineFactory;
     }
 
     @Override
@@ -244,6 +247,11 @@ public class DefaultRequest implements Request {
     @Override
     public NameResolver<InetAddress> getNameResolver() {
         return nameResolver;
+    }
+
+    @Override
+    public SslEngineFactory getSslEngineFactory() {
+        return sslEngineFactory;
     }
 
     @Override

--- a/client/src/main/java/org/asynchttpclient/Request.java
+++ b/client/src/main/java/org/asynchttpclient/Request.java
@@ -182,4 +182,9 @@ public interface Request {
      * @return the NameResolver to be used to resolve hostnams's IP
      */
     NameResolver<InetAddress> getNameResolver();
+
+    /**
+     * @return the SSLEngineFactory. Non null values means "override config value".
+     */
+    SslEngineFactory getSslEngineFactory();
 }

--- a/client/src/main/java/org/asynchttpclient/RequestBuilderBase.java
+++ b/client/src/main/java/org/asynchttpclient/RequestBuilderBase.java
@@ -92,6 +92,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
     protected Charset charset;
     protected ChannelPoolPartitioning channelPoolPartitioning = ChannelPoolPartitioning.PerHostChannelPoolPartitioning.INSTANCE;
     protected NameResolver<InetAddress> nameResolver = DEFAULT_NAME_RESOLVER;
+    protected SslEngineFactory sslEngineFactory = null; // Overrides client-level SslEngineFactory if specified.
 
     protected RequestBuilderBase(String method, boolean disableUrlEncoding) {
         this(method, disableUrlEncoding, true);
@@ -533,6 +534,11 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
         return asDerivedType();
     }
 
+    public T setSslEngineFactory(SslEngineFactory sslEngineFactory) {
+        this.sslEngineFactory = sslEngineFactory;
+        return asDerivedType();
+    }
+
     public T setSignatureCalculator(SignatureCalculator signatureCalculator) {
         this.signatureCalculator = signatureCalculator;
         return asDerivedType();
@@ -579,6 +585,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
         rb.charset = this.charset;
         rb.channelPoolPartitioning = this.channelPoolPartitioning;
         rb.nameResolver = this.nameResolver;
+        rb.sslEngineFactory = this.sslEngineFactory;
         Request unsignedRequest = rb.build();
         signatureCalculator.calculateAndAddSignature(unsignedRequest, rb);
         return rb;
@@ -652,6 +659,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
                 rb.rangeOffset,//
                 finalCharset,//
                 rb.channelPoolPartitioning,//
-                rb.nameResolver);
+                rb.nameResolver,
+                rb.sslEngineFactory);
     }
 }

--- a/client/src/main/java/org/asynchttpclient/netty/channel/NettyConnectListener.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/NettyConnectListener.java
@@ -25,6 +25,7 @@ import java.net.InetSocketAddress;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import org.asynchttpclient.Request;
+import org.asynchttpclient.SslEngineFactory;
 import org.asynchttpclient.handler.AsyncHandlerExtensions;
 import org.asynchttpclient.netty.NettyResponseFuture;
 import org.asynchttpclient.netty.SimpleFutureListener;
@@ -47,17 +48,20 @@ public final class NettyConnectListener<T> {
     private final ChannelManager channelManager;
     private final ConnectionSemaphore connectionSemaphore;
     private final Object partitionKey;
+    private final SslEngineFactory sslEngineFactory;
 
     public NettyConnectListener(NettyResponseFuture<T> future,//
             NettyRequestSender requestSender,//
             ChannelManager channelManager,//
             ConnectionSemaphore connectionSemaphore,//
-            Object partitionKey) {
+            Object partitionKey,
+            SslEngineFactory sslEngineFactory) {
         this.future = future;
         this.requestSender = requestSender;
         this.channelManager = channelManager;
         this.connectionSemaphore = connectionSemaphore;
         this.partitionKey = partitionKey;
+        this.sslEngineFactory = sslEngineFactory;
     }
 
     private boolean futureIsAlreadyCancelled(Channel channel) {
@@ -120,7 +124,7 @@ public final class NettyConnectListener<T> {
         if (future.getProxyServer() == null && uri.isSecured()) {
             SslHandler sslHandler = null;
             try {
-                sslHandler = channelManager.addSslHandler(channel.pipeline(), uri, request.getVirtualHost());
+                sslHandler = channelManager.addSslHandler(channel.pipeline(), uri, request.getVirtualHost(), sslEngineFactory);
             } catch (Exception sslError) {
                 onFailure(channel, sslError);
                 return;

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ConnectSuccessInterceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ConnectSuccessInterceptor.java
@@ -54,7 +54,7 @@ public class ConnectSuccessInterceptor {
         Uri requestUri = request.getUri();
         LOGGER.debug("Connecting to proxy {} for scheme {}", proxyServer, requestUri.getScheme());
 
-        channelManager.upgradeProtocol(channel.pipeline(), requestUri);
+        channelManager.upgradeProtocol(channel.pipeline(), requestUri, request.getSslEngineFactory());
         future.setReuseChannel(true);
         future.setConnectAllowed(false);
         requestSender.drainChannelAndExecuteNextRequest(channel, future, new RequestBuilder(future.getTargetRequest()).build());

--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
@@ -307,7 +307,7 @@ public final class NettyRequestSender {
 
                     @Override
                     protected void onSuccess(List<InetSocketAddress> addresses) {
-                        NettyConnectListener<T> connectListener = new NettyConnectListener<>(future, NettyRequestSender.this, channelManager, connectionSemaphore, partitionKey);
+                        NettyConnectListener<T> connectListener = new NettyConnectListener<>(future, NettyRequestSender.this, channelManager, connectionSemaphore, partitionKey, request.getSslEngineFactory());
                         NettyChannelConnector connector = new NettyChannelConnector(request.getLocalAddress(), addresses, asyncHandler, clientState, config);
                         if (!future.isDone()) {
                             connector.connect(bootstrap, connectListener);


### PR DESCRIPTION
Someone was looking for such functionality a long time ago: https://groups.google.com/forum/#!topic/asynchttpclient/7vxcOxeerjo, and I have worked on projects where such functionality can be useful so I have take this upon myself to add support for customizing the SSLEngineFactory on a per request basis. The approach that I have taken is intended to be non-intrusive (existing code logic remain the same if SSLEngineFactory is not specified at the request level) but suggestions on how to better organize the injection of the request-specific SSLEngineFactory are welcome.