### PR TITLE
#857 Support multipart files using InputStream from source file

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,6 @@ This part can be of type:
 * `InputStreamPart`
 * `StringPart`
 
-**NOTE**: `InputStreamPart` does not support zero-copy transfers. Explicitly disable zero-copy using `config.setDisableZeroCopy(true)` when one of the body parts is an `InputStreamPart`.
-
 ### Dealing with Responses
 
 #### Blocking on the Future

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Use the `addBodyPart` method to add a multipart part to the request.
 This part can be of type:
 * `ByteArrayPart`
 * `FilePart`
+* `InputStreamPart`
 * `StringPart`
 
 ### Dealing with Responses

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ This part can be of type:
 * `InputStreamPart`
 * `StringPart`
 
+**NOTE**: `InputStreamPart` does not support zero-copy transfers. Explicitly disable zero-copy using `config.setDisableZeroCopy(true)` when one of the body parts is an `InputStreamPart`.
+
 ### Dealing with Responses
 
 #### Blocking on the Future

--- a/client/src/main/java/org/asynchttpclient/netty/request/body/NettyBodyBody.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/body/NettyBodyBody.java
@@ -53,14 +53,8 @@ public class NettyBodyBody implements NettyBody {
   public void write(final Channel channel, NettyResponseFuture<?> future) {
 
     Object msg;
-    if (body instanceof RandomAccessBody && !ChannelManager.isSslHandlerConfigured(channel.pipeline()) && !config.isDisableZeroCopy()) {
-      long contentLength = getContentLength();
-      if (contentLength < 0) {
-        // contentLength unknown in advance, use chunked input
-        msg = new BodyChunkedInput(body);
-      } else {
-        msg = new BodyFileRegion((RandomAccessBody) body);
-      }
+    if (body instanceof RandomAccessBody && !ChannelManager.isSslHandlerConfigured(channel.pipeline()) && !config.isDisableZeroCopy() && getContentLength() > 0) {
+      msg = new BodyFileRegion((RandomAccessBody) body);
 
     } else {
       msg = new BodyChunkedInput(body);

--- a/client/src/main/java/org/asynchttpclient/netty/request/body/NettyBodyBody.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/body/NettyBodyBody.java
@@ -54,13 +54,7 @@ public class NettyBodyBody implements NettyBody {
 
     Object msg;
     if (body instanceof RandomAccessBody && !ChannelManager.isSslHandlerConfigured(channel.pipeline()) && !config.isDisableZeroCopy()) {
-      long contentLength = getContentLength();
-      if (contentLength < 0) {
-        // contentLength unknown in advance, use chunked input
-        msg = new BodyChunkedInput(body);
-      } else {
-        msg = new BodyFileRegion((RandomAccessBody) body);
-      }
+      msg = new BodyFileRegion((RandomAccessBody) body);
 
     } else {
       msg = new BodyChunkedInput(body);

--- a/client/src/main/java/org/asynchttpclient/netty/request/body/NettyBodyBody.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/body/NettyBodyBody.java
@@ -54,7 +54,13 @@ public class NettyBodyBody implements NettyBody {
 
     Object msg;
     if (body instanceof RandomAccessBody && !ChannelManager.isSslHandlerConfigured(channel.pipeline()) && !config.isDisableZeroCopy()) {
-      msg = new BodyFileRegion((RandomAccessBody) body);
+      long contentLength = getContentLength();
+      if (contentLength < 0) {
+        // contentLength unknown in advance, use chunked input
+        msg = new BodyChunkedInput(body);
+      } else {
+        msg = new BodyFileRegion((RandomAccessBody) body);
+      }
 
     } else {
       msg = new BodyChunkedInput(body);

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/InputStreamPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/InputStreamPart.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright (c) 2018 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
 package org.asynchttpclient.request.body.multipart;
 
 import java.io.InputStream;

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/InputStreamPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/InputStreamPart.java
@@ -1,0 +1,49 @@
+package org.asynchttpclient.request.body.multipart;
+
+import java.io.InputStream;
+import java.nio.charset.Charset;
+
+import static org.asynchttpclient.util.Assertions.assertNotNull;
+
+public class InputStreamPart extends FileLikePart {
+
+  private final InputStream inputStream;
+  private final long contentLength;
+
+  public InputStreamPart(String name, InputStream inputStream, long contentLength, String fileName) {
+    this(name, inputStream, contentLength, fileName, null);
+  }
+
+  public InputStreamPart(String name, InputStream inputStream, long contentLength, String fileName, String contentType) {
+    this(name, inputStream, contentLength, fileName, contentType, null);
+  }
+
+  public InputStreamPart(String name, InputStream inputStream, long contentLength, String fileName, String contentType, Charset charset) {
+    this(name, inputStream, contentLength, fileName, contentType, charset, null);
+  }
+
+  public InputStreamPart(String name, InputStream inputStream, long contentLength, String fileName, String contentType, Charset charset,
+                         String contentId) {
+    this(name, inputStream, contentLength, fileName, contentType, charset, contentId, null);
+  }
+
+  public InputStreamPart(String name, InputStream inputStream, long contentLength, String fileName, String contentType, Charset charset,
+                         String contentId, String transferEncoding) {
+    super(name,
+            contentType,
+            charset,
+            fileName,
+            contentId,
+            transferEncoding);
+    this.inputStream = assertNotNull(inputStream, "inputStream");
+    this.contentLength = contentLength;
+  }
+
+  public InputStream getInputStream() {
+    return inputStream;
+  }
+
+  public long getContentLength() {
+    return contentLength;
+  }
+}

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/InputStreamPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/InputStreamPart.java
@@ -10,24 +10,28 @@ public class InputStreamPart extends FileLikePart {
   private final InputStream inputStream;
   private final long contentLength;
 
-  public InputStreamPart(String name, InputStream inputStream, long contentLength, String fileName) {
-    this(name, inputStream, contentLength, fileName, null);
+  public InputStreamPart(String name, InputStream inputStream, String fileName) {
+    this(name, inputStream, fileName, -1);
   }
 
-  public InputStreamPart(String name, InputStream inputStream, long contentLength, String fileName, String contentType) {
-    this(name, inputStream, contentLength, fileName, contentType, null);
+  public InputStreamPart(String name, InputStream inputStream, String fileName, long contentLength) {
+    this(name, inputStream, fileName, contentLength, null);
   }
 
-  public InputStreamPart(String name, InputStream inputStream, long contentLength, String fileName, String contentType, Charset charset) {
-    this(name, inputStream, contentLength, fileName, contentType, charset, null);
+  public InputStreamPart(String name, InputStream inputStream, String fileName, long contentLength, String contentType) {
+    this(name, inputStream, fileName, contentLength, contentType, null);
   }
 
-  public InputStreamPart(String name, InputStream inputStream, long contentLength, String fileName, String contentType, Charset charset,
+  public InputStreamPart(String name, InputStream inputStream, String fileName, long contentLength, String contentType, Charset charset) {
+    this(name, inputStream, fileName, contentLength, contentType, charset, null);
+  }
+
+  public InputStreamPart(String name, InputStream inputStream, String fileName, long contentLength, String contentType, Charset charset,
                          String contentId) {
-    this(name, inputStream, contentLength, fileName, contentType, charset, contentId, null);
+    this(name, inputStream, fileName, contentLength, contentType, charset, contentId, null);
   }
 
-  public InputStreamPart(String name, InputStream inputStream, long contentLength, String fileName, String contentType, Charset charset,
+  public InputStreamPart(String name, InputStream inputStream, String fileName, long contentLength, String contentType, Charset charset,
                          String contentId, String transferEncoding) {
     super(name,
             contentType,

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/MultipartUtils.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/MultipartUtils.java
@@ -75,6 +75,9 @@ public class MultipartUtils {
       } else if (part instanceof StringPart) {
         multipartParts.add(new StringMultipartPart((StringPart) part, boundary));
 
+      } else if (part instanceof InputStreamPart) {
+        multipartParts.add(new InputStreamMultipartPart((InputStreamPart) part, boundary));
+
       } else {
         throw new IllegalArgumentException("Unknown part type: " + part);
       }

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/part/InputStreamMultipartPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/part/InputStreamMultipartPart.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright (c) 2018 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
 package org.asynchttpclient.request.body.multipart.part;
 
 import io.netty.buffer.ByteBuf;

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/part/InputStreamMultipartPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/part/InputStreamMultipartPart.java
@@ -1,14 +1,10 @@
 package org.asynchttpclient.request.body.multipart.part;
 
 import io.netty.buffer.ByteBuf;
-import org.asynchttpclient.netty.request.body.BodyChunkedInput;
 import org.asynchttpclient.request.body.multipart.InputStreamPart;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
-import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 
 import static org.asynchttpclient.util.MiscUtils.closeSilently;
@@ -16,25 +12,9 @@ import static org.asynchttpclient.util.MiscUtils.closeSilently;
 public class InputStreamMultipartPart extends FileLikeMultipartPart<InputStreamPart> {
 
   private long position = 0L;
-  private ByteBuffer buffer;
-  private ReadableByteChannel channel;
 
   public InputStreamMultipartPart(InputStreamPart part, byte[] boundary) {
     super(part, boundary);
-  }
-
-  private ByteBuffer getBuffer() {
-    if (buffer == null) {
-      buffer = ByteBuffer.allocateDirect(BodyChunkedInput.DEFAULT_CHUNK_SIZE);
-    }
-    return buffer;
-  }
-
-  private ReadableByteChannel getChannel() {
-    if (channel == null) {
-      channel = Channels.newChannel(part.getInputStream());
-    }
-    return channel;
   }
 
   @Override
@@ -58,35 +38,13 @@ public class InputStreamMultipartPart extends FileLikeMultipartPart<InputStreamP
 
   @Override
   protected long transferContentTo(WritableByteChannel target) throws IOException {
-    ReadableByteChannel channel = getChannel();
-    ByteBuffer buffer = getBuffer();
-
-    int transferred = 0;
-    int read = channel.read(buffer);
-
-    if (read > 0) {
-      buffer.flip();
-      while (buffer.hasRemaining()) {
-        transferred += target.write(buffer);
-      }
-      buffer.compact();
-      position += transferred;
-    }
-    if (position == getContentLength() || read < 0) {
-      state = MultipartState.POST_CONTENT;
-      if (channel.isOpen()) {
-        channel.close();
-      }
-    }
-
-    return transferred;
+    throw new UnsupportedOperationException("InputStreamPart does not support zero-copy transfers");
   }
 
   @Override
   public void close() {
     super.close();
     closeSilently(part.getInputStream());
-    closeSilently(channel);
   }
 
 }

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/part/InputStreamMultipartPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/part/InputStreamMultipartPart.java
@@ -1,10 +1,14 @@
 package org.asynchttpclient.request.body.multipart.part;
 
 import io.netty.buffer.ByteBuf;
+import org.asynchttpclient.netty.request.body.BodyChunkedInput;
 import org.asynchttpclient.request.body.multipart.InputStreamPart;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 
 import static org.asynchttpclient.util.MiscUtils.closeSilently;
@@ -12,9 +16,25 @@ import static org.asynchttpclient.util.MiscUtils.closeSilently;
 public class InputStreamMultipartPart extends FileLikeMultipartPart<InputStreamPart> {
 
   private long position = 0L;
+  private ByteBuffer buffer;
+  private ReadableByteChannel channel;
 
   public InputStreamMultipartPart(InputStreamPart part, byte[] boundary) {
     super(part, boundary);
+  }
+
+  private ByteBuffer getBuffer() {
+    if (buffer == null) {
+      buffer = ByteBuffer.allocateDirect(BodyChunkedInput.DEFAULT_CHUNK_SIZE);
+    }
+    return buffer;
+  }
+
+  private ReadableByteChannel getChannel() {
+    if (channel == null) {
+      channel = Channels.newChannel(part.getInputStream());
+    }
+    return channel;
   }
 
   @Override
@@ -38,13 +58,35 @@ public class InputStreamMultipartPart extends FileLikeMultipartPart<InputStreamP
 
   @Override
   protected long transferContentTo(WritableByteChannel target) throws IOException {
-    throw new UnsupportedOperationException("InputStreamPart does not support zero-copy transfers");
+    ReadableByteChannel channel = getChannel();
+    ByteBuffer buffer = getBuffer();
+
+    int transferred = 0;
+    int read = channel.read(buffer);
+
+    if (read > 0) {
+      buffer.flip();
+      while (buffer.hasRemaining()) {
+        transferred += target.write(buffer);
+      }
+      buffer.compact();
+      position += transferred;
+    }
+    if (position == getContentLength() || read < 0) {
+      state = MultipartState.POST_CONTENT;
+      if (channel.isOpen()) {
+        channel.close();
+      }
+    }
+
+    return transferred;
   }
 
   @Override
   public void close() {
     super.close();
     closeSilently(part.getInputStream());
+    closeSilently(channel);
   }
 
 }

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/part/InputStreamMultipartPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/part/InputStreamMultipartPart.java
@@ -1,0 +1,92 @@
+package org.asynchttpclient.request.body.multipart.part;
+
+import io.netty.buffer.ByteBuf;
+import org.asynchttpclient.netty.request.body.BodyChunkedInput;
+import org.asynchttpclient.request.body.multipart.InputStreamPart;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+import static org.asynchttpclient.util.MiscUtils.closeSilently;
+
+public class InputStreamMultipartPart extends FileLikeMultipartPart<InputStreamPart> {
+
+  private long position = 0L;
+  private ByteBuffer buffer;
+  private ReadableByteChannel channel;
+
+  public InputStreamMultipartPart(InputStreamPart part, byte[] boundary) {
+    super(part, boundary);
+  }
+
+  private ByteBuffer getBuffer() {
+    if (buffer == null) {
+      buffer = ByteBuffer.allocateDirect(BodyChunkedInput.DEFAULT_CHUNK_SIZE);
+    }
+    return buffer;
+  }
+
+  private ReadableByteChannel getChannel() {
+    if (channel == null) {
+      channel = Channels.newChannel(part.getInputStream());
+    }
+    return channel;
+  }
+
+  @Override
+  protected long getContentLength() {
+    return part.getContentLength();
+  }
+
+  @Override
+  protected long transferContentTo(ByteBuf target) throws IOException {
+    InputStream inputStream = part.getInputStream();
+    int transferred = target.writeBytes(inputStream, target.writableBytes());
+    if (transferred > 0) {
+      position += transferred;
+    }
+    if (position == getContentLength() || transferred < 0) {
+      state = MultipartState.POST_CONTENT;
+      inputStream.close();
+    }
+    return transferred;
+  }
+
+  @Override
+  protected long transferContentTo(WritableByteChannel target) throws IOException {
+    ReadableByteChannel channel = getChannel();
+    ByteBuffer buffer = getBuffer();
+
+    int transferred = 0;
+    int read = channel.read(buffer);
+
+    if (read > 0) {
+      buffer.flip();
+      while (buffer.hasRemaining()) {
+        transferred += target.write(buffer);
+      }
+      buffer.compact();
+      position += transferred;
+    }
+    if (position == getContentLength() || read < 0) {
+      state = MultipartState.POST_CONTENT;
+      if (channel.isOpen()) {
+        channel.close();
+      }
+    }
+
+    return transferred;
+  }
+
+  @Override
+  public void close() {
+    super.close();
+    closeSilently(part.getInputStream());
+    closeSilently(channel);
+  }
+
+}

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/part/MultipartPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/part/MultipartPart.java
@@ -106,6 +106,10 @@ public abstract class MultipartPart<T extends PartBase> implements Closeable {
   }
 
   public long length() {
+    long contentLength = getContentLength();
+    if (contentLength < 0) {
+      return contentLength;
+    }
     return preContentLength + postContentLength + getContentLength();
   }
 

--- a/client/src/test/java/org/asynchttpclient/request/body/InputStreamPartLargeFileTest.java
+++ b/client/src/test/java/org/asynchttpclient/request/body/InputStreamPartLargeFileTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2010-2012 Sonatype, Inc. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.request.body;
+
+import org.asynchttpclient.AbstractBasicTest;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.Response;
+import org.asynchttpclient.request.body.multipart.FilePart;
+import org.asynchttpclient.request.body.multipart.InputStreamPart;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.testng.annotations.Test;
+
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.*;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.asynchttpclient.Dsl.asyncHttpClient;
+import static org.asynchttpclient.Dsl.config;
+import static org.asynchttpclient.test.TestUtils.LARGE_IMAGE_FILE;
+import static org.asynchttpclient.test.TestUtils.createTempFile;
+import static org.testng.Assert.assertEquals;
+
+public class InputStreamPartLargeFileTest extends AbstractBasicTest {
+
+  @Override
+  public AbstractHandler configureHandler() throws Exception {
+    return new AbstractHandler() {
+
+      public void handle(String target, Request baseRequest, HttpServletRequest req, HttpServletResponse resp) throws IOException {
+
+        ServletInputStream in = req.getInputStream();
+        byte[] b = new byte[8192];
+
+        int count;
+        int total = 0;
+        while ((count = in.read(b)) != -1) {
+          b = new byte[8192];
+          total += count;
+        }
+        resp.setStatus(200);
+        resp.addHeader("X-TRANSFERRED", String.valueOf(total));
+        resp.getOutputStream().flush();
+        resp.getOutputStream().close();
+
+        baseRequest.setHandled(true);
+      }
+    };
+  }
+
+  @Test
+  public void testPutImageFile() throws Exception {
+    try (AsyncHttpClient client = asyncHttpClient(config().setRequestTimeout(100 * 6000))) {
+      InputStream inputStream = new BufferedInputStream(new FileInputStream(LARGE_IMAGE_FILE));
+      Response response = client.preparePut(getTargetUrl()).addBodyPart(new InputStreamPart("test", inputStream, LARGE_IMAGE_FILE.length(), LARGE_IMAGE_FILE.getName(), "application/octet-stream", UTF_8)).execute().get();
+      assertEquals(response.getStatusCode(), 200);
+    }
+  }
+
+  @Test
+  public void testPutLargeTextFile() throws Exception {
+    File file = createTempFile(1024 * 1024);
+    InputStream inputStream = new BufferedInputStream(new FileInputStream(file));
+
+    try (AsyncHttpClient client = asyncHttpClient(config().setRequestTimeout(100 * 6000))) {
+      Response response = client.preparePut(getTargetUrl())
+              .addBodyPart(new InputStreamPart("test", inputStream, file.length(), file.getName(), "application/octet-stream", UTF_8)).execute().get();
+      assertEquals(response.getStatusCode(), 200);
+    }
+  }
+}

--- a/client/src/test/java/org/asynchttpclient/request/body/InputStreamPartLargeFileTest.java
+++ b/client/src/test/java/org/asynchttpclient/request/body/InputStreamPartLargeFileTest.java
@@ -24,7 +24,6 @@ import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.*;
-import java.util.concurrent.ExecutionException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.asynchttpclient.Dsl.asyncHttpClient;
@@ -60,61 +59,20 @@ public class InputStreamPartLargeFileTest extends AbstractBasicTest {
     };
   }
 
-  @Test(expectedExceptions = ExecutionException.class)
-  public void testPutImageFileThrowsExecutionException() throws Exception {
-    // Should throw ExecutionException when zero-copy is enabled
-    try (AsyncHttpClient client = asyncHttpClient(config().setRequestTimeout(100 * 6000))) {
-      InputStream inputStream = new BufferedInputStream(new FileInputStream(LARGE_IMAGE_FILE));
-      client.preparePut(getTargetUrl()).addBodyPart(new InputStreamPart("test", inputStream, LARGE_IMAGE_FILE.getName(), LARGE_IMAGE_FILE.length(), "application/octet-stream", UTF_8)).execute().get();
-    }
-  }
-
-  @Test(expectedExceptions = ExecutionException.class)
-  public void testPutImageFileUnknownSizeThrowsExecutionException() throws Exception {
-    // Should throw ExecutionException when zero-copy is enabled
-    try (AsyncHttpClient client = asyncHttpClient(config().setRequestTimeout(100 * 6000))) {
-      InputStream inputStream = new BufferedInputStream(new FileInputStream(LARGE_IMAGE_FILE));
-      client.preparePut(getTargetUrl()).addBodyPart(new InputStreamPart("test", inputStream, LARGE_IMAGE_FILE.getName(), -1, "application/octet-stream", UTF_8)).execute().get();
-    }
-  }
-
   @Test
   public void testPutImageFile() throws Exception {
-    try (AsyncHttpClient client = asyncHttpClient(config().setRequestTimeout(100 * 6000).setDisableZeroCopy(true))) {
+    try (AsyncHttpClient client = asyncHttpClient(config().setRequestTimeout(100 * 6000))) {
       InputStream inputStream = new BufferedInputStream(new FileInputStream(LARGE_IMAGE_FILE));
-      client.preparePut(getTargetUrl()).addBodyPart(new InputStreamPart("test", inputStream, LARGE_IMAGE_FILE.getName(), LARGE_IMAGE_FILE.length(), "application/octet-stream", UTF_8)).execute().get();
+      Response response = client.preparePut(getTargetUrl()).addBodyPart(new InputStreamPart("test", inputStream, LARGE_IMAGE_FILE.getName(), LARGE_IMAGE_FILE.length(), "application/octet-stream", UTF_8)).execute().get();
+      assertEquals(response.getStatusCode(), 200);
     }
   }
 
   @Test
   public void testPutImageFileUnknownSize() throws Exception {
-    try (AsyncHttpClient client = asyncHttpClient(config().setRequestTimeout(100 * 6000).setDisableZeroCopy(true))) {
+    try (AsyncHttpClient client = asyncHttpClient(config().setRequestTimeout(100 * 6000))) {
       InputStream inputStream = new BufferedInputStream(new FileInputStream(LARGE_IMAGE_FILE));
       Response response = client.preparePut(getTargetUrl()).addBodyPart(new InputStreamPart("test", inputStream, LARGE_IMAGE_FILE.getName(), -1, "application/octet-stream", UTF_8)).execute().get();
-      assertEquals(response.getStatusCode(), 200);
-    }
-  }
-
-  @Test(expectedExceptions = ExecutionException.class)
-  public void testPutLargeTextFileThrowsExecutionException() throws Exception {
-    File file = createTempFile(1024 * 1024);
-    InputStream inputStream = new BufferedInputStream(new FileInputStream(file));
-
-    try (AsyncHttpClient client = asyncHttpClient(config().setRequestTimeout(100 * 6000))) {
-      Response response = client.preparePut(getTargetUrl())
-              .addBodyPart(new InputStreamPart("test", inputStream, file.getName(), file.length(), "application/octet-stream", UTF_8)).execute().get();
-      assertEquals(response.getStatusCode(), 200);
-    }
-  }
-
-  @Test(expectedExceptions = ExecutionException.class)
-  public void testPutLargeTextFileUnknownSizeThrowsExecutionException() throws Exception {
-    File file = createTempFile(1024 * 1024);
-    InputStream inputStream = new BufferedInputStream(new FileInputStream(file));
-
-    try (AsyncHttpClient client = asyncHttpClient(config().setRequestTimeout(100 * 6000))) {
-      Response response = client.preparePut(getTargetUrl())
-              .addBodyPart(new InputStreamPart("test", inputStream, file.getName(), -1, "application/octet-stream", UTF_8)).execute().get();
       assertEquals(response.getStatusCode(), 200);
     }
   }
@@ -124,7 +82,7 @@ public class InputStreamPartLargeFileTest extends AbstractBasicTest {
     File file = createTempFile(1024 * 1024);
     InputStream inputStream = new BufferedInputStream(new FileInputStream(file));
 
-    try (AsyncHttpClient client = asyncHttpClient(config().setRequestTimeout(100 * 6000).setDisableZeroCopy(true))) {
+    try (AsyncHttpClient client = asyncHttpClient(config().setRequestTimeout(100 * 6000))) {
       Response response = client.preparePut(getTargetUrl())
               .addBodyPart(new InputStreamPart("test", inputStream, file.getName(), file.length(), "application/octet-stream", UTF_8)).execute().get();
       assertEquals(response.getStatusCode(), 200);
@@ -136,7 +94,7 @@ public class InputStreamPartLargeFileTest extends AbstractBasicTest {
     File file = createTempFile(1024 * 1024);
     InputStream inputStream = new BufferedInputStream(new FileInputStream(file));
 
-    try (AsyncHttpClient client = asyncHttpClient(config().setRequestTimeout(100 * 6000).setDisableZeroCopy(true))) {
+    try (AsyncHttpClient client = asyncHttpClient(config().setRequestTimeout(100 * 6000))) {
       Response response = client.preparePut(getTargetUrl())
               .addBodyPart(new InputStreamPart("test", inputStream, file.getName(), -1, "application/octet-stream", UTF_8)).execute().get();
       assertEquals(response.getStatusCode(), 200);

--- a/client/src/test/java/org/asynchttpclient/request/body/InputStreamPartLargeFileTest.java
+++ b/client/src/test/java/org/asynchttpclient/request/body/InputStreamPartLargeFileTest.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2010-2012 Sonatype, Inc. All rights reserved.
+ * Copyright (c) 2018 AsyncHttpClient Project. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
- * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the Apache License Version 2.0 is distributed on an

--- a/client/src/test/java/org/asynchttpclient/request/body/InputStreamPartLargeFileTest.java
+++ b/client/src/test/java/org/asynchttpclient/request/body/InputStreamPartLargeFileTest.java
@@ -69,6 +69,15 @@ public class InputStreamPartLargeFileTest extends AbstractBasicTest {
   }
 
   @Test
+  public void testPutImageFileUnknownSize() throws Exception {
+    try (AsyncHttpClient client = asyncHttpClient(config().setRequestTimeout(100 * 6000))) {
+      InputStream inputStream = new BufferedInputStream(new FileInputStream(LARGE_IMAGE_FILE));
+      Response response = client.preparePut(getTargetUrl()).addBodyPart(new InputStreamPart("test", inputStream, LARGE_IMAGE_FILE.getName(), -1, "application/octet-stream", UTF_8)).execute().get();
+      assertEquals(response.getStatusCode(), 200);
+    }
+  }
+
+  @Test
   public void testPutLargeTextFile() throws Exception {
     File file = createTempFile(1024 * 1024);
     InputStream inputStream = new BufferedInputStream(new FileInputStream(file));
@@ -76,6 +85,18 @@ public class InputStreamPartLargeFileTest extends AbstractBasicTest {
     try (AsyncHttpClient client = asyncHttpClient(config().setRequestTimeout(100 * 6000))) {
       Response response = client.preparePut(getTargetUrl())
               .addBodyPart(new InputStreamPart("test", inputStream, file.getName(), file.length(), "application/octet-stream", UTF_8)).execute().get();
+      assertEquals(response.getStatusCode(), 200);
+    }
+  }
+
+  @Test
+  public void testPutLargeTextFileUnknownSize() throws Exception {
+    File file = createTempFile(1024 * 1024);
+    InputStream inputStream = new BufferedInputStream(new FileInputStream(file));
+
+    try (AsyncHttpClient client = asyncHttpClient(config().setRequestTimeout(100 * 6000))) {
+      Response response = client.preparePut(getTargetUrl())
+              .addBodyPart(new InputStreamPart("test", inputStream, file.getName(), -1, "application/octet-stream", UTF_8)).execute().get();
       assertEquals(response.getStatusCode(), 200);
     }
   }

--- a/client/src/test/java/org/asynchttpclient/request/body/InputStreamPartLargeFileTest.java
+++ b/client/src/test/java/org/asynchttpclient/request/body/InputStreamPartLargeFileTest.java
@@ -15,7 +15,6 @@ package org.asynchttpclient.request.body;
 import org.asynchttpclient.AbstractBasicTest;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.Response;
-import org.asynchttpclient.request.body.multipart.FilePart;
 import org.asynchttpclient.request.body.multipart.InputStreamPart;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -64,7 +63,7 @@ public class InputStreamPartLargeFileTest extends AbstractBasicTest {
   public void testPutImageFile() throws Exception {
     try (AsyncHttpClient client = asyncHttpClient(config().setRequestTimeout(100 * 6000))) {
       InputStream inputStream = new BufferedInputStream(new FileInputStream(LARGE_IMAGE_FILE));
-      Response response = client.preparePut(getTargetUrl()).addBodyPart(new InputStreamPart("test", inputStream, LARGE_IMAGE_FILE.length(), LARGE_IMAGE_FILE.getName(), "application/octet-stream", UTF_8)).execute().get();
+      Response response = client.preparePut(getTargetUrl()).addBodyPart(new InputStreamPart("test", inputStream, LARGE_IMAGE_FILE.getName(), LARGE_IMAGE_FILE.length(), "application/octet-stream", UTF_8)).execute().get();
       assertEquals(response.getStatusCode(), 200);
     }
   }
@@ -76,7 +75,7 @@ public class InputStreamPartLargeFileTest extends AbstractBasicTest {
 
     try (AsyncHttpClient client = asyncHttpClient(config().setRequestTimeout(100 * 6000))) {
       Response response = client.preparePut(getTargetUrl())
-              .addBodyPart(new InputStreamPart("test", inputStream, file.length(), file.getName(), "application/octet-stream", UTF_8)).execute().get();
+              .addBodyPart(new InputStreamPart("test", inputStream, file.getName(), file.length(), "application/octet-stream", UTF_8)).execute().get();
       assertEquals(response.getStatusCode(), 200);
     }
   }

--- a/client/src/test/java/org/asynchttpclient/request/body/multipart/MultipartBodyTest.java
+++ b/client/src/test/java/org/asynchttpclient/request/body/multipart/MultipartBodyTest.java
@@ -19,8 +19,7 @@ import io.netty.handler.codec.http.EmptyHttpHeaders;
 import org.asynchttpclient.request.body.Body.BodyState;
 import org.testng.annotations.Test;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.ByteBuffer;
@@ -63,7 +62,15 @@ public class MultipartBodyTest {
   }
 
   private static MultipartBody buildMultipart() {
-    return MultipartUtils.newMultipartBody(PARTS, EmptyHttpHeaders.INSTANCE);
+    List<Part> parts = new ArrayList<>(PARTS);
+    try {
+      File testFile = getTestfile();
+      InputStream inputStream = new BufferedInputStream(new FileInputStream(testFile));
+      parts.add(new InputStreamPart("isPart", inputStream, testFile.length(), testFile.getName()));
+    } catch (URISyntaxException | FileNotFoundException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+    return MultipartUtils.newMultipartBody(parts, EmptyHttpHeaders.INSTANCE);
   }
 
   private static long transferWithCopy(MultipartBody multipartBody, int bufferSize) throws IOException {

--- a/client/src/test/java/org/asynchttpclient/request/body/multipart/MultipartBodyTest.java
+++ b/client/src/test/java/org/asynchttpclient/request/body/multipart/MultipartBodyTest.java
@@ -36,7 +36,6 @@ public class MultipartBodyTest {
 
   private static final List<Part> PARTS = new ArrayList<>();
   private static long MAX_MULTIPART_CONTENT_LENGTH_ESTIMATE;
-  private static long MAX_MULTIPART_CONTENT_LENGTH_WITH_INPUT_STREAM_PART_ESTIMATE;
 
   static {
     try {
@@ -55,13 +54,6 @@ public class MultipartBodyTest {
     }
   }
 
-  static {
-    try (MultipartBody dummyBody = buildMultipartWithInputStreamPart()) {
-      // separator is random
-      MAX_MULTIPART_CONTENT_LENGTH_WITH_INPUT_STREAM_PART_ESTIMATE = dummyBody.getContentLength() + 100;
-    }
-  }
-
   private static File getTestfile() throws URISyntaxException {
     final ClassLoader cl = MultipartBodyTest.class.getClassLoader();
     final URL url = cl.getResource("textfile.txt");
@@ -70,10 +62,6 @@ public class MultipartBodyTest {
   }
 
   private static MultipartBody buildMultipart() {
-    return MultipartUtils.newMultipartBody(PARTS, EmptyHttpHeaders.INSTANCE);
-  }
-
-  private static MultipartBody buildMultipartWithInputStreamPart() {
     List<Part> parts = new ArrayList<>(PARTS);
     try {
       File testFile = getTestfile();
@@ -141,30 +129,11 @@ public class MultipartBodyTest {
   }
 
   @Test
-  public void transferWithCopyAndInputStreamPart() throws Exception {
-    for (int bufferLength = 1; bufferLength < MAX_MULTIPART_CONTENT_LENGTH_WITH_INPUT_STREAM_PART_ESTIMATE + 1; bufferLength++) {
-      try (MultipartBody multipartBody = buildMultipartWithInputStreamPart()) {
-        long transferred = transferWithCopy(multipartBody, bufferLength);
-        assertEquals(transferred, multipartBody.getContentLength());
-      }
-    }
-  }
-
-  @Test
   public void transferZeroCopy() throws Exception {
     for (int bufferLength = 1; bufferLength < MAX_MULTIPART_CONTENT_LENGTH_ESTIMATE + 1; bufferLength++) {
       try (MultipartBody multipartBody = buildMultipart()) {
         long tranferred = transferZeroCopy(multipartBody, bufferLength);
         assertEquals(tranferred, multipartBody.getContentLength());
-      }
-    }
-  }
-
-  @Test(expectedExceptions = UnsupportedOperationException.class)
-  public void transferZeroCopyWithInputStreamPart() throws Exception {
-    for (int bufferLength = 1; bufferLength < MAX_MULTIPART_CONTENT_LENGTH_WITH_INPUT_STREAM_PART_ESTIMATE + 1; bufferLength++) {
-      try (MultipartBody multipartBody = buildMultipartWithInputStreamPart()) {
-        transferZeroCopy(multipartBody, bufferLength);
       }
     }
   }

--- a/client/src/test/java/org/asynchttpclient/request/body/multipart/MultipartBodyTest.java
+++ b/client/src/test/java/org/asynchttpclient/request/body/multipart/MultipartBodyTest.java
@@ -36,6 +36,7 @@ public class MultipartBodyTest {
 
   private static final List<Part> PARTS = new ArrayList<>();
   private static long MAX_MULTIPART_CONTENT_LENGTH_ESTIMATE;
+  private static long MAX_MULTIPART_CONTENT_LENGTH_WITH_INPUT_STREAM_PART_ESTIMATE;
 
   static {
     try {
@@ -54,6 +55,13 @@ public class MultipartBodyTest {
     }
   }
 
+  static {
+    try (MultipartBody dummyBody = buildMultipartWithInputStreamPart()) {
+      // separator is random
+      MAX_MULTIPART_CONTENT_LENGTH_WITH_INPUT_STREAM_PART_ESTIMATE = dummyBody.getContentLength() + 100;
+    }
+  }
+
   private static File getTestfile() throws URISyntaxException {
     final ClassLoader cl = MultipartBodyTest.class.getClassLoader();
     final URL url = cl.getResource("textfile.txt");
@@ -62,6 +70,10 @@ public class MultipartBodyTest {
   }
 
   private static MultipartBody buildMultipart() {
+    return MultipartUtils.newMultipartBody(PARTS, EmptyHttpHeaders.INSTANCE);
+  }
+
+  private static MultipartBody buildMultipartWithInputStreamPart() {
     List<Part> parts = new ArrayList<>(PARTS);
     try {
       File testFile = getTestfile();
@@ -129,11 +141,30 @@ public class MultipartBodyTest {
   }
 
   @Test
+  public void transferWithCopyAndInputStreamPart() throws Exception {
+    for (int bufferLength = 1; bufferLength < MAX_MULTIPART_CONTENT_LENGTH_WITH_INPUT_STREAM_PART_ESTIMATE + 1; bufferLength++) {
+      try (MultipartBody multipartBody = buildMultipartWithInputStreamPart()) {
+        long transferred = transferWithCopy(multipartBody, bufferLength);
+        assertEquals(transferred, multipartBody.getContentLength());
+      }
+    }
+  }
+
+  @Test
   public void transferZeroCopy() throws Exception {
     for (int bufferLength = 1; bufferLength < MAX_MULTIPART_CONTENT_LENGTH_ESTIMATE + 1; bufferLength++) {
       try (MultipartBody multipartBody = buildMultipart()) {
         long tranferred = transferZeroCopy(multipartBody, bufferLength);
         assertEquals(tranferred, multipartBody.getContentLength());
+      }
+    }
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void transferZeroCopyWithInputStreamPart() throws Exception {
+    for (int bufferLength = 1; bufferLength < MAX_MULTIPART_CONTENT_LENGTH_WITH_INPUT_STREAM_PART_ESTIMATE + 1; bufferLength++) {
+      try (MultipartBody multipartBody = buildMultipartWithInputStreamPart()) {
+        transferZeroCopy(multipartBody, bufferLength);
       }
     }
   }

--- a/client/src/test/java/org/asynchttpclient/request/body/multipart/MultipartBodyTest.java
+++ b/client/src/test/java/org/asynchttpclient/request/body/multipart/MultipartBodyTest.java
@@ -66,7 +66,7 @@ public class MultipartBodyTest {
     try {
       File testFile = getTestfile();
       InputStream inputStream = new BufferedInputStream(new FileInputStream(testFile));
-      parts.add(new InputStreamPart("isPart", inputStream, testFile.length(), testFile.getName()));
+      parts.add(new InputStreamPart("isPart", inputStream, testFile.getName(), testFile.length()));
     } catch (URISyntaxException | FileNotFoundException e) {
       throw new ExceptionInInitializerError(e);
     }

--- a/client/src/test/java/org/asynchttpclient/request/body/multipart/MultipartUploadTest.java
+++ b/client/src/test/java/org/asynchttpclient/request/body/multipart/MultipartUploadTest.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import java.util.zip.GZIPInputStream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -85,22 +86,13 @@ public class MultipartUploadTest extends AbstractBasicTest {
     testFiles.add(testResource1File);
     testFiles.add(testResource2File);
     testFiles.add(testResource3File);
-    testFiles.add(testResource3File);
-    testFiles.add(testResource2File);
-    testFiles.add(testResource1File);
 
     List<String> expected = new ArrayList<>();
     expected.add(expectedContents);
     expected.add(expectedContents2);
     expected.add(expectedContents3);
-    expected.add(expectedContents3);
-    expected.add(expectedContents2);
-    expected.add(expectedContents);
 
     List<Boolean> gzipped = new ArrayList<>();
-    gzipped.add(false);
-    gzipped.add(true);
-    gzipped.add(false);
     gzipped.add(false);
     gzipped.add(true);
     gzipped.add(false);
@@ -121,10 +113,41 @@ public class MultipartUploadTest extends AbstractBasicTest {
               .addBodyPart(new StringPart("Name", "Dominic"))
               .addBodyPart(new FilePart("file3", testResource3File, "text/plain", UTF_8))
               .addBodyPart(new StringPart("Age", "3")).addBodyPart(new StringPart("Height", "shrimplike"))
-              .addBodyPart(new InputStreamPart("inputStream3", inputStreamFile3, testResource3File.getName(), testResource3File.length(), "text/plain", UTF_8))
-              .addBodyPart(new InputStreamPart("inputStream2", inputStreamFile2, testResource2File.getName(), testResource2File.length(), "application/x-gzip", null))
               .addBodyPart(new StringPart("Hair", "ridiculous")).addBodyPart(new ByteArrayPart("file4",
                       expectedContents.getBytes(UTF_8), "text/plain", UTF_8, "bytearray.txt"))
+              .build();
+
+      Response res = c.executeRequest(r).get();
+
+      assertEquals(res.getStatusCode(), 200);
+
+      testSentFile(expected, testFiles, res, gzipped);
+    }
+
+    testFiles.add(testResource3File);
+    testFiles.add(testResource2File);
+    testFiles.add(testResource1File);
+
+    expected.add(expectedContents3);
+    expected.add(expectedContents2);
+    expected.add(expectedContents);
+
+    gzipped.add(false);
+    gzipped.add(true);
+    gzipped.add(false);
+
+    // Zero-copy should be disabled when using InputStreamPart
+    try (AsyncHttpClient c = asyncHttpClient(config().setDisableZeroCopy(true))) {
+      Request r = post("http://localhost" + ":" + port1 + "/upload")
+              .addBodyPart(new FilePart("file1", testResource1File, "text/plain", UTF_8))
+              .addBodyPart(new FilePart("file2", testResource2File, "application/x-gzip", null))
+              .addBodyPart(new StringPart("Name", "Dominic"))
+              .addBodyPart(new FilePart("file3", testResource3File, "text/plain", UTF_8))
+              .addBodyPart(new StringPart("Age", "3")).addBodyPart(new StringPart("Height", "shrimplike"))
+              .addBodyPart(new ByteArrayPart("file4", expectedContents.getBytes(UTF_8), "text/plain", UTF_8, "bytearray.txt"))
+              .addBodyPart(new InputStreamPart("inputStream3", inputStreamFile3, testResource3File.getName(), testResource3File.length(), "text/plain", UTF_8))
+              .addBodyPart(new InputStreamPart("inputStream2", inputStreamFile2, testResource2File.getName(), testResource2File.length(), "application/x-gzip", null))
+              .addBodyPart(new StringPart("Hair", "ridiculous"))
               .addBodyPart(new InputStreamPart("inputStream1", inputStreamFile1, testResource1File.getName(), testResource1File.length(), "text/plain", UTF_8))
               .build();
 
@@ -174,7 +197,7 @@ public class MultipartUploadTest extends AbstractBasicTest {
     sendEmptyFileInputStream(true);
   }
 
-  @Test
+  @Test(expectedExceptions = ExecutionException.class)
   public void testSendEmptyFileInputStreamZeroCopy() throws Exception {
     sendEmptyFileInputStream(false);
   }
@@ -201,7 +224,7 @@ public class MultipartUploadTest extends AbstractBasicTest {
     sendFileInputStream(false, true);
   }
 
-  @Test
+  @Test(expectedExceptions = ExecutionException.class)
   public void testSendFileInputStreamZeroCopyUnknownContentLength() throws Exception {
     sendFileInputStream(false, false);
   }
@@ -211,7 +234,7 @@ public class MultipartUploadTest extends AbstractBasicTest {
     sendFileInputStream(true, true);
   }
 
-  @Test
+  @Test(expectedExceptions = ExecutionException.class)
   public void testSendFileInputStreamZeroCopyKnownContentLength() throws Exception {
     sendFileInputStream(true, false);
   }

--- a/client/src/test/java/org/asynchttpclient/request/body/multipart/MultipartUploadTest.java
+++ b/client/src/test/java/org/asynchttpclient/request/body/multipart/MultipartUploadTest.java
@@ -41,7 +41,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 import java.util.zip.GZIPInputStream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -86,13 +85,22 @@ public class MultipartUploadTest extends AbstractBasicTest {
     testFiles.add(testResource1File);
     testFiles.add(testResource2File);
     testFiles.add(testResource3File);
+    testFiles.add(testResource3File);
+    testFiles.add(testResource2File);
+    testFiles.add(testResource1File);
 
     List<String> expected = new ArrayList<>();
     expected.add(expectedContents);
     expected.add(expectedContents2);
     expected.add(expectedContents3);
+    expected.add(expectedContents3);
+    expected.add(expectedContents2);
+    expected.add(expectedContents);
 
     List<Boolean> gzipped = new ArrayList<>();
+    gzipped.add(false);
+    gzipped.add(true);
+    gzipped.add(false);
     gzipped.add(false);
     gzipped.add(true);
     gzipped.add(false);
@@ -113,41 +121,10 @@ public class MultipartUploadTest extends AbstractBasicTest {
               .addBodyPart(new StringPart("Name", "Dominic"))
               .addBodyPart(new FilePart("file3", testResource3File, "text/plain", UTF_8))
               .addBodyPart(new StringPart("Age", "3")).addBodyPart(new StringPart("Height", "shrimplike"))
-              .addBodyPart(new StringPart("Hair", "ridiculous")).addBodyPart(new ByteArrayPart("file4",
-                      expectedContents.getBytes(UTF_8), "text/plain", UTF_8, "bytearray.txt"))
-              .build();
-
-      Response res = c.executeRequest(r).get();
-
-      assertEquals(res.getStatusCode(), 200);
-
-      testSentFile(expected, testFiles, res, gzipped);
-    }
-
-    testFiles.add(testResource3File);
-    testFiles.add(testResource2File);
-    testFiles.add(testResource1File);
-
-    expected.add(expectedContents3);
-    expected.add(expectedContents2);
-    expected.add(expectedContents);
-
-    gzipped.add(false);
-    gzipped.add(true);
-    gzipped.add(false);
-
-    // Zero-copy should be disabled when using InputStreamPart
-    try (AsyncHttpClient c = asyncHttpClient(config().setDisableZeroCopy(true))) {
-      Request r = post("http://localhost" + ":" + port1 + "/upload")
-              .addBodyPart(new FilePart("file1", testResource1File, "text/plain", UTF_8))
-              .addBodyPart(new FilePart("file2", testResource2File, "application/x-gzip", null))
-              .addBodyPart(new StringPart("Name", "Dominic"))
-              .addBodyPart(new FilePart("file3", testResource3File, "text/plain", UTF_8))
-              .addBodyPart(new StringPart("Age", "3")).addBodyPart(new StringPart("Height", "shrimplike"))
-              .addBodyPart(new ByteArrayPart("file4", expectedContents.getBytes(UTF_8), "text/plain", UTF_8, "bytearray.txt"))
               .addBodyPart(new InputStreamPart("inputStream3", inputStreamFile3, testResource3File.getName(), testResource3File.length(), "text/plain", UTF_8))
               .addBodyPart(new InputStreamPart("inputStream2", inputStreamFile2, testResource2File.getName(), testResource2File.length(), "application/x-gzip", null))
-              .addBodyPart(new StringPart("Hair", "ridiculous"))
+              .addBodyPart(new StringPart("Hair", "ridiculous")).addBodyPart(new ByteArrayPart("file4",
+                      expectedContents.getBytes(UTF_8), "text/plain", UTF_8, "bytearray.txt"))
               .addBodyPart(new InputStreamPart("inputStream1", inputStreamFile1, testResource1File.getName(), testResource1File.length(), "text/plain", UTF_8))
               .build();
 
@@ -197,7 +174,7 @@ public class MultipartUploadTest extends AbstractBasicTest {
     sendEmptyFileInputStream(true);
   }
 
-  @Test(expectedExceptions = ExecutionException.class)
+  @Test
   public void testSendEmptyFileInputStreamZeroCopy() throws Exception {
     sendEmptyFileInputStream(false);
   }
@@ -224,7 +201,7 @@ public class MultipartUploadTest extends AbstractBasicTest {
     sendFileInputStream(false, true);
   }
 
-  @Test(expectedExceptions = ExecutionException.class)
+  @Test
   public void testSendFileInputStreamZeroCopyUnknownContentLength() throws Exception {
     sendFileInputStream(false, false);
   }
@@ -234,7 +211,7 @@ public class MultipartUploadTest extends AbstractBasicTest {
     sendFileInputStream(true, true);
   }
 
-  @Test(expectedExceptions = ExecutionException.class)
+  @Test
   public void testSendFileInputStreamZeroCopyKnownContentLength() throws Exception {
     sendFileInputStream(true, false);
   }


### PR DESCRIPTION
**Motivation:**

- In certain situations it's useful for the user to be able to provide an `InputStream` to a file instead of the `File` object itself for a multipart file part.
- E.g.: Upload large files accessible over a network protocol such as SFTP to a remote server without copying the file to the local filesystem or loading it fully into memory

**Changes:**

- Introduce new `InputStreamPart`type for use in the `addBodyPart(...)` API
- Implement `InputStreamMultipartPart` to transfer `InputStream `to a Netty `ByteBuf` or `WritableByteChannel`
- _Unfortunately did not find a way to implement `protected long transferContentTo(WritableByteChannel target) throws IOException` for zero-copy uploads._
- Added new tests and updated existing tests to cover scenarios similar to `FilePart`

**Results:**

- It is now possible to provide an `InputStream` as a multipart body part

**Related Issue:**

[#857](https://github.com/AsyncHttpClient/async-http-client/issues/857)