### PR TITLE
Allow to use channel manager provided via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ AsyncHttpClientConfig cf = new DefaultAsyncHttpClientConfig.Builder()
 AsyncHttpClient c = new DefaultAsyncHttpClient(cf);
 ```
 
+It's possible to create shared resources (EventLoop, Timer, ChannelManager) beforehand and pass them to multiple client instances in the config. 
+You'll then be responsible for closing those shared resources.
+
 ## WebSocket
 
 Async Http Client also support WebSocket by simply doing:

--- a/client/src/main/java/org/asynchttpclient/AsyncHttpClientConfig.java
+++ b/client/src/main/java/org/asynchttpclient/AsyncHttpClientConfig.java
@@ -32,6 +32,7 @@ import org.asynchttpclient.filter.RequestFilter;
 import org.asynchttpclient.filter.ResponseFilter;
 import org.asynchttpclient.netty.EagerResponseBodyPart;
 import org.asynchttpclient.netty.LazyResponseBodyPart;
+import org.asynchttpclient.netty.channel.ChannelManager;
 import org.asynchttpclient.proxy.ProxyServer;
 import org.asynchttpclient.proxy.ProxyServerSelector;
 
@@ -269,6 +270,8 @@ public interface AsyncHttpClientConfig {
     ResponseBodyPartFactory getResponseBodyPartFactory();
 
     ChannelPool getChannelPool();
+
+    ChannelManager getChannelManager();
 
     Timer getNettyTimer();
 

--- a/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClientConfig.java
+++ b/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClientConfig.java
@@ -38,6 +38,7 @@ import org.asynchttpclient.channel.KeepAliveStrategy;
 import org.asynchttpclient.filter.IOExceptionFilter;
 import org.asynchttpclient.filter.RequestFilter;
 import org.asynchttpclient.filter.ResponseFilter;
+import org.asynchttpclient.netty.channel.ChannelManager;
 import org.asynchttpclient.proxy.ProxyServer;
 import org.asynchttpclient.proxy.ProxyServerSelector;
 import org.asynchttpclient.util.ProxyUtils;
@@ -91,6 +92,7 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
     private final int maxConnections;
     private final int maxConnectionsPerHost;
     private final ChannelPool channelPool;
+    private final ChannelManager channelManager;
     private final KeepAliveStrategy keepAliveStrategy;
 
     // ssl
@@ -163,6 +165,7 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
             int maxConnections,//
             int maxConnectionsPerHost,//
             ChannelPool channelPool,//
+            ChannelManager channelManager,//
             KeepAliveStrategy keepAliveStrategy,//
 
             // ssl
@@ -236,6 +239,7 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
         this.maxConnections = maxConnections;
         this.maxConnectionsPerHost = maxConnectionsPerHost;
         this.channelPool = channelPool;
+        this.channelManager = channelManager;
         this.keepAliveStrategy = keepAliveStrategy;
 
         // ssl
@@ -403,6 +407,11 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
     @Override
     public ChannelPool getChannelPool() {
         return channelPool;
+    }
+
+    @Override
+    public ChannelManager getChannelManager() {
+        return channelManager;
     }
 
     @Override
@@ -625,6 +634,7 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
         private int maxConnections = defaultMaxConnections();
         private int maxConnectionsPerHost = defaultMaxConnectionsPerHost();
         private ChannelPool channelPool;
+        private ChannelManager channelManager;
         private KeepAliveStrategy keepAliveStrategy = new DefaultKeepAliveStrategy();
 
         // ssl
@@ -700,6 +710,7 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
             maxConnections = config.getMaxConnections();
             maxConnectionsPerHost = config.getMaxConnectionsPerHost();
             channelPool = config.getChannelPool();
+            channelManager = config.getChannelManager();
             keepAliveStrategy = config.getKeepAliveStrategy();
 
             // ssl
@@ -883,6 +894,11 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
 
         public Builder setChannelPool(ChannelPool channelPool) {
             this.channelPool = channelPool;
+            return this;
+        }
+
+        public Builder setChannelManager(ChannelManager channelManager) {
+            this.channelManager = channelManager;
             return this;
         }
 
@@ -1121,6 +1137,7 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
                     maxConnections, //
                     maxConnectionsPerHost, //
                     channelPool, //
+                    channelManager, //
                     keepAliveStrategy, //
                     useOpenSsl, //
                     acceptAnyCertificate, //

--- a/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
@@ -141,15 +141,7 @@ public class ChannelManager {
                 public boolean remove(Object o) {
                     boolean removed = super.remove(o);
                     if (removed) {
-                        freeChannels.release();
-                        if (maxConnectionsPerHostEnabled) {
-                            Object partitionKey = Channel.class.cast(o).attr(partitionKeyAttr).getAndSet(null);
-                            if (partitionKey != null) {
-                                NonBlockingSemaphore hostFreeChannels = freeChannelsPerHost.get(partitionKey);
-                                if (hostFreeChannels != null)
-                                    hostFreeChannels.release();
-                            }
-                        }
+                        releaseChannelLock(Channel.class.cast(o).attr(partitionKeyAttr).getAndSet(null));
                     }
                     return removed;
                 }


### PR DESCRIPTION
Sometimes it could be useful to provide custom ChannelManager and/or reuse it, like it is done with Timer.
Also, to support this feature, method `releaseChannelLock` is being reused in `DefaultChannelGroup#remove`, since logic is effectively the same.