### PR TITLE
Fix SpnegoEngine.getCompleteServicePrincipalName when servicePrincipalName is not specified.

### DIFF
--- a/client/src/main/java/org/asynchttpclient/spnego/SpnegoEngine.java
+++ b/client/src/main/java/org/asynchttpclient/spnego/SpnegoEngine.java
@@ -262,12 +262,12 @@ public class SpnegoEngine {
       if (useCanonicalHostname) {
         host = getCanonicalHostname(host);
       }
-      name = "HTTP/" + host;
+      name = "HTTP@" + host;
     } else {
       name = servicePrincipalName;
-    }
-    if (realmName != null) {
-      name += "@" + realmName;
+      if (realmName != null && !name.contains("@")) {
+        name += "@" + realmName;
+      }
     }
     log.debug("Service Principal Name is {}", name);
     return name;

--- a/client/src/main/java/org/asynchttpclient/spnego/SpnegoEngine.java
+++ b/client/src/main/java/org/asynchttpclient/spnego/SpnegoEngine.java
@@ -256,7 +256,7 @@ public class SpnegoEngine {
     }
   }
 
-  protected String getCompleteServicePrincipalName(String host) {
+  String getCompleteServicePrincipalName(String host) {
     String name;
     if (servicePrincipalName == null) {
       if (useCanonicalHostname) {
@@ -285,7 +285,7 @@ public class SpnegoEngine {
     return canonicalHostname;
   }
 
-  public CallbackHandler getUsernamePasswordHandler() {
+  private CallbackHandler getUsernamePasswordHandler() {
     if (username == null) {
       return null;
     }

--- a/client/src/test/java/org/asynchttpclient/spnego/SpnegoEngineTest.java
+++ b/client/src/test/java/org/asynchttpclient/spnego/SpnegoEngineTest.java
@@ -113,6 +113,44 @@ public class SpnegoEngineTest extends AbstractBasicTest {
     Assert.assertTrue(token.startsWith("YII"));
   }
 
+  @Test
+  public void testGetCompleteServicePrincipalName() throws Exception {
+    {
+      SpnegoEngine spnegoEngine = new SpnegoEngine(null,
+          null,
+          "bob",
+          "service.ws.apache.org",
+          false,
+          null,
+          null,
+          null);
+      Assert.assertEquals("bob@service.ws.apache.org", spnegoEngine.getCompleteServicePrincipalName("localhost"));
+    }
+    {
+      SpnegoEngine spnegoEngine = new SpnegoEngine(null,
+          null,
+          null,
+          "service.ws.apache.org",
+          true,
+          null,
+          null,
+          null);
+      Assert.assertNotEquals("HTTP@localhost", spnegoEngine.getCompleteServicePrincipalName("localhost"));
+      Assert.assertTrue(spnegoEngine.getCompleteServicePrincipalName("localhost").startsWith("HTTP@"));
+    }
+    {
+      SpnegoEngine spnegoEngine = new SpnegoEngine(null,
+          null,
+          null,
+          "service.ws.apache.org",
+          false,
+          null,
+          null,
+          null);
+      Assert.assertEquals("HTTP@localhost", spnegoEngine.getCompleteServicePrincipalName("localhost"));
+    }
+  }
+
   @AfterClass
   public static void cleanup() throws Exception {
     if (kerbyServer != null) {


### PR DESCRIPTION
Small fix related to previous PR https://github.com/AsyncHttpClient/async-http-client/pull/1582/files

By making my previous fix I broke scenario when principal name is not specified.

Added a simple unit test to prove this works better. 