### PR TITLE
Fixed #1507. Made socks proxy work with https.

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
@@ -359,7 +359,7 @@ public class ChannelManager {
     }
   }
 
-  public SslHandler addSslHandler(ChannelPipeline pipeline, Uri uri, String virtualHost) {
+  public SslHandler addSslHandler(ChannelPipeline pipeline, Uri uri, String virtualHost, boolean hasSocksProxyHandler) {
     String peerHost;
     int peerPort;
 
@@ -379,7 +379,10 @@ public class ChannelManager {
     }
 
     SslHandler sslHandler = createSslHandler(peerHost, peerPort);
-    pipeline.addFirst(ChannelManager.SSL_HANDLER, sslHandler);
+    if (hasSocksProxyHandler)
+      pipeline.addAfter(ChannelManager.SOCKS_HANDLER, ChannelManager.SSL_HANDLER, sslHandler);
+    else
+      pipeline.addFirst(ChannelManager.SSL_HANDLER, sslHandler);
     return sslHandler;
   }
 

--- a/client/src/main/java/org/asynchttpclient/netty/channel/NettyConnectListener.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/NettyConnectListener.java
@@ -112,7 +112,7 @@ public final class NettyConnectListener<T> {
     if ((proxyServer == null || proxyServer.getProxyType().isSocks()) && uri.isSecured()) {
       SslHandler sslHandler;
       try {
-        sslHandler = channelManager.addSslHandler(channel.pipeline(), uri, request.getVirtualHost());
+        sslHandler = channelManager.addSslHandler(channel.pipeline(), uri, request.getVirtualHost(), proxyServer != null);
       } catch (Exception sslError) {
         onFailure(channel, sslError);
         return;


### PR DESCRIPTION
A quick (and possibly dirty) fix. This fix ensures the SslHandler is added to the netty channel pipeline AFTER the Socks4ProxyHandler/Socks5ProxyHandler. Without it any attempt to send a request to a https URL via a socks proxy ends with a java.nio.channels.ClosedChannelException.

I am not familiar with Java/maven/JUnit as I primarily write on scala/sbt/scalatest, so I cannot provide an automatic test for this, but I tried to test this manually from within my scala project - and it worked. Also I am not sure about HTTPS support over HTTP proxy (with HTTP CONNECT tunneling) as I do not have it available. This might require further investigation, tests and fixes. But socks proxy supports HTTPS with this fix for sure.

P.S. Sorry for my English, I'm not a native speaker ;)