### PR TITLE
Thread factory provided by the client should be used if not null

### DIFF
--- a/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClient.java
+++ b/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClient.java
@@ -92,7 +92,7 @@ public class DefaultAsyncHttpClient implements AsyncHttpClient {
   }
 
   private Timer newNettyTimer(AsyncHttpClientConfig config) {
-    ThreadFactory threadFactory = config.getThreadFactory() != null ? config.getThreadFactory() : new DefaultThreadFactory(config.getThreadPoolName());
+    ThreadFactory threadFactory = config.getThreadFactory() != null ? config.getThreadFactory() : new DefaultThreadFactory(config.getThreadPoolName() + "-timer");
 
     HashedWheelTimer timer = new HashedWheelTimer(threadFactory);
     timer.start();

--- a/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClient.java
+++ b/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClient.java
@@ -92,7 +92,8 @@ public class DefaultAsyncHttpClient implements AsyncHttpClient {
   }
 
   private Timer newNettyTimer(AsyncHttpClientConfig config) {
-    ThreadFactory threadFactory = new DefaultThreadFactory(config.getThreadPoolName() + "-timer");
+    ThreadFactory threadFactory = config.getThreadFactory() != null ? config.getThreadFactory() : new DefaultThreadFactory(config.getThreadPoolName());
+
     HashedWheelTimer timer = new HashedWheelTimer(threadFactory);
     timer.start();
     return timer;


### PR DESCRIPTION
Thread factory provided by the client should be used if not null, as being done in ChannelManager
