### PR TITLE
Support of 308 HTTP Status

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Redirect30xInterceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Redirect30xInterceptor.java
@@ -50,6 +50,7 @@ public class Redirect30xInterceptor {
         REDIRECT_STATUSES.add(FOUND_302);
         REDIRECT_STATUSES.add(SEE_OTHER_303);
         REDIRECT_STATUSES.add(TEMPORARY_REDIRECT_307);
+        REDIRECT_STATUSES.add(PERMANENT_REDIRECT_308);
     }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Redirect30xInterceptor.class);
@@ -87,7 +88,7 @@ public class Redirect30xInterceptor {
                 String originalMethod = request.getMethod();
                 boolean switchToGet = !originalMethod.equals(GET)
                         && (statusCode == MOVED_PERMANENTLY_301 || statusCode == SEE_OTHER_303 || (statusCode == FOUND_302 && !config.isStrict302Handling()));
-                boolean keepBody = statusCode == TEMPORARY_REDIRECT_307 || (statusCode == FOUND_302 && config.isStrict302Handling());
+                boolean keepBody = statusCode == TEMPORARY_REDIRECT_307 || statusCode == PERMANENT_REDIRECT_308 || (statusCode == FOUND_302 && config.isStrict302Handling());
 
                 final RequestBuilder requestBuilder = new RequestBuilder(switchToGet ? GET : originalMethod)//
                         .setCookies(request.getCookies())//

--- a/client/src/main/java/org/asynchttpclient/util/HttpConstants.java
+++ b/client/src/main/java/org/asynchttpclient/util/HttpConstants.java
@@ -42,6 +42,7 @@ public final class HttpConstants {
         public static final int SEE_OTHER_303 = HttpResponseStatus.SEE_OTHER.code();
         public static final int NOT_MODIFIED_304 = HttpResponseStatus.NOT_MODIFIED.code();
         public static final int TEMPORARY_REDIRECT_307 = HttpResponseStatus.TEMPORARY_REDIRECT.code();
+        public static final int PERMANENT_REDIRECT_308 = HttpResponseStatus.PERMANENT_REDIRECT.code();
         public static final int UNAUTHORIZED_401 = HttpResponseStatus.UNAUTHORIZED.code();
         public static final int PROXY_AUTHENTICATION_REQUIRED_407 = HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED.code();
 


### PR DESCRIPTION
Motivation:
The status 308 is defined by RFC7538.
This RFC has currently the state Proposed Standard since 2 years, but the status code is already handle by all browsers (Chrome, Firefox, Edge, Safari, …).

Changes:
HTTP Status 308 is added to constants
HTTP Status 308 is added on well-known statuses for redirection
When 308, according to the RFC, we are not allowed to switch to get and we keep body