### PR TITLE
#1503: Add setter for connectionPoolCleanerPeriod in AsyncHttpClient Builder

### DIFF
--- a/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClientConfig.java
+++ b/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClientConfig.java
@@ -949,6 +949,11 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
       return this;
     }
 
+    public Builder setConnectionPoolCleanerPeriod(int connectionPoolCleanerPeriod) {
+      this.connectionPoolCleanerPeriod = connectionPoolCleanerPeriod;
+      return this;
+    }
+
     public Builder setConnectionTtl(int connectionTtl) {
       this.connectionTtl = connectionTtl;
       return this;


### PR DESCRIPTION
Adding a setter for connectionPoolCleanerPeriod.

See issue here: #1503