### PR TITLE
Allow setting headers using a Map with a subclass of CharSequence as the key type

### DIFF
--- a/client/src/main/java/org/asynchttpclient/RequestBuilderBase.java
+++ b/client/src/main/java/org/asynchttpclient/RequestBuilderBase.java
@@ -267,7 +267,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
    * @param headers map of header names as the map keys and header values {@link Iterable} as the map values
    * @return {@code this}
    */
-  public T setHeaders(Map<CharSequence, ? extends Iterable<?>> headers) {
+  public T setHeaders(Map<? extends CharSequence, ? extends Iterable<?>> headers) {
     clearHeaders();
     if (headers != null) {
       headers.forEach((name, values) -> this.headers.add(name, values));
@@ -282,7 +282,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
    * @param headers map of header names as the map keys and header values as the map values
    * @return {@code this}
    */
-  public T setSingleHeaders(Map<CharSequence, ?> headers) {
+  public T setSingleHeaders(Map<? extends CharSequence, ?> headers) {
     clearHeaders();
     if (headers != null) {
       headers.forEach((name, value) -> this.headers.add(name, value));

--- a/client/src/test/java/org/asynchttpclient/RequestBuilderTest.java
+++ b/client/src/test/java/org/asynchttpclient/RequestBuilderTest.java
@@ -20,10 +20,7 @@ import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.util.*;
-import java.util.concurrent.ExecutionException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
@@ -173,5 +170,17 @@ public class RequestBuilderTest {
     requestBuilder.setUrl("http://localhost");
     Request request = requestBuilder.build();
     assertEquals(request.getUrl(), "http://localhost?key=value");
+  }
+
+  @Test
+  public void testSettingHeadersUsingMapWithStringKeys() {
+    Map<String, List<String>> headers = new HashMap<>();
+    headers.put("X-Forwarded-For", singletonList("10.0.0.1"));
+
+    RequestBuilder requestBuilder = new RequestBuilder();
+    requestBuilder.setHeaders(headers);
+    requestBuilder.setUrl("http://localhost");
+    Request request =  requestBuilder.build();
+    assertEquals(request.getHeaders().get("X-Forwarded-For"), "10.0.0.1");
   }
 }

--- a/extras/simple/src/main/java/org/asynchttpclient/extras/simple/SimpleAsyncHttpClient.java
+++ b/extras/simple/src/main/java/org/asynchttpclient/extras/simple/SimpleAsyncHttpClient.java
@@ -380,7 +380,7 @@ public class SimpleAsyncHttpClient implements Closeable {
 
     DerivedBuilder setFormParams(Map<String, List<String>> params);
 
-    DerivedBuilder setHeaders(Map<CharSequence, Collection<?>> headers);
+    DerivedBuilder setHeaders(Map<? extends CharSequence, Collection<?>> headers);
 
     DerivedBuilder setHeaders(HttpHeaders headers);
 
@@ -465,7 +465,7 @@ public class SimpleAsyncHttpClient implements Closeable {
       return this;
     }
 
-    public Builder setHeaders(Map<CharSequence, Collection<?>> headers) {
+    public Builder setHeaders(Map<? extends CharSequence, Collection<?>> headers) {
       requestBuilder.setHeaders(headers);
       return this;
     }


### PR DESCRIPTION
Currently this isn't supported:

```
Map<String, List<String>> headers = new HashMap<>();
headers.put("X-Forwarded-For", Colllections.singletonList("10.0.0.1"));

RequestBuilder requestBuilder = new RequestBuilder();
requestBuilder.setHeaders(headers);
```

My IDE reports: `Cannot resolve method 'setHeaders(java.util.Map<java.lang.String,java.util.List<java.lang.String>>)'`

This pull requests adds support for the above construct.