### PR TITLE
set useLaxCookieEncoder in DefaultAHCConfig.Builder constructor

### DIFF
--- a/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClientConfig.java
+++ b/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClientConfig.java
@@ -754,6 +754,7 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
       realm = config.getRealm();
       maxRequestRetry = config.getMaxRequestRetry();
       disableUrlEncodingForBoundRequests = config.isDisableUrlEncodingForBoundRequests();
+      useLaxCookieEncoder = config.isUseLaxCookieEncoder();
       disableZeroCopy = config.isDisableZeroCopy();
       keepEncodingHeader = config.isKeepEncodingHeader();
       proxyServerSelector = config.getProxyServerSelector();


### PR DESCRIPTION
It seems that `useLaxCookieEncoder` is not set when creating a `DefaultAHCConfig.Builder` from an instance of `AsyncHttpClientConfig`