### PR TITLE
Improve SpnegoEngine to allow more login configuration options

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -73,5 +73,11 @@
       <artifactId>reactive-streams-examples</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.kerby</groupId>
+      <artifactId>kerb-simplekdc</artifactId>
+      <version>${cxf.kerby.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -76,7 +76,6 @@
     <dependency>
       <groupId>org.apache.kerby</groupId>
       <artifactId>kerb-simplekdc</artifactId>
-      <version>${cxf.kerby.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/client/src/main/java/org/asynchttpclient/Dsl.java
+++ b/client/src/main/java/org/asynchttpclient/Dsl.java
@@ -100,6 +100,8 @@ public final class Dsl {
             .setNtlmHost(prototype.getNtlmHost())
             .setUseAbsoluteURI(prototype.isUseAbsoluteURI())
             .setOmitQuery(prototype.isOmitQuery())
+            .setServicePrincipalName(prototype.getServicePrincipalName())
+            .setUseCanonicalHostname(prototype.isUseCanonicalHostname())
             .setCustomLoginConfig(prototype.getCustomLoginConfig());
   }
 

--- a/client/src/main/java/org/asynchttpclient/Dsl.java
+++ b/client/src/main/java/org/asynchttpclient/Dsl.java
@@ -99,7 +99,9 @@ public final class Dsl {
             .setNtlmDomain(prototype.getNtlmDomain())
             .setNtlmHost(prototype.getNtlmHost())
             .setUseAbsoluteURI(prototype.isUseAbsoluteURI())
-            .setOmitQuery(prototype.isOmitQuery());
+            .setOmitQuery(prototype.isOmitQuery())
+            .setSpnegoKeytabFilePath(prototype.getSpnegoKeytabFilePath())
+            .setSpnegoPrincipal(prototype.getSpnegoPrincipal());
   }
 
   public static Realm.Builder realm(AuthScheme scheme, String principal, String password) {

--- a/client/src/main/java/org/asynchttpclient/Dsl.java
+++ b/client/src/main/java/org/asynchttpclient/Dsl.java
@@ -102,7 +102,8 @@ public final class Dsl {
             .setOmitQuery(prototype.isOmitQuery())
             .setServicePrincipalName(prototype.getServicePrincipalName())
             .setUseCanonicalHostname(prototype.isUseCanonicalHostname())
-            .setCustomLoginConfig(prototype.getCustomLoginConfig());
+            .setCustomLoginConfig(prototype.getCustomLoginConfig())
+            .setLoginContextName(prototype.getLoginContextName());
   }
 
   public static Realm.Builder realm(AuthScheme scheme, String principal, String password) {

--- a/client/src/main/java/org/asynchttpclient/Dsl.java
+++ b/client/src/main/java/org/asynchttpclient/Dsl.java
@@ -100,8 +100,7 @@ public final class Dsl {
             .setNtlmHost(prototype.getNtlmHost())
             .setUseAbsoluteURI(prototype.isUseAbsoluteURI())
             .setOmitQuery(prototype.isOmitQuery())
-            .setSpnegoKeytabFilePath(prototype.getSpnegoKeytabFilePath())
-            .setSpnegoPrincipal(prototype.getSpnegoPrincipal());
+            .setCustomLoginConfig(prototype.getCustomLoginConfig());
   }
 
   public static Realm.Builder realm(AuthScheme scheme, String principal, String password) {

--- a/client/src/main/java/org/asynchttpclient/Realm.java
+++ b/client/src/main/java/org/asynchttpclient/Realm.java
@@ -60,6 +60,8 @@ public class Realm {
   private final String ntlmDomain;
   private final boolean useAbsoluteURI;
   private final boolean omitQuery;
+  private final String spnegoKeytabFilePath;
+  private final String spnegoPrincipal;
 
   private Realm(AuthScheme scheme,
                 String principal,
@@ -78,7 +80,9 @@ public class Realm {
                 String ntlmDomain,
                 String ntlmHost,
                 boolean useAbsoluteURI,
-                boolean omitQuery) {
+                boolean omitQuery,
+                String spnegoKeytabFilePath,
+                String spnegoPrincipal) {
 
     this.scheme = assertNotNull(scheme, "scheme");
     this.principal = assertNotNull(principal, "principal");
@@ -98,6 +102,8 @@ public class Realm {
     this.ntlmHost = ntlmHost;
     this.useAbsoluteURI = useAbsoluteURI;
     this.omitQuery = omitQuery;
+    this.spnegoKeytabFilePath = spnegoKeytabFilePath;
+    this.spnegoPrincipal = spnegoPrincipal;
   }
 
   public String getPrincipal() {
@@ -187,6 +193,14 @@ public class Realm {
     return omitQuery;
   }
 
+  public String getSpnegoKeytabFilePath() {
+    return spnegoKeytabFilePath;
+  }
+
+  public String getSpnegoPrincipal() {
+    return spnegoPrincipal;
+  }
+
   @Override
   public String toString() {
     return "Realm{" + "principal='" + principal + '\'' + ", scheme=" + scheme + ", realmName='" + realmName + '\''
@@ -207,6 +221,8 @@ public class Realm {
     private final String principal;
     private final String password;
     private AuthScheme scheme;
+    private String spnegoKeytabFilePath;
+    private String spnegoPrincipal;
     private String realmName;
     private String nonce;
     private String algorithm;
@@ -223,6 +239,11 @@ public class Realm {
     private String ntlmHost = "localhost";
     private boolean useAbsoluteURI = false;
     private boolean omitQuery;
+
+    public Builder() {
+      this.principal = null;
+      this.password = null;
+    }
 
     public Builder(String principal, String password) {
       this.principal = principal;
@@ -308,6 +329,16 @@ public class Realm {
 
     public Builder setCharset(Charset charset) {
       this.charset = charset;
+      return this;
+    }
+
+    public Builder setSpnegoKeytabFilePath(String spnegoKeytabFilePath) {
+      this.spnegoKeytabFilePath = spnegoKeytabFilePath;
+      return this;
+    }
+
+    public Builder setSpnegoPrincipal(String spnegoPrincipal) {
+      this.spnegoPrincipal = spnegoPrincipal;
       return this;
     }
 
@@ -501,7 +532,9 @@ public class Realm {
               ntlmDomain,
               ntlmHost,
               useAbsoluteURI,
-              omitQuery);
+              omitQuery,
+              spnegoKeytabFilePath,
+              spnegoPrincipal);
     }
   }
 }

--- a/client/src/main/java/org/asynchttpclient/Realm.java
+++ b/client/src/main/java/org/asynchttpclient/Realm.java
@@ -84,8 +84,8 @@ public class Realm {
                 Map<String, String> customLoginConfig) {
 
     this.scheme = assertNotNull(scheme, "scheme");
-    this.principal = assertNotNull(principal, "principal");
-    this.password = assertNotNull(password, "password");
+    this.principal = principal;
+    this.password = password;
     this.realmName = realmName;
     this.nonce = nonce;
     this.algorithm = algorithm;

--- a/client/src/main/java/org/asynchttpclient/Realm.java
+++ b/client/src/main/java/org/asynchttpclient/Realm.java
@@ -64,6 +64,7 @@ public class Realm {
   private final Map<String, String> customLoginConfig;
   private final String servicePrincipalName;
   private final boolean useCanonicalHostname;
+  private final String loginContextName;
 
   private Realm(AuthScheme scheme,
                 String principal,
@@ -85,7 +86,8 @@ public class Realm {
                 boolean omitQuery,
                 String servicePrincipalName,
                 boolean useCanonicalHostname,
-                Map<String, String> customLoginConfig) {
+                Map<String, String> customLoginConfig,
+                String loginContextName) {
 
     this.scheme = assertNotNull(scheme, "scheme");
     this.principal = principal;
@@ -108,6 +110,7 @@ public class Realm {
     this.servicePrincipalName = servicePrincipalName;
     this.useCanonicalHostname = useCanonicalHostname;
     this.customLoginConfig = customLoginConfig;
+    this.loginContextName = loginContextName;
   }
 
   public String getPrincipal() {
@@ -209,6 +212,10 @@ public class Realm {
     return useCanonicalHostname;
   }
 
+  public String getLoginContextName() {
+    return loginContextName;
+  }
+
   @Override
   public String toString() {
     return "Realm{" +
@@ -233,6 +240,7 @@ public class Realm {
         ", customLoginConfig=" + customLoginConfig +
         ", servicePrincipalName='" + servicePrincipalName + '\'' +
         ", useCanonicalHostname=" + useCanonicalHostname +
+        ", loginContextName='" + loginContextName + '\'' +
         '}';
   }
 
@@ -270,6 +278,7 @@ public class Realm {
     private Map<String, String> customLoginConfig;
     private String servicePrincipalName;
     private boolean useCanonicalHostname;
+    private String loginContextName;
 
     public Builder() {
       this.principal = null;
@@ -375,6 +384,11 @@ public class Realm {
 
     public Builder setUseCanonicalHostname(boolean useCanonicalHostname) {
       this.useCanonicalHostname = useCanonicalHostname;
+      return this;
+    }
+
+    public Builder setLoginContextName(String loginContextName) {
+      this.loginContextName = loginContextName;
       return this;
     }
 
@@ -571,7 +585,8 @@ public class Realm {
               omitQuery,
               servicePrincipalName,
               useCanonicalHostname,
-              customLoginConfig);
+              customLoginConfig,
+              loginContextName);
     }
   }
 }

--- a/client/src/main/java/org/asynchttpclient/Realm.java
+++ b/client/src/main/java/org/asynchttpclient/Realm.java
@@ -62,6 +62,8 @@ public class Realm {
   private final boolean useAbsoluteURI;
   private final boolean omitQuery;
   private final Map<String, String> customLoginConfig;
+  private final String servicePrincipalName;
+  private final boolean useCanonicalHostname;
 
   private Realm(AuthScheme scheme,
                 String principal,
@@ -81,6 +83,8 @@ public class Realm {
                 String ntlmHost,
                 boolean useAbsoluteURI,
                 boolean omitQuery,
+                String servicePrincipalName,
+                boolean useCanonicalHostname,
                 Map<String, String> customLoginConfig) {
 
     this.scheme = assertNotNull(scheme, "scheme");
@@ -101,6 +105,8 @@ public class Realm {
     this.ntlmHost = ntlmHost;
     this.useAbsoluteURI = useAbsoluteURI;
     this.omitQuery = omitQuery;
+    this.servicePrincipalName = servicePrincipalName;
+    this.useCanonicalHostname = useCanonicalHostname;
     this.customLoginConfig = customLoginConfig;
   }
 
@@ -195,29 +201,39 @@ public class Realm {
     return customLoginConfig;
   }
 
+  public String getServicePrincipalName() {
+    return servicePrincipalName;
+  }
+
+  public boolean isUseCanonicalHostname() {
+    return useCanonicalHostname;
+  }
+
   @Override
   public String toString() {
     return "Realm{" +
-      "principal='" + principal + '\'' +
-      ", password='" + password + '\'' +
-      ", scheme=" + scheme +
-      ", realmName='" + realmName + '\'' +
-      ", nonce='" + nonce + '\'' +
-      ", algorithm='" + algorithm + '\'' +
-      ", response='" + response + '\'' +
-      ", opaque='" + opaque + '\'' +
-      ", qop='" + qop + '\'' +
-      ", nc='" + nc + '\'' +
-      ", cnonce='" + cnonce + '\'' +
-      ", uri=" + uri +
-      ", usePreemptiveAuth=" + usePreemptiveAuth +
-      ", charset=" + charset +
-      ", ntlmHost='" + ntlmHost + '\'' +
-      ", ntlmDomain='" + ntlmDomain + '\'' +
-      ", useAbsoluteURI=" + useAbsoluteURI +
-      ", omitQuery=" + omitQuery +
-      ", customLoginConfig=" + customLoginConfig +
-      '}';
+        "principal='" + principal + '\'' +
+        ", password='" + password + '\'' +
+        ", scheme=" + scheme +
+        ", realmName='" + realmName + '\'' +
+        ", nonce='" + nonce + '\'' +
+        ", algorithm='" + algorithm + '\'' +
+        ", response='" + response + '\'' +
+        ", opaque='" + opaque + '\'' +
+        ", qop='" + qop + '\'' +
+        ", nc='" + nc + '\'' +
+        ", cnonce='" + cnonce + '\'' +
+        ", uri=" + uri +
+        ", usePreemptiveAuth=" + usePreemptiveAuth +
+        ", charset=" + charset +
+        ", ntlmHost='" + ntlmHost + '\'' +
+        ", ntlmDomain='" + ntlmDomain + '\'' +
+        ", useAbsoluteURI=" + useAbsoluteURI +
+        ", omitQuery=" + omitQuery +
+        ", customLoginConfig=" + customLoginConfig +
+        ", servicePrincipalName='" + servicePrincipalName + '\'' +
+        ", useCanonicalHostname=" + useCanonicalHostname +
+        '}';
   }
 
   public enum AuthScheme {
@@ -248,7 +264,12 @@ public class Realm {
     private String ntlmHost = "localhost";
     private boolean useAbsoluteURI = false;
     private boolean omitQuery;
+    /**
+     * Kerberos/Spnego properties
+     */
     private Map<String, String> customLoginConfig;
+    private String servicePrincipalName;
+    private boolean useCanonicalHostname;
 
     public Builder() {
       this.principal = null;
@@ -344,6 +365,16 @@ public class Realm {
 
     public Builder setCustomLoginConfig(Map<String, String> customLoginConfig) {
       this.customLoginConfig = customLoginConfig;
+      return this;
+    }
+
+    public Builder setServicePrincipalName(String servicePrincipalName) {
+      this.servicePrincipalName = servicePrincipalName;
+      return this;
+    }
+
+    public Builder setUseCanonicalHostname(boolean useCanonicalHostname) {
+      this.useCanonicalHostname = useCanonicalHostname;
       return this;
     }
 
@@ -538,6 +569,8 @@ public class Realm {
               ntlmHost,
               useAbsoluteURI,
               omitQuery,
+              servicePrincipalName,
+              useCanonicalHostname,
               customLoginConfig);
     }
   }

--- a/client/src/main/java/org/asynchttpclient/Realm.java
+++ b/client/src/main/java/org/asynchttpclient/Realm.java
@@ -23,6 +23,7 @@ import org.asynchttpclient.util.StringUtils;
 
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
+import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static java.nio.charset.StandardCharsets.*;
@@ -60,8 +61,7 @@ public class Realm {
   private final String ntlmDomain;
   private final boolean useAbsoluteURI;
   private final boolean omitQuery;
-  private final String spnegoKeytabFilePath;
-  private final String spnegoPrincipal;
+  private final Map<String, String> customLoginConfig;
 
   private Realm(AuthScheme scheme,
                 String principal,
@@ -81,8 +81,7 @@ public class Realm {
                 String ntlmHost,
                 boolean useAbsoluteURI,
                 boolean omitQuery,
-                String spnegoKeytabFilePath,
-                String spnegoPrincipal) {
+                Map<String, String> customLoginConfig) {
 
     this.scheme = assertNotNull(scheme, "scheme");
     this.principal = assertNotNull(principal, "principal");
@@ -102,8 +101,7 @@ public class Realm {
     this.ntlmHost = ntlmHost;
     this.useAbsoluteURI = useAbsoluteURI;
     this.omitQuery = omitQuery;
-    this.spnegoKeytabFilePath = spnegoKeytabFilePath;
-    this.spnegoPrincipal = spnegoPrincipal;
+    this.customLoginConfig = customLoginConfig;
   }
 
   public String getPrincipal() {
@@ -193,20 +191,33 @@ public class Realm {
     return omitQuery;
   }
 
-  public String getSpnegoKeytabFilePath() {
-    return spnegoKeytabFilePath;
-  }
-
-  public String getSpnegoPrincipal() {
-    return spnegoPrincipal;
+  public Map<String, String> getCustomLoginConfig() {
+    return customLoginConfig;
   }
 
   @Override
   public String toString() {
-    return "Realm{" + "principal='" + principal + '\'' + ", scheme=" + scheme + ", realmName='" + realmName + '\''
-            + ", nonce='" + nonce + '\'' + ", algorithm='" + algorithm + '\'' + ", response='" + response + '\''
-            + ", qop='" + qop + '\'' + ", nc='" + nc + '\'' + ", cnonce='" + cnonce + '\'' + ", uri='" + uri + '\''
-            + ", useAbsoluteURI='" + useAbsoluteURI + '\'' + ", omitQuery='" + omitQuery + '\'' + '}';
+    return "Realm{" +
+      "principal='" + principal + '\'' +
+      ", password='" + password + '\'' +
+      ", scheme=" + scheme +
+      ", realmName='" + realmName + '\'' +
+      ", nonce='" + nonce + '\'' +
+      ", algorithm='" + algorithm + '\'' +
+      ", response='" + response + '\'' +
+      ", opaque='" + opaque + '\'' +
+      ", qop='" + qop + '\'' +
+      ", nc='" + nc + '\'' +
+      ", cnonce='" + cnonce + '\'' +
+      ", uri=" + uri +
+      ", usePreemptiveAuth=" + usePreemptiveAuth +
+      ", charset=" + charset +
+      ", ntlmHost='" + ntlmHost + '\'' +
+      ", ntlmDomain='" + ntlmDomain + '\'' +
+      ", useAbsoluteURI=" + useAbsoluteURI +
+      ", omitQuery=" + omitQuery +
+      ", customLoginConfig=" + customLoginConfig +
+      '}';
   }
 
   public enum AuthScheme {
@@ -221,8 +232,6 @@ public class Realm {
     private final String principal;
     private final String password;
     private AuthScheme scheme;
-    private String spnegoKeytabFilePath;
-    private String spnegoPrincipal;
     private String realmName;
     private String nonce;
     private String algorithm;
@@ -239,6 +248,7 @@ public class Realm {
     private String ntlmHost = "localhost";
     private boolean useAbsoluteURI = false;
     private boolean omitQuery;
+    private Map<String, String> customLoginConfig;
 
     public Builder() {
       this.principal = null;
@@ -332,13 +342,8 @@ public class Realm {
       return this;
     }
 
-    public Builder setSpnegoKeytabFilePath(String spnegoKeytabFilePath) {
-      this.spnegoKeytabFilePath = spnegoKeytabFilePath;
-      return this;
-    }
-
-    public Builder setSpnegoPrincipal(String spnegoPrincipal) {
-      this.spnegoPrincipal = spnegoPrincipal;
+    public Builder setCustomLoginConfig(Map<String, String> customLoginConfig) {
+      this.customLoginConfig = customLoginConfig;
       return this;
     }
 
@@ -533,8 +538,7 @@ public class Realm {
               ntlmHost,
               useAbsoluteURI,
               omitQuery,
-              spnegoKeytabFilePath,
-              spnegoPrincipal);
+              customLoginConfig);
     }
   }
 }

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ProxyUnauthorized407Interceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ProxyUnauthorized407Interceptor.java
@@ -188,10 +188,13 @@ public class ProxyUnauthorized407Interceptor {
                                       ProxyServer proxyServer,
                                       HttpHeaders headers) throws SpnegoEngineException {
 
-    String challengeHeader = SpnegoEngine.instance(proxyRealm.getServicePrincipalName(),
+    String challengeHeader = SpnegoEngine.instance(proxyRealm.getPrincipal(),
+        proxyRealm.getPassword(),
+        proxyRealm.getServicePrincipalName(),
         proxyRealm.getRealmName(),
         proxyRealm.isUseCanonicalHostname(),
-        proxyRealm.getCustomLoginConfig()).generateToken(proxyServer.getHost());
+        proxyRealm.getCustomLoginConfig(),
+        proxyRealm.getLoginContextName()).generateToken(proxyServer.getHost());
     headers.set(PROXY_AUTHORIZATION, NEGOTIATE + " " + challengeHeader);
   }
 

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ProxyUnauthorized407Interceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ProxyUnauthorized407Interceptor.java
@@ -188,7 +188,10 @@ public class ProxyUnauthorized407Interceptor {
                                       ProxyServer proxyServer,
                                       HttpHeaders headers) throws SpnegoEngineException {
 
-    String challengeHeader = SpnegoEngine.instance(proxyRealm.getCustomLoginConfig()).generateToken(proxyServer.getHost());
+    String challengeHeader = SpnegoEngine.instance(proxyRealm.getServicePrincipalName(),
+        proxyRealm.getRealmName(),
+        proxyRealm.isUseCanonicalHostname(),
+        proxyRealm.getCustomLoginConfig()).generateToken(proxyServer.getHost());
     headers.set(PROXY_AUTHORIZATION, NEGOTIATE + " " + challengeHeader);
   }
 

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ProxyUnauthorized407Interceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ProxyUnauthorized407Interceptor.java
@@ -140,7 +140,7 @@ public class ProxyUnauthorized407Interceptor {
           return false;
         }
         try {
-          kerberosProxyChallenge(proxyServer, requestHeaders);
+          kerberosProxyChallenge(proxyRealm, proxyServer, requestHeaders);
 
         } catch (SpnegoEngineException e) {
           // FIXME
@@ -184,10 +184,11 @@ public class ProxyUnauthorized407Interceptor {
     return true;
   }
 
-  private void kerberosProxyChallenge(ProxyServer proxyServer,
+  private void kerberosProxyChallenge(Realm proxyRealm,
+                                      ProxyServer proxyServer,
                                       HttpHeaders headers) throws SpnegoEngineException {
 
-    String challengeHeader = SpnegoEngine.instance().generateToken(proxyServer.getHost());
+    String challengeHeader = SpnegoEngine.instance(proxyRealm.getSpnegoKeytabFilePath(), proxyRealm.getSpnegoPrincipal()).generateToken(proxyServer.getHost());
     headers.set(PROXY_AUTHORIZATION, NEGOTIATE + " " + challengeHeader);
   }
 

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ProxyUnauthorized407Interceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ProxyUnauthorized407Interceptor.java
@@ -188,7 +188,7 @@ public class ProxyUnauthorized407Interceptor {
                                       ProxyServer proxyServer,
                                       HttpHeaders headers) throws SpnegoEngineException {
 
-    String challengeHeader = SpnegoEngine.instance(proxyRealm.getSpnegoKeytabFilePath(), proxyRealm.getSpnegoPrincipal()).generateToken(proxyServer.getHost());
+    String challengeHeader = SpnegoEngine.instance(proxyRealm.getCustomLoginConfig()).generateToken(proxyServer.getHost());
     headers.set(PROXY_AUTHORIZATION, NEGOTIATE + " " + challengeHeader);
   }
 

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Unauthorized401Interceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Unauthorized401Interceptor.java
@@ -206,7 +206,10 @@ public class Unauthorized401Interceptor {
 
     Uri uri = request.getUri();
     String host = withDefault(request.getVirtualHost(), uri.getHost());
-    String challengeHeader = SpnegoEngine.instance(realm.getCustomLoginConfig()).generateToken(host);
+    String challengeHeader = SpnegoEngine.instance(realm.getServicePrincipalName(),
+        realm.getRealmName(),
+        realm.isUseCanonicalHostname(),
+        realm.getCustomLoginConfig()).generateToken(host);
     headers.set(AUTHORIZATION, NEGOTIATE + " " + challengeHeader);
   }
 }

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Unauthorized401Interceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Unauthorized401Interceptor.java
@@ -206,10 +206,13 @@ public class Unauthorized401Interceptor {
 
     Uri uri = request.getUri();
     String host = withDefault(request.getVirtualHost(), uri.getHost());
-    String challengeHeader = SpnegoEngine.instance(realm.getServicePrincipalName(),
+    String challengeHeader = SpnegoEngine.instance(realm.getPrincipal(),
+        realm.getPassword(),
+        realm.getServicePrincipalName(),
         realm.getRealmName(),
         realm.isUseCanonicalHostname(),
-        realm.getCustomLoginConfig()).generateToken(host);
+        realm.getCustomLoginConfig(),
+        realm.getLoginContextName()).generateToken(host);
     headers.set(AUTHORIZATION, NEGOTIATE + " " + challengeHeader);
   }
 }

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Unauthorized401Interceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Unauthorized401Interceptor.java
@@ -206,7 +206,7 @@ public class Unauthorized401Interceptor {
 
     Uri uri = request.getUri();
     String host = withDefault(request.getVirtualHost(), uri.getHost());
-    String challengeHeader = SpnegoEngine.instance(realm.getSpnegoKeytabFilePath(), realm.getSpnegoPrincipal()).generateToken(host);
+    String challengeHeader = SpnegoEngine.instance(realm.getCustomLoginConfig()).generateToken(host);
     headers.set(AUTHORIZATION, NEGOTIATE + " " + challengeHeader);
   }
 }

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Unauthorized401Interceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Unauthorized401Interceptor.java
@@ -139,7 +139,7 @@ public class Unauthorized401Interceptor {
           return false;
         }
         try {
-          kerberosChallenge(request, requestHeaders);
+          kerberosChallenge(realm, request, requestHeaders);
 
         } catch (SpnegoEngineException e) {
           // FIXME
@@ -200,12 +200,13 @@ public class Unauthorized401Interceptor {
     }
   }
 
-  private void kerberosChallenge(Request request,
+  private void kerberosChallenge(Realm realm,
+                                 Request request,
                                  HttpHeaders headers) throws SpnegoEngineException {
 
     Uri uri = request.getUri();
     String host = withDefault(request.getVirtualHost(), uri.getHost());
-    String challengeHeader = SpnegoEngine.instance().generateToken(host);
+    String challengeHeader = SpnegoEngine.instance(realm.getSpnegoKeytabFilePath(), realm.getSpnegoPrincipal()).generateToken(host);
     headers.set(AUTHORIZATION, NEGOTIATE + " " + challengeHeader);
   }
 }

--- a/client/src/main/java/org/asynchttpclient/spnego/NamePasswordCallbackHandler.java
+++ b/client/src/main/java/org/asynchttpclient/spnego/NamePasswordCallbackHandler.java
@@ -1,0 +1,82 @@
+package org.asynchttpclient.spnego;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import java.io.IOException;
+import java.lang.reflect.Method;
+
+public class NamePasswordCallbackHandler implements CallbackHandler {
+  private final Logger log = LoggerFactory.getLogger(getClass());
+  private static final String PASSWORD_CALLBACK_NAME = "setObject";
+  private static final Class<?>[] PASSWORD_CALLBACK_TYPES =
+      new Class<?>[] {Object.class, char[].class, String.class};
+
+  private String username;
+  private String password;
+
+  private String passwordCallbackName;
+
+  public NamePasswordCallbackHandler(String username, String password) {
+    this(username, password, null);
+  }
+
+  public NamePasswordCallbackHandler(String username, String password, String passwordCallbackName) {
+    this.username = username;
+    this.password = password;
+    this.passwordCallbackName = passwordCallbackName;
+  }
+
+  public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+    for (int i = 0; i < callbacks.length; i++) {
+      Callback callback = callbacks[i];
+      if (handleCallback(callback)) {
+        continue;
+      } else if (callback instanceof NameCallback) {
+        ((NameCallback) callback).setName(username);
+      } else if (callback instanceof PasswordCallback) {
+        PasswordCallback pwCallback = (PasswordCallback) callback;
+        pwCallback.setPassword(password.toCharArray());
+      } else if (!invokePasswordCallback(callback)) {
+        String errorMsg = "Unsupported callback type " + callbacks[i].getClass().getName();
+        log.info(errorMsg);
+        throw new UnsupportedCallbackException(callbacks[i], errorMsg);
+      }
+    }
+  }
+
+  protected boolean handleCallback(Callback callback) {
+    return false;
+  }
+
+  /*
+   * This method is called from the handle(Callback[]) method when the specified callback
+   * did not match any of the known callback classes. It looks for the callback method
+   * having the specified method name with one of the suppported parameter types.
+   * If found, it invokes the callback method on the object and returns true.
+   * If not, it returns false.
+   */
+  private boolean invokePasswordCallback(Callback callback) {
+    String cbname = passwordCallbackName == null
+        ? PASSWORD_CALLBACK_NAME : passwordCallbackName;
+    for (Class<?> arg : PASSWORD_CALLBACK_TYPES) {
+      try {
+        Method method = callback.getClass().getMethod(cbname, arg);
+        Object args[] = new Object[] {
+            arg == String.class ? password : password.toCharArray()
+        };
+        method.invoke(callback, args);
+        return true;
+      } catch (Exception e) {
+        // ignore and continue
+        log.debug(e.toString());
+      }
+    }
+    return false;
+  }
+}

--- a/client/src/main/java/org/asynchttpclient/spnego/SpnegoEngine.java
+++ b/client/src/main/java/org/asynchttpclient/spnego/SpnegoEngine.java
@@ -140,7 +140,7 @@ public class SpnegoEngine {
           final Oid negotiationOidFinal = negotiationOid;
           final PrivilegedExceptionAction<GSSCredential> action = () -> manager.createCredential(null,
             GSSCredential.INDEFINITE_LIFETIME, negotiationOidFinal, GSSCredential.INITIATE_AND_ACCEPT);
-          myCred = loginContext != null ? Subject.doAs(loginContext.getSubject(), action) : null;
+          myCred = Subject.doAs(loginContext.getSubject(), action);
         }
         gssContext = manager.createContext(serverName.canonicalize(negotiationOid), negotiationOid, myCred, GSSContext.DEFAULT_LIFETIME);
         gssContext.requestMutualAuth(true);

--- a/client/src/main/java/org/asynchttpclient/spnego/SpnegoEngine.java
+++ b/client/src/main/java/org/asynchttpclient/spnego/SpnegoEngine.java
@@ -67,7 +67,7 @@ public class SpnegoEngine {
 
   private static final String SPNEGO_OID = "1.3.6.1.5.5.2";
   private static final String KERBEROS_OID = "1.2.840.113554.1.2.2";
-  private static SpnegoEngine instance;
+  private static Map<String, SpnegoEngine> instances = new HashMap<>();
   private final Logger log = LoggerFactory.getLogger(getClass());
   private final SpnegoTokenGenerator spnegoGenerator;
   private final Map<String, String> customLoginConfig;
@@ -82,9 +82,19 @@ public class SpnegoEngine {
   }
 
   public static SpnegoEngine instance(final Map<String, String> customLoginConfig) {
-    if (instance == null)
-      instance = new SpnegoEngine(customLoginConfig, null);
-    return instance;
+    String key = "";
+    if (customLoginConfig != null) {
+      StringBuilder customLoginConfigKeyValues = new StringBuilder();
+      for (String loginConfigKey : customLoginConfig.keySet()) {
+        customLoginConfigKeyValues.append(loginConfigKey).append("=")
+          .append(customLoginConfig.get(loginConfigKey));
+      }
+      key = customLoginConfigKeyValues.toString();
+    }
+    if (!instances.containsKey(key)) {
+      instances.put(key, new SpnegoEngine(customLoginConfig, null));
+    }
+    return instances.get(key);
   }
 
   public String generateToken(String server) throws SpnegoEngineException {

--- a/client/src/main/java/org/asynchttpclient/spnego/SpnegoEngine.java
+++ b/client/src/main/java/org/asynchttpclient/spnego/SpnegoEngine.java
@@ -117,13 +117,19 @@ public class SpnegoEngine {
                                       final Map<String, String> customLoginConfig,
                                       final String loginContextName) {
     String key = "";
-    if (customLoginConfig != null) {
+    if (customLoginConfig != null && !customLoginConfig.isEmpty()) {
       StringBuilder customLoginConfigKeyValues = new StringBuilder();
       for (String loginConfigKey : customLoginConfig.keySet()) {
         customLoginConfigKeyValues.append(loginConfigKey).append("=")
           .append(customLoginConfig.get(loginConfigKey));
       }
       key = customLoginConfigKeyValues.toString();
+    }
+    if (username != null) {
+      key += username;
+    }
+    if (loginContextName != null) {
+      key += loginContextName;
     }
     if (!instances.containsKey(key)) {
       instances.put(key, new SpnegoEngine(username,

--- a/client/src/main/java/org/asynchttpclient/util/AuthenticatorUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/AuthenticatorUtils.java
@@ -175,7 +175,7 @@ public final class AuthenticatorUtils {
             host = request.getUri().getHost();
 
           try {
-            authorizationHeader = NEGOTIATE + " " + SpnegoEngine.instance(realm.getSpnegoKeytabFilePath(), realm.getSpnegoPrincipal()).generateToken(host);
+            authorizationHeader = NEGOTIATE + " " + SpnegoEngine.instance(realm.getCustomLoginConfig()).generateToken(host);
           } catch (SpnegoEngineException e) {
             throw new RuntimeException(e);
           }

--- a/client/src/main/java/org/asynchttpclient/util/AuthenticatorUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/AuthenticatorUtils.java
@@ -175,10 +175,14 @@ public final class AuthenticatorUtils {
             host = request.getUri().getHost();
 
           try {
-            authorizationHeader = NEGOTIATE + " " + SpnegoEngine.instance(realm.getServicePrincipalName(),
+            authorizationHeader = NEGOTIATE + " " + SpnegoEngine.instance(
+                realm.getPrincipal(),
+                realm.getPassword(),
+                realm.getServicePrincipalName(),
                 realm.getRealmName(),
                 realm.isUseCanonicalHostname(),
-                realm.getCustomLoginConfig()).generateToken(host);
+                realm.getCustomLoginConfig(),
+                realm.getLoginContextName()).generateToken(host);
           } catch (SpnegoEngineException e) {
             throw new RuntimeException(e);
           }

--- a/client/src/main/java/org/asynchttpclient/util/AuthenticatorUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/AuthenticatorUtils.java
@@ -175,7 +175,7 @@ public final class AuthenticatorUtils {
             host = request.getUri().getHost();
 
           try {
-            authorizationHeader = NEGOTIATE + " " + SpnegoEngine.instance().generateToken(host);
+            authorizationHeader = NEGOTIATE + " " + SpnegoEngine.instance(realm.getSpnegoKeytabFilePath(), realm.getSpnegoPrincipal()).generateToken(host);
           } catch (SpnegoEngineException e) {
             throw new RuntimeException(e);
           }

--- a/client/src/main/java/org/asynchttpclient/util/AuthenticatorUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/AuthenticatorUtils.java
@@ -175,7 +175,10 @@ public final class AuthenticatorUtils {
             host = request.getUri().getHost();
 
           try {
-            authorizationHeader = NEGOTIATE + " " + SpnegoEngine.instance(realm.getCustomLoginConfig()).generateToken(host);
+            authorizationHeader = NEGOTIATE + " " + SpnegoEngine.instance(realm.getServicePrincipalName(),
+                realm.getRealmName(),
+                realm.isUseCanonicalHostname(),
+                realm.getCustomLoginConfig()).generateToken(host);
           } catch (SpnegoEngineException e) {
             throw new RuntimeException(e);
           }

--- a/client/src/test/java/org/asynchttpclient/spnego/SpnegoEngineTest.java
+++ b/client/src/test/java/org/asynchttpclient/spnego/SpnegoEngineTest.java
@@ -3,7 +3,6 @@ package org.asynchttpclient.spnego;
 import org.apache.commons.io.FileUtils;
 import org.apache.kerby.kerberos.kerb.server.SimpleKdcServer;
 import org.asynchttpclient.AbstractBasicTest;
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -61,8 +60,6 @@ public class SpnegoEngineTest extends AbstractBasicTest {
     kerbyServer.start();
 
     FileUtils.copyInputStreamToFile(SpnegoEngine.class.getResourceAsStream("/kerberos.jaas"), loginConfig);
-
-    LoggerFactory.getLogger(SpnegoEngineTest.class).info("Able to log in as {} successfully. Kerby server is ready.", alice);
   }
 
   @Test

--- a/client/src/test/java/org/asynchttpclient/spnego/SpnegoEngineTest.java
+++ b/client/src/test/java/org/asynchttpclient/spnego/SpnegoEngineTest.java
@@ -1,0 +1,116 @@
+package org.asynchttpclient.spnego;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.kerby.kerberos.kerb.server.SimpleKdcServer;
+import org.asynchttpclient.AbstractBasicTest;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import javax.security.auth.Subject;
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
+import javax.security.auth.login.LoginContext;
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SpnegoEngineTest extends AbstractBasicTest {
+  private static SimpleKdcServer kerbyServer;
+
+  private static String basedir;
+  private static String alice;
+  private static String bob;
+  private static File aliceKeytab;
+  private static File bobKeytab;
+
+  @BeforeClass
+  public static void startServers() throws Exception {
+    basedir = System.getProperty("basedir");
+    if (basedir == null) {
+      basedir = new File(".").getCanonicalPath();
+    }
+
+    // System.setProperty("sun.security.krb5.debug", "true");
+    System.setProperty("java.security.krb5.conf",
+        new File(basedir + File.separator + "target" + File.separator + "krb5.conf").getCanonicalPath());
+
+    kerbyServer = new SimpleKdcServer();
+
+    kerbyServer.setKdcRealm("service.ws.apache.org");
+    kerbyServer.setAllowUdp(false);
+    kerbyServer.setWorkDir(new File(basedir, "target"));
+
+    //kerbyServer.setInnerKdcImpl(new NettyKdcServerImpl(kerbyServer.getKdcSetting()));
+
+    kerbyServer.init();
+
+    // Create principals
+    alice = "alice@service.ws.apache.org";
+    bob = "bob/service.ws.apache.org@service.ws.apache.org";
+
+    kerbyServer.createPrincipal(alice, "alice");
+    kerbyServer.createPrincipal(bob, "bob");
+
+    aliceKeytab = new File(basedir + File.separator + "target" + File.separator + "alice.keytab");
+    bobKeytab = new File(basedir + File.separator + "target" + File.separator + "bob.keytab");
+    kerbyServer.exportPrincipal(alice, aliceKeytab);
+    kerbyServer.exportPrincipal(bob, bobKeytab);
+
+    kerbyServer.start();
+
+    Map<String, String> loginConfig = new HashMap<>();
+    loginConfig.put("useKeyTab", "true");
+    loginConfig.put("refreshKrb5Config", "true");
+    loginConfig.put("keyTab", bobKeytab.getCanonicalPath());
+    loginConfig.put("principal", bob);
+    loginConfig.put("debug", String.valueOf(true));
+
+    LoginContext loginContext;
+    loginContext = new LoginContext("", new Subject(), null, new Configuration() {
+      @Override
+      public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+        return new AppConfigurationEntry[] {
+            new AppConfigurationEntry("com.sun.security.auth.module.Krb5LoginModule",
+                AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+                loginConfig)};
+      }
+    });
+    loginContext.login();
+
+    LoggerFactory.getLogger(SpnegoEngineTest.class).info("Able to log in as {} successfully. Kerby server is ready.", alice);
+
+    loginContext.logout();
+  }
+
+  @Test
+  public void testSpnegoGenerateTokenWithCustomLoginConfig() throws Exception {
+    Map<String, String> loginConfig = new HashMap<>();
+    loginConfig.put("useKeyTab", "true");
+    loginConfig.put("storeKey", "true");
+    loginConfig.put("refreshKrb5Config", "true");
+    loginConfig.put("keyTab", aliceKeytab.getCanonicalPath());
+    loginConfig.put("principal", alice);
+    loginConfig.put("debug", String.valueOf(true));
+    SpnegoEngine spnegoEngine = new SpnegoEngine("bob",
+        "service.ws.apache.org",
+        false,
+        loginConfig,
+        null);
+
+    String token = spnegoEngine.generateToken("localhost");
+    Assert.assertNotNull(token);
+    Assert.assertTrue(token.startsWith("YII"));
+  }
+
+  @AfterClass
+  public static void cleanup() throws Exception {
+    if (kerbyServer != null) {
+      kerbyServer.stop();
+    }
+    FileUtils.deleteQuietly(aliceKeytab);
+    FileUtils.deleteQuietly(bobKeytab);
+  }
+}

--- a/client/src/test/resources/kerberos.jaas
+++ b/client/src/test/resources/kerberos.jaas
@@ -1,0 +1,8 @@
+
+alice {
+    com.sun.security.auth.module.Krb5LoginModule required refreshKrb5Config=true useKeyTab=false principal="alice";
+};
+
+bob {
+    com.sun.security.auth.module.Krb5LoginModule required refreshKrb5Config=true useKeyTab=false storeKey=true principal="bob/service.ws.apache.org";
+};

--- a/client/src/test/resources/kerberos.jaas
+++ b/client/src/test/resources/kerberos.jaas
@@ -1,8 +1,0 @@
-
-alice {
-    com.sun.security.auth.module.Krb5LoginModule required refreshKrb5Config=true useKeyTab=false principal="alice";
-};
-
-bob {
-    com.sun.security.auth.module.Krb5LoginModule required refreshKrb5Config=true useKeyTab=false storeKey=true principal="bob/service.ws.apache.org";
-};

--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,12 @@
         <artifactId>rxjava</artifactId>
         <version>${rxjava2.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.kerby</groupId>
+        <artifactId>kerb-simplekdc</artifactId>
+        <version>${cxf.kerby.version}</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -418,5 +424,6 @@
     <privilegedaccessor.version>1.2.2</privilegedaccessor.version>
     <mockito.version>2.19.0</mockito.version>
     <hamcrest.version>2.0.0.0</hamcrest.version>
+    <cxf.kerby.version>1.1.1</cxf.kerby.version>
   </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,7 @@
       <dependency>
         <groupId>org.apache.kerby</groupId>
         <artifactId>kerb-simplekdc</artifactId>
-        <version>${cxf.kerby.version}</version>
+        <version>${kerby.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>
@@ -424,6 +424,6 @@
     <privilegedaccessor.version>1.2.2</privilegedaccessor.version>
     <mockito.version>2.19.0</mockito.version>
     <hamcrest.version>2.0.0.0</hamcrest.version>
-    <cxf.kerby.version>1.1.1</cxf.kerby.version>
+    <kerby.version>1.1.1</kerby.version>
   </properties>
 </project>


### PR DESCRIPTION
# SpnegoEngine improvements

## Summary 

The current spnego implementation locks you into using a single kerberos login configuration, and the SpnegoEngine has no unit test coverage.

This fixes those things.

* Add a `SpnegoEngineTest` that uses apache kerby to test `SpnegoEngine`.
* Allow different JAAS login configurations as parameters to `SpnegoEngine`.
* Properly obtain SPN and don't hard code `HTTP@` spns.
* We should not need to specify a username/password in the `new Realm.Builder()`. It's optional for spnego, so we should not be asserting that it's not null.

## New parameters to the `SpnegoEngine` (parameters added to Realm/DSL where needed)
`servicePrincipalName` - new param* - to allow user to specify their own SPN.
`useCanonicalHostname` -new param* -  whether or not to obtain the canonical hostname or just use the raw host.
`customLoginConfig` - new param* - allow to specify your own login configuration as map<string, string>
`loginContextName` - new param* - allow to choose a specific login configuration from the login conf
`realmName` - send existing realm name to spnego engine to allow users to customize the `@realmName` appended to the SPN.
`username` and `password` - send existing principal and password to the spnego engine to allow username/password kerberos auth as well.