### PR TITLE
Apache.org does not send TRACE Accept HTTP header any more

### DIFF
--- a/src/test/java/com/ning/http/client/async/AsyncStreamHandlerTest.java
+++ b/src/test/java/com/ning/http/client/async/AsyncStreamHandlerTest.java
@@ -412,7 +412,7 @@ public abstract class AsyncStreamHandlerTest extends AbstractBasicTest {
         final AtomicReference<FluentCaseInsensitiveStringsMap> responseHeaders = new AtomicReference<>();
 
         try (AsyncHttpClient client = getAsyncHttpClient(null)) {
-            final String[] expected = { "GET", "HEAD", "OPTIONS", "POST", "TRACE" };
+            final String[] expected = { "GET", "HEAD", "OPTIONS", "POST" }; //, "TRACE" }; Trace has been disabled by apache.org
             Future<String> f = client.prepareOptions("http://www.apache.org/").execute(new AsyncHandlerAdapter() {
 
                 @Override


### PR DESCRIPTION
AsyncStreamHandlerTest expect the site www.apache.org to contain TRACE as Accept HTTP header. However this has been disabled on that site lately, so the test fails.

As a quick fix, just look for the remaining, but provided headers

- GET
- POST
- HEAD
- OPTIONS

