### PR TITLE
Added handling of httpOnly and secure flags of cookies when redirecting

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Redirect30xInterceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Redirect30xInterceptor.java
@@ -129,8 +129,10 @@ public class Redirect30xInterceptor {
 
                 for (String cookieStr : responseHeaders.getAll(SET_COOKIE)) {
                     Cookie c = ClientCookieDecoder.STRICT.decode(cookieStr);
-                    if (c != null)
-                        requestBuilder.addOrReplaceCookie(c);
+                    if (c != null) {
+                        if ((!c.isHttpOnly() && !c.isSecure()) || (c.isHttpOnly() && !newUri.isSecured()) || (c.isSecure() && newUri.isSecured()))
+                            requestBuilder.addOrReplaceCookie(c);
+                    }
                 }
 
                 boolean sameBase = isSameBase(request.getUri(), newUri);


### PR DESCRIPTION
Certain calls work incorrectly due to overridden cookies. 

For example GET request of 
http://www.thelancet.com/journals/lancet/article/PIIS1474-4422(17)30433-7
consists of eight redirects and all of them are HTTPS calls.

Response from 3rd redirect to `id.elsevier.com` returns `Set-Cookie` for `JSESSION` with `httpOnly` flag. But `JSESSION` is already set. This response overrides it which breaks subsequent call to `secure.jbs.elsevierhealth.com`.

As result client is being redirected to front page of the website.