### PR TITLE
Improved error messages if an invalid URL was passed

### DIFF
--- a/client/src/main/java/org/asynchttpclient/uri/Uri.java
+++ b/client/src/main/java/org/asynchttpclient/uri/Uri.java
@@ -61,7 +61,7 @@ public class Uri {
             String path,//
             String query) {
 
-        this.scheme = assertNotNull(scheme, "The scheme could not be resolved. Please provide a valid URL including the protocol.");
+        this.scheme = assertNotNull(scheme, "The scheme could not be resolved. Please provide a valid URL.");
         this.userInfo = userInfo;
         this.host = assertNotNull(host, "The host could not be resolved. Please provide a valid host.");
         this.port = port;

--- a/client/src/main/java/org/asynchttpclient/uri/Uri.java
+++ b/client/src/main/java/org/asynchttpclient/uri/Uri.java
@@ -61,9 +61,9 @@ public class Uri {
             String path,//
             String query) {
 
-        this.scheme = assertNotNull(scheme, "The scheme could not be resolved. Please provide a valid URL.");
+        this.scheme = assertNotNull(scheme, "scheme");
         this.userInfo = userInfo;
-        this.host = assertNotNull(host, "The host could not be resolved. Please provide a valid host.");
+        this.host = assertNotNull(host, "host");
         this.port = port;
         this.path = path;
         this.query = query;

--- a/client/src/main/java/org/asynchttpclient/uri/Uri.java
+++ b/client/src/main/java/org/asynchttpclient/uri/Uri.java
@@ -36,6 +36,12 @@ public class Uri {
         UriParser parser = new UriParser();
         parser.parse(context, originalUrl);
 
+        if (null == parser.scheme || null == parser.host) {
+            throw new IllegalArgumentException(
+                    String.format("The UriParser could not extract all required values: scheme=%s, host=%s. Please "
+                                  + "make sure you provide a valid URL.", parser.scheme, parser.host));
+        }
+
         return new Uri(parser.scheme,//
                 parser.userInfo,//
                 parser.host,//

--- a/client/src/main/java/org/asynchttpclient/uri/Uri.java
+++ b/client/src/main/java/org/asynchttpclient/uri/Uri.java
@@ -61,7 +61,7 @@ public class Uri {
             String path,//
             String query) {
 
-        this.scheme = assertNotNull(scheme, "The scheme could not be resolved. Please provide a valid URL.");
+        this.scheme = assertNotNull(scheme, "The scheme could not be resolved. Please provide a valid URL including the protocol.");
         this.userInfo = userInfo;
         this.host = assertNotNull(host, "The host could not be resolved. Please provide a valid host.");
         this.port = port;

--- a/client/src/main/java/org/asynchttpclient/uri/Uri.java
+++ b/client/src/main/java/org/asynchttpclient/uri/Uri.java
@@ -61,9 +61,9 @@ public class Uri {
             String path,//
             String query) {
 
-        this.scheme = assertNotNull(scheme, "scheme");
+        this.scheme = assertNotNull(scheme, "The scheme could not be resolved. Please provide a valid URL.");
         this.userInfo = userInfo;
-        this.host = assertNotNull(host, "host");
+        this.host = assertNotNull(host, "The host could not be resolved. Please provide a valid host.");
         this.port = port;
         this.path = path;
         this.query = query;

--- a/client/src/test/java/org/asynchttpclient/BasicHttpTest.java
+++ b/client/src/test/java/org/asynchttpclient/BasicHttpTest.java
@@ -240,7 +240,7 @@ public class BasicHttpTest extends HttpTest {
         });
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void nullSchemeThrowsNPE() throws Throwable {
         withClient().run(client -> client.prepareGet("gatling.io").execute());
     }
@@ -859,7 +859,7 @@ public class BasicHttpTest extends HttpTest {
         });
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void malformedUriThrowsException() throws Throwable {
         withClient().run(client -> {
             withServer(server).run(server -> {

--- a/client/src/test/java/org/asynchttpclient/uri/UriTest.java
+++ b/client/src/test/java/org/asynchttpclient/uri/UriTest.java
@@ -358,4 +358,33 @@ public class UriTest {
         uri = Uri.create(url);
         assertTrue(uri.isWebSocket(), "isWebSocket should return true for wss url");
     }
+
+    @Test
+    public void testCreateWithInvalidUrl_throwsIllegalArgumentException() {
+        // a valid URL would contain the scheme/protocol
+        String invalidUrl = "localhost";
+
+        Throwable exception = null;
+        try {
+            // run
+            Uri.create(invalidUrl);
+        } catch (IllegalArgumentException ex) {
+            exception = ex;
+        }
+
+        // verify
+        assertNotNull(exception);
+        assertEquals("The UriParser could not extract all required values: scheme=null, host=null. Please make "
+                     + "sure you provide a valid URL.", exception.getMessage());
+    }
+
+    @Test
+    public void testCreateWithValidUrl_doesNotThrowException() {
+        String validUrl = "https://localhost";
+        try {
+            Uri.create(validUrl);
+        } catch (IllegalArgumentException ex) {
+            fail(ex.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
```
    @Test
    public void name() throws Exception {
        AsyncHttpClient asyncHttpClient = sut.getAsyncHttpClient();
        asyncHttpClient.prepareDelete("url");
    }
```

currently leads to

```
java.lang.NullPointerException: scheme

	at org.asynchttpclient.util.Assertions.assertNotNull(Assertions.java:23)
	at org.asynchttpclient.uri.Uri.<init>(Uri.java:64)
	at org.asynchttpclient.uri.Uri.create(Uri.java:39)
	at org.asynchttpclient.uri.Uri.create(Uri.java:32)
	at org.asynchttpclient.RequestBuilderBase.setUrl(RequestBuilderBase.java:148)
	at org.asynchttpclient.DefaultAsyncHttpClient.requestBuilder(DefaultAsyncHttpClient.java:259)
	at org.asynchttpclient.DefaultAsyncHttpClient.prepareDelete(DefaultAsyncHttpClient.java:157)
```

This may be confusing at first, so I changed the value passed from the Uri constructor to assertNotNull to be more descriptive.