### PR TITLE
Add non-null ResponseBody for responses with empty body

### DIFF
--- a/extras/retrofit2/src/main/java/org/asynchttpclient/extras/retrofit/AsyncHttpClientCall.java
+++ b/extras/retrofit2/src/main/java/org/asynchttpclient/extras/retrofit/AsyncHttpClientCall.java
@@ -45,6 +45,8 @@ class AsyncHttpClientCall implements Cloneable, okhttp3.Call {
    * @see #executeTimeoutMillis
    */
   public static final long DEFAULT_EXECUTE_TIMEOUT_MILLIS = 30_000;
+
+  private static final ResponseBody EMPTY_BODY = ResponseBody.create(null, "");
   /**
    * Tells whether call has been executed.
    *
@@ -255,7 +257,7 @@ class AsyncHttpClientCall implements Cloneable, okhttp3.Call {
       val okHttpBody = ResponseBody.create(contentType, asyncHttpClientResponse.getResponseBodyAsBytes());
       rspBuilder.body(okHttpBody);
     } else {
-      rspBuilder.body(ResponseBody.create(null, ""));
+      rspBuilder.body(EMPTY_BODY);
     }
 
     return rspBuilder.build();

--- a/extras/retrofit2/src/main/java/org/asynchttpclient/extras/retrofit/AsyncHttpClientCall.java
+++ b/extras/retrofit2/src/main/java/org/asynchttpclient/extras/retrofit/AsyncHttpClientCall.java
@@ -254,6 +254,8 @@ class AsyncHttpClientCall implements Cloneable, okhttp3.Call {
               ? null : MediaType.parse(asyncHttpClientResponse.getContentType());
       val okHttpBody = ResponseBody.create(contentType, asyncHttpClientResponse.getResponseBodyAsBytes());
       rspBuilder.body(okHttpBody);
+    } else {
+      rspBuilder.body(ResponseBody.create(null, ""));
     }
 
     return rspBuilder.build();

--- a/extras/retrofit2/src/test/java/org/asynchttpclient/extras/retrofit/AsyncHttpClientCallTest.java
+++ b/extras/retrofit2/src/test/java/org/asynchttpclient/extras/retrofit/AsyncHttpClientCallTest.java
@@ -41,6 +41,7 @@ import static org.asynchttpclient.extras.retrofit.AsyncHttpClientCall.runConsume
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 public class AsyncHttpClientCallTest {
@@ -281,6 +282,19 @@ public class AsyncHttpClientCallTest {
 
     }
 
+    @Test
+    public void bodyIsNotNullInResponse() throws Exception {
+        AsyncHttpClient client = mock(AsyncHttpClient.class);
+
+        givenResponseIsProduced(client, responseWithNoBody());
+
+        okhttp3.Response response = whenRequestIsMade(client, REQUEST);
+
+        assertEquals(response.code(), 200);
+        assertEquals(response.header("Server"), "nginx");
+        assertNotEquals(response.body(), null);
+    }
+
     private void givenResponseIsProduced(AsyncHttpClient client, Response response) {
         when(client.executeRequest(any(org.asynchttpclient.Request.class), any())).thenAnswer(invocation -> {
             AsyncCompletionHandler<Response> handler = invocation.getArgument(1);
@@ -320,6 +334,13 @@ public class AsyncHttpClientCallTest {
         when(response.hasResponseBody()).thenReturn(true);
         when(response.getContentType()).thenReturn(contentType);
         when(response.getResponseBodyAsBytes()).thenReturn(content.getBytes(StandardCharsets.UTF_8));
+        return response;
+    }
+
+    private Response responseWithNoBody() {
+        Response response = aResponse();
+        when(response.hasResponseBody()).thenReturn(false);
+        when(response.getContentType()).thenReturn(null);
         return response;
     }
 


### PR DESCRIPTION
PR after discussion [NullPointer while processing response with no body using retrofit](https://github.com/AsyncHttpClient/async-http-client/issues/1568)