### PR TITLE
Fix missing read timeout in RequestBuilder

### DIFF
--- a/client/src/main/java/org/asynchttpclient/RequestBuilderBase.java
+++ b/client/src/main/java/org/asynchttpclient/RequestBuilderBase.java
@@ -132,6 +132,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
     this.file = prototype.getFile();
     this.followRedirect = prototype.getFollowRedirect();
     this.requestTimeout = prototype.getRequestTimeout();
+    this.readTimeout = prototype.getReadTimeout();
     this.rangeOffset = prototype.getRangeOffset();
     this.charset = prototype.getCharset();
     this.channelPoolPartitioning = prototype.getChannelPoolPartitioning();


### PR DESCRIPTION
Currently it's not possible to set readTimeout on a `Request` when using `httpClient.prepareRequest`. This PR should fix that.

My current workaround is to use `httpClient.executeRequest` which doesn't seem to rebuild the request.