### PR TITLE
Workaround for netty chunked upload issue

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/future/StackTraceInspector.java
+++ b/client/src/main/java/org/asynchttpclient/netty/future/StackTraceInspector.java
@@ -15,6 +15,8 @@ package org.asynchttpclient.netty.future;
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 
+import io.netty.channel.socket.ChannelOutputShutdownException;
+
 public class StackTraceInspector {
 
   private static boolean exceptionInMethod(Throwable t, String className, String methodName) {
@@ -37,6 +39,11 @@ public class StackTraceInspector {
     return t instanceof ClosedChannelException
             || exceptionInMethod(t, "io.netty.handler.ssl.SslHandler", "disconnect")
             || (t.getCause() != null && recoverOnConnectCloseException(t.getCause()));
+  }
+
+  public static boolean recoverOnChunkedUploadFailed(Throwable t) {
+    return t instanceof ChannelOutputShutdownException
+          && exceptionInMethod(t, "io.netty.handler.stream.ChunkedWriteHandler", "flush");
   }
 
   public static boolean recoverOnReadOrWriteException(Throwable t) {

--- a/client/src/main/java/org/asynchttpclient/netty/request/WriteListener.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/WriteListener.java
@@ -36,7 +36,7 @@ public abstract class WriteListener {
     this.notifyHeaders = notifyHeaders;
   }
 
-  private boolean abortOnThrowable(Channel channel, Throwable cause) {
+  protected boolean abortOnThrowable(Channel channel, Throwable cause) {
     if (cause != null) {
       if (cause instanceof IllegalStateException || cause instanceof ClosedChannelException || StackTraceInspector.recoverOnReadOrWriteException(cause)) {
         LOGGER.debug(cause.getMessage(), cause);

--- a/client/src/main/java/org/asynchttpclient/netty/request/body/NettyBodyBody.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/body/NettyBodyBody.java
@@ -15,12 +15,12 @@ package org.asynchttpclient.netty.request.body;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelProgressiveFuture;
+import io.netty.channel.socket.ChannelOutputShutdownException;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import org.asynchttpclient.AsyncHttpClientConfig;
 import org.asynchttpclient.netty.NettyResponseFuture;
 import org.asynchttpclient.netty.channel.ChannelManager;
-import org.asynchttpclient.netty.future.StackTraceInspector;
 import org.asynchttpclient.netty.request.WriteProgressListener;
 import org.asynchttpclient.request.body.Body;
 import org.asynchttpclient.request.body.RandomAccessBody;
@@ -87,7 +87,7 @@ public class NettyBodyBody implements NettyBody {
               @Override
               protected boolean abortOnThrowable(Channel channel, Throwable cause) {
                 // FIXME dirty hack until netty issue is not resolved, see https://github.com/netty/netty/issues/6706
-                return StackTraceInspector.recoverOnChunkedUploadFailed(cause)
+                return cause instanceof ChannelOutputShutdownException
                       || super.abortOnThrowable(channel, cause);
               }
             });

--- a/client/src/test/java/org/asynchttpclient/test/EchoHandler.java
+++ b/client/src/test/java/org/asynchttpclient/test/EchoHandler.java
@@ -69,6 +69,13 @@ public class EchoHandler extends AbstractHandler {
         httpResponse.sendRedirect(httpRequest.getHeader("X-redirect"));
         return;
       }
+      if (headerName.startsWith("X-fail")) {
+        httpResponse.setStatus(HttpServletResponse.SC_EXPECTATION_FAILED);
+        httpResponse.getOutputStream().write("custom error message".getBytes());
+        httpResponse.getOutputStream().flush();
+        httpResponse.getOutputStream().close();
+        return;
+      }
       httpResponse.addHeader("X-" + headerName, httpRequest.getHeader(headerName));
     }
 

--- a/client/src/test/java/org/asynchttpclient/test/EchoHandler.java
+++ b/client/src/test/java/org/asynchttpclient/test/EchoHandler.java
@@ -24,6 +24,7 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
@@ -71,7 +72,9 @@ public class EchoHandler extends AbstractHandler {
       }
       if (headerName.startsWith("X-fail")) {
         httpResponse.setStatus(HttpServletResponse.SC_EXPECTATION_FAILED);
-        httpResponse.getOutputStream().write("custom error message".getBytes());
+        byte[] responseBytes = "custom error message".getBytes(StandardCharsets.UTF_8);
+        httpResponse.addIntHeader(CONTENT_LENGTH.toString(), responseBytes.length);
+        httpResponse.getOutputStream().write(responseBytes);
         httpResponse.getOutputStream().flush();
         httpResponse.getOutputStream().close();
         return;


### PR DESCRIPTION
Motivation:
Netty doesn't provide any ability to handle early server response when uploading chunked file and instead, `IOException: Pipe closed` is thrown (see https://github.com/netty/netty/issues/6706 for details).

Changes:
NettyInputStreamBody swallows ChannelOutputShutdownException in case it is thrown from netty's ChunkedWriteHandler.

Result:
Multipart early response is available to be handled properly.