### PR TITLE
Handle asynchronous calls to onSubscribe

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -68,5 +68,10 @@
       <artifactId>rxjava</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.reactivestreams</groupId>
+      <artifactId>reactive-streams-examples</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/client/src/main/java/org/asynchttpclient/netty/request/body/NettyReactiveStreamsBody.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/body/NettyReactiveStreamsBody.java
@@ -96,6 +96,7 @@ public class NettyReactiveStreamsBody implements NettyBody {
     private final Channel channel;
     private final NettyResponseFuture<?> future;
     private volatile Subscription deferredSubscription;
+    private volatile Boolean delayStart = true;      
 
     NettySubscriber(Channel channel, NettyResponseFuture<?> future) {
       super(channel.eventLoop());
@@ -111,11 +112,18 @@ public class NettyReactiveStreamsBody implements NettyBody {
 
     @Override
     public void onSubscribe(Subscription subscription) {
-      deferredSubscription = subscription;
+      if (delayStart) {
+        deferredSubscription = subscription;
+      } else {
+        super.onSubscribe(subscription);
+      }
     }
 
     void delayedStart() {
-      super.onSubscribe(deferredSubscription);
+      delayStart = false;
+      if (deferredSubscription != null) {
+        super.onSubscribe(deferredSubscription);
+      }
     }
 
     @Override

--- a/client/src/main/java/org/asynchttpclient/netty/request/body/NettyReactiveStreamsBody.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/body/NettyReactiveStreamsBody.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.asynchttpclient.util.Assertions.assertNotNull;
 
@@ -93,10 +94,14 @@ public class NettyReactiveStreamsBody implements NettyBody {
   private static class NettySubscriber extends HandlerSubscriber<HttpContent> {
     private static final Logger LOGGER = LoggerFactory.getLogger(NettySubscriber.class);
 
+    private static final Subscription DO_NOT_DELAY = new Subscription() {
+      public void cancel() {}
+      public void request(long l) {}
+    };
+      
     private final Channel channel;
     private final NettyResponseFuture<?> future;
-    private volatile Subscription deferredSubscription;
-    private volatile Boolean delayStart = true;      
+    private AtomicReference<Subscription> deferredSubscription = new AtomicReference<>();      
 
     NettySubscriber(Channel channel, NettyResponseFuture<?> future) {
       super(channel.eventLoop());
@@ -112,17 +117,17 @@ public class NettyReactiveStreamsBody implements NettyBody {
 
     @Override
     public void onSubscribe(Subscription subscription) {
-      if (delayStart) {
-        deferredSubscription = subscription;
-      } else {
+      if (!deferredSubscription.compareAndSet(null, subscription)) {
         super.onSubscribe(subscription);
       }
     }
 
     void delayedStart() {
-      delayStart = false;
-      if (deferredSubscription != null) {
-        super.onSubscribe(deferredSubscription);
+      // If we won the race against onSubscribe, we need to tell it
+      // know not to delay, because we won't be called again.
+      Subscription subscription = deferredSubscription.getAndSet(DO_NOT_DELAY);
+      if (subscription != null) {
+        super.onSubscribe(subscription);
       }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,11 @@
         <version>${reactive-streams.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.reactivestreams</groupId>
+        <artifactId>reactive-streams-examples</artifactId>
+        <version>${reactive-streams.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.typesafe.netty</groupId>
         <artifactId>netty-reactive-streams</artifactId>
         <version>${netty-reactive-streams.version}</version>


### PR DESCRIPTION
Publishers are not required to call `subscriber.onSubscribe` synchronously from `subscribe`.  When they don't, `delayedStart()` is called with a null `subscription`.  This modification allows `onSubscribe` to proceed as normal in case no subscription was yet available at the time of `delayedStart()`.

See 391b4d8e0eced22e56f390d4c5ee8a51c1c98d27 for context on why `delayedStart()` is necessary.