### PR TITLE
Use ConnectionSemaphoreFactory provided via config

### DIFF
--- a/client/src/main/java/org/asynchttpclient/AsyncHttpClientConfig.java
+++ b/client/src/main/java/org/asynchttpclient/AsyncHttpClientConfig.java
@@ -28,6 +28,7 @@ import org.asynchttpclient.filter.RequestFilter;
 import org.asynchttpclient.filter.ResponseFilter;
 import org.asynchttpclient.netty.EagerResponseBodyPart;
 import org.asynchttpclient.netty.LazyResponseBodyPart;
+import org.asynchttpclient.netty.channel.ConnectionSemaphoreFactory;
 import org.asynchttpclient.proxy.ProxyServer;
 import org.asynchttpclient.proxy.ProxyServerSelector;
 
@@ -292,6 +293,8 @@ public interface AsyncHttpClientConfig {
   ResponseBodyPartFactory getResponseBodyPartFactory();
 
   ChannelPool getChannelPool();
+
+  ConnectionSemaphoreFactory getConnectionSemaphoreFactory();
 
   Timer getNettyTimer();
 

--- a/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClientConfig.java
+++ b/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClientConfig.java
@@ -30,6 +30,7 @@ import org.asynchttpclient.cookie.ThreadSafeCookieStore;
 import org.asynchttpclient.filter.IOExceptionFilter;
 import org.asynchttpclient.filter.RequestFilter;
 import org.asynchttpclient.filter.ResponseFilter;
+import org.asynchttpclient.netty.channel.ConnectionSemaphoreFactory;
 import org.asynchttpclient.proxy.ProxyServer;
 import org.asynchttpclient.proxy.ProxyServerSelector;
 import org.asynchttpclient.util.ProxyUtils;
@@ -84,6 +85,7 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
   private final int maxConnections;
   private final int maxConnectionsPerHost;
   private final ChannelPool channelPool;
+  private final ConnectionSemaphoreFactory connectionSemaphoreFactory;
   private final KeepAliveStrategy keepAliveStrategy;
 
   // ssl
@@ -162,6 +164,7 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
                                        int maxConnections,
                                        int maxConnectionsPerHost,
                                        ChannelPool channelPool,
+                                       ConnectionSemaphoreFactory connectionSemaphoreFactory,
                                        KeepAliveStrategy keepAliveStrategy,
 
                                        // ssl
@@ -248,6 +251,7 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
     this.maxConnections = maxConnections;
     this.maxConnectionsPerHost = maxConnectionsPerHost;
     this.channelPool = channelPool;
+    this.connectionSemaphoreFactory = connectionSemaphoreFactory;
     this.keepAliveStrategy = keepAliveStrategy;
 
     // ssl
@@ -444,6 +448,11 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
   @Override
   public ChannelPool getChannelPool() {
     return channelPool;
+  }
+
+  @Override
+  public ConnectionSemaphoreFactory getConnectionSemaphoreFactory() {
+    return connectionSemaphoreFactory;
   }
 
   @Override
@@ -688,6 +697,7 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
     private int maxConnections = defaultMaxConnections();
     private int maxConnectionsPerHost = defaultMaxConnectionsPerHost();
     private ChannelPool channelPool;
+    private ConnectionSemaphoreFactory connectionSemaphoreFactory;
     private KeepAliveStrategy keepAliveStrategy = new DefaultKeepAliveStrategy();
 
     // ssl
@@ -768,6 +778,7 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
       maxConnections = config.getMaxConnections();
       maxConnectionsPerHost = config.getMaxConnectionsPerHost();
       channelPool = config.getChannelPool();
+      connectionSemaphoreFactory = config.getConnectionSemaphoreFactory();
       keepAliveStrategy = config.getKeepAliveStrategy();
 
       // ssl
@@ -981,6 +992,11 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
 
     public Builder setChannelPool(ChannelPool channelPool) {
       this.channelPool = channelPool;
+      return this;
+    }
+
+    public Builder setConnectionSemaphoreFactory(ConnectionSemaphoreFactory connectionSemaphoreFactory) {
+      this.connectionSemaphoreFactory = connectionSemaphoreFactory;
       return this;
     }
 
@@ -1233,6 +1249,7 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
               maxConnections,
               maxConnectionsPerHost,
               channelPool,
+              connectionSemaphoreFactory,
               keepAliveStrategy,
               useOpenSsl,
               useInsecureTrustManager,

--- a/client/src/main/java/org/asynchttpclient/netty/channel/ConnectionSemaphoreFactory.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/ConnectionSemaphoreFactory.java
@@ -13,15 +13,10 @@
  */
 package org.asynchttpclient.netty.channel;
 
-import java.io.IOException;
+import org.asynchttpclient.AsyncHttpClientConfig;
 
-/**
- * Connections limiter.
- */
-public interface ConnectionSemaphore {
+public interface ConnectionSemaphoreFactory {
 
-    void acquireChannelLock(Object partitionKey) throws IOException;
-
-    void releaseChannelLock(Object partitionKey);
+    ConnectionSemaphore newConnectionSemaphore(AsyncHttpClientConfig config);
 
 }

--- a/client/src/main/java/org/asynchttpclient/netty/channel/DefaultConnectionSemaphoreFactory.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/DefaultConnectionSemaphoreFactory.java
@@ -13,15 +13,18 @@
  */
 package org.asynchttpclient.netty.channel;
 
-import java.io.IOException;
+import org.asynchttpclient.AsyncHttpClientConfig;
 
-/**
- * Connections limiter.
- */
-public interface ConnectionSemaphore {
+public class DefaultConnectionSemaphoreFactory implements ConnectionSemaphoreFactory {
 
-    void acquireChannelLock(Object partitionKey) throws IOException;
-
-    void releaseChannelLock(Object partitionKey);
-
+    public ConnectionSemaphore newConnectionSemaphore(AsyncHttpClientConfig config) {
+        ConnectionSemaphore semaphore = new NoopConnectionSemaphore();
+        if (config.getMaxConnections() > 0) {
+            semaphore = new MaxConnectionSemaphore(config.getMaxConnections());
+        }
+        if (config.getMaxConnectionsPerHost() > 0) {
+            semaphore = new PerHostConnectionSemaphore(config.getMaxConnectionsPerHost(), semaphore);
+        }
+        return semaphore;
+    }
 }

--- a/client/src/main/java/org/asynchttpclient/netty/channel/MaxConnectionSemaphore.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/MaxConnectionSemaphore.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.netty.channel;
+
+import org.asynchttpclient.exception.TooManyConnectionsException;
+
+import java.io.IOException;
+
+import static org.asynchttpclient.util.ThrowableUtil.unknownStackTrace;
+
+/**
+ * Max connections limiter.
+ *
+ * @author Stepan Koltsov
+ */
+public class MaxConnectionSemaphore implements ConnectionSemaphore {
+
+  private final NonBlockingSemaphoreLike freeChannels;
+  private final IOException tooManyConnections;
+
+  MaxConnectionSemaphore(int maxConnections) {
+    tooManyConnections = unknownStackTrace(new TooManyConnectionsException(maxConnections), MaxConnectionSemaphore.class, "acquireChannelLock");
+    freeChannels = new NonBlockingSemaphore(maxConnections);
+  }
+
+  @Override
+  public void acquireChannelLock(Object partitionKey) throws IOException {
+    if (!freeChannels.tryAcquire())
+      throw tooManyConnections;
+  }
+
+  @Override
+  public void releaseChannelLock(Object partitionKey) {
+    freeChannels.release();
+  }
+}

--- a/client/src/main/java/org/asynchttpclient/netty/channel/MaxConnectionSemaphore.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/MaxConnectionSemaphore.java
@@ -31,7 +31,7 @@ public class MaxConnectionSemaphore implements ConnectionSemaphore {
 
   MaxConnectionSemaphore(int maxConnections) {
     tooManyConnections = unknownStackTrace(new TooManyConnectionsException(maxConnections), MaxConnectionSemaphore.class, "acquireChannelLock");
-    freeChannels = new NonBlockingSemaphore(maxConnections);
+    freeChannels = maxConnections > 0 ? new NonBlockingSemaphore(maxConnections) : NonBlockingSemaphoreInfinite.INSTANCE;
   }
 
   @Override

--- a/client/src/main/java/org/asynchttpclient/netty/channel/NoopConnectionSemaphore.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/NoopConnectionSemaphore.java
@@ -16,12 +16,15 @@ package org.asynchttpclient.netty.channel;
 import java.io.IOException;
 
 /**
- * Connections limiter.
+ * No-op implementation of {@link ConnectionSemaphore}.
  */
-public interface ConnectionSemaphore {
+public class NoopConnectionSemaphore implements ConnectionSemaphore {
 
-    void acquireChannelLock(Object partitionKey) throws IOException;
+  @Override
+  public void acquireChannelLock(Object partitionKey) throws IOException {
+  }
 
-    void releaseChannelLock(Object partitionKey);
-
+  @Override
+  public void releaseChannelLock(Object partitionKey) {
+  }
 }

--- a/client/src/main/java/org/asynchttpclient/netty/channel/PerHostConnectionSemaphore.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/PerHostConnectionSemaphore.java
@@ -54,6 +54,8 @@ public class PerHostConnectionSemaphore implements ConnectionSemaphore {
   }
 
   private NonBlockingSemaphoreLike getFreeConnectionsForHost(Object partitionKey) {
-    return freeChannelsPerHost.computeIfAbsent(partitionKey, pk -> new NonBlockingSemaphore(maxConnectionsPerHost));
+    return maxConnectionsPerHost > 0 ?
+            freeChannelsPerHost.computeIfAbsent(partitionKey, pk -> new NonBlockingSemaphore(maxConnectionsPerHost)) :
+            NonBlockingSemaphoreInfinite.INSTANCE;
   }
 }

--- a/client/src/main/java/org/asynchttpclient/netty/channel/PerHostConnectionSemaphore.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/PerHostConnectionSemaphore.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2018 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.netty.channel;
+
+import org.asynchttpclient.exception.TooManyConnectionsPerHostException;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.asynchttpclient.util.ThrowableUtil.unknownStackTrace;
+
+/**
+ * Max per-host connections limiter.
+ */
+public class PerHostConnectionSemaphore implements ConnectionSemaphore {
+
+  private final ConnectionSemaphore globalSemaphore;
+
+  private final ConcurrentHashMap<Object, NonBlockingSemaphore> freeChannelsPerHost = new ConcurrentHashMap<>();
+  private final int maxConnectionsPerHost;
+  private final IOException tooManyConnectionsPerHost;
+
+  PerHostConnectionSemaphore(int maxConnectionsPerHost, ConnectionSemaphore globalSemaphore) {
+    this.globalSemaphore = globalSemaphore;
+    tooManyConnectionsPerHost = unknownStackTrace(new TooManyConnectionsPerHostException(maxConnectionsPerHost), PerHostConnectionSemaphore.class, "acquireChannelLock");
+    this.maxConnectionsPerHost = maxConnectionsPerHost;
+  }
+
+  @Override
+  public void acquireChannelLock(Object partitionKey) throws IOException {
+    globalSemaphore.acquireChannelLock(partitionKey);
+
+    if (!getFreeConnectionsForHost(partitionKey).tryAcquire()) {
+      globalSemaphore.releaseChannelLock(partitionKey);
+      throw tooManyConnectionsPerHost;
+    }
+  }
+
+  @Override
+  public void releaseChannelLock(Object partitionKey) {
+    globalSemaphore.releaseChannelLock(partitionKey);
+    getFreeConnectionsForHost(partitionKey).release();
+  }
+
+  private NonBlockingSemaphoreLike getFreeConnectionsForHost(Object partitionKey) {
+    return freeChannelsPerHost.computeIfAbsent(partitionKey, pk -> new NonBlockingSemaphore(maxConnectionsPerHost));
+  }
+}

--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
@@ -75,7 +75,9 @@ public final class NettyRequestSender {
                             AsyncHttpClientState clientState) {
     this.config = config;
     this.channelManager = channelManager;
-    this.connectionSemaphore = ConnectionSemaphore.newConnectionSemaphore(config);
+    this.connectionSemaphore = config.getConnectionSemaphoreFactory() == null
+            ? new DefaultConnectionSemaphoreFactory().newConnectionSemaphore(config)
+            : config.getConnectionSemaphoreFactory().newConnectionSemaphore(config);
     this.nettyTimer = nettyTimer;
     this.clientState = clientState;
     requestFactory = new NettyRequestFactory(config);

--- a/extras/typesafeconfig/src/main/java/org/asynchttpclient/extras/typesafeconfig/AsyncHttpClientTypesafeConfig.java
+++ b/extras/typesafeconfig/src/main/java/org/asynchttpclient/extras/typesafeconfig/AsyncHttpClientTypesafeConfig.java
@@ -31,6 +31,7 @@ import org.asynchttpclient.cookie.ThreadSafeCookieStore;
 import org.asynchttpclient.filter.IOExceptionFilter;
 import org.asynchttpclient.filter.RequestFilter;
 import org.asynchttpclient.filter.ResponseFilter;
+import org.asynchttpclient.netty.channel.ConnectionSemaphoreFactory;
 import org.asynchttpclient.proxy.ProxyServerSelector;
 
 import java.util.*;
@@ -320,6 +321,11 @@ public class AsyncHttpClientTypesafeConfig implements AsyncHttpClientConfig {
 
   @Override
   public ChannelPool getChannelPool() {
+    return null;
+  }
+
+  @Override
+  public ConnectionSemaphoreFactory getConnectionSemaphoreFactory() {
     return null;
   }
 


### PR DESCRIPTION
Expose ConnectionSemaphoreFactory from AsyncHttpClientConfig to be able to provide custom channel limits using custom compositions of ConnectionSemaphore.
Can be useful to provide custom channel/connection limit (not only total and per-host connections).