### PR TITLE
Fix NullPointerException while setting custom InetAddress

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
@@ -344,14 +344,14 @@ public final class NettyRequestSender {
     } else {
       int port = uri.getExplicitPort();
 
+      InetSocketAddress unresolvedRemoteAddress = InetSocketAddress.createUnresolved(uri.getHost(), port);
+      scheduleRequestTimeout(future, unresolvedRemoteAddress);
+
       if (request.getAddress() != null) {
         // bypass resolution
         InetSocketAddress inetSocketAddress = new InetSocketAddress(request.getAddress(), port);
         return promise.setSuccess(singletonList(inetSocketAddress));
-
       } else {
-        InetSocketAddress unresolvedRemoteAddress = InetSocketAddress.createUnresolved(uri.getHost(), port);
-        scheduleRequestTimeout(future, unresolvedRemoteAddress);
         return RequestHostnameResolver.INSTANCE.resolve(request.getNameResolver(), unresolvedRemoteAddress, asyncHandler);
       }
     }

--- a/client/src/test/java/org/asynchttpclient/CustomRemoteAddressTest.java
+++ b/client/src/test/java/org/asynchttpclient/CustomRemoteAddressTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient;
+
+import io.netty.util.internal.SocketUtils;
+import org.asynchttpclient.test.TestUtils.AsyncCompletionHandlerAdapter;
+import org.asynchttpclient.testserver.HttpServer;
+import org.asynchttpclient.testserver.HttpTest;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.asynchttpclient.Dsl.get;
+import static org.asynchttpclient.test.TestUtils.TIMEOUT;
+import static org.testng.Assert.assertEquals;
+
+public class CustomRemoteAddressTest extends HttpTest {
+
+  private static HttpServer server;
+
+  @BeforeClass
+  public static void start() throws Throwable {
+    server = new HttpServer();
+    server.start();
+  }
+
+  @AfterClass
+  public static void stop() throws Throwable {
+    server.close();
+  }
+
+  @Test
+  public void getRootUrlWithCustomRemoteAddress() throws Throwable {
+    withClient().run(client ->
+      withServer(server).run(server -> {
+        String url = server.getHttpUrl();
+        server.enqueueOk();
+        RequestBuilder request = get(url).setAddress(SocketUtils.addressByName("localhost"));
+        Response response = client.executeRequest(request, new AsyncCompletionHandlerAdapter()).get(TIMEOUT, SECONDS);
+        assertEquals(response.getStatusCode(), 200);
+      }));
+  }
+}


### PR DESCRIPTION
When we set remote `InetAddress` manually to the request object, the `TimeoutsHolder` object is not set to the `NettyResponseFuture`. This causes `NullPointerException` at `NettyConnectListener.java:107` while trying to set the resolved remote address to the `TimeoutsHolder`.

Error stack trace below:

```
java.lang.NullPointerException
	at org.asynchttpclient.netty.channel.NettyConnectListener.onSuccess(NettyConnectListener.java:107)
	at org.asynchttpclient.netty.request.NettyChannelConnector$1.onSuccess(NettyChannelConnector.java:93)
	at org.asynchttpclient.netty.SimpleChannelFutureListener.operationComplete(SimpleChannelFutureListener.java:26)
	at org.asynchttpclient.netty.SimpleChannelFutureListener.operationComplete(SimpleChannelFutureListener.java:20)
	at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:507)
	at io.netty.util.concurrent.DefaultPromise.notifyListeners0(DefaultPromise.java:500)
	at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:479)
	at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:420)
	at io.netty.util.concurrent.DefaultPromise.trySuccess(DefaultPromise.java:104)
	at io.netty.channel.DefaultChannelPromise.trySuccess(DefaultChannelPromise.java:82)
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.fulfillConnectPromise(AbstractNioChannel.java:306)
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.finishConnect(AbstractNioChannel.java:341)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:633)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:580)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:497)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:459)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:886)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:748)
```