### PR TITLE
Expose SSL Session of a connection to AsyncHandler.onTlsHandshakeSuccess

### DIFF
--- a/client/src/main/java/org/asynchttpclient/AsyncHandler.java
+++ b/client/src/main/java/org/asynchttpclient/AsyncHandler.java
@@ -19,6 +19,7 @@ import io.netty.channel.Channel;
 import io.netty.handler.codec.http.HttpHeaders;
 import org.asynchttpclient.netty.request.NettyRequest;
 
+import javax.net.ssl.SSLSession;
 import java.net.InetSocketAddress;
 import java.util.List;
 
@@ -186,7 +187,7 @@ public interface AsyncHandler<T> {
   /**
    * Notify the callback after the TLS was successful
    */
-  default void onTlsHandshakeSuccess() {
+  default void onTlsHandshakeSuccess(SSLSession sslSession) {
   }
 
   /**

--- a/client/src/main/java/org/asynchttpclient/netty/channel/NettyConnectListener.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/NettyConnectListener.java
@@ -130,7 +130,7 @@ public final class NettyConnectListener<T> {
         @Override
         protected void onSuccess(Channel value) {
           try {
-            asyncHandler.onTlsHandshakeSuccess();
+            asyncHandler.onTlsHandshakeSuccess(sslHandler.engine().getSession());
           } catch (Exception e) {
             LOGGER.error("onTlsHandshakeSuccess crashed", e);
             NettyConnectListener.this.onFailure(channel, e);

--- a/client/src/test/java/org/asynchttpclient/test/EventCollectingHandler.java
+++ b/client/src/test/java/org/asynchttpclient/test/EventCollectingHandler.java
@@ -20,6 +20,7 @@ import org.asynchttpclient.Response;
 import org.asynchttpclient.netty.request.NettyRequest;
 import org.testng.Assert;
 
+import javax.net.ssl.SSLSession;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Queue;
@@ -128,7 +129,7 @@ public class EventCollectingHandler extends AsyncCompletionHandlerBase {
   }
 
   @Override
-  public void onTlsHandshakeSuccess() {
+  public void onTlsHandshakeSuccess(SSLSession sslSession) {
     firedEvents.add(TLS_HANDSHAKE_SUCCESS_EVENT);
   }
 

--- a/client/src/test/java/org/asynchttpclient/test/EventCollectingHandler.java
+++ b/client/src/test/java/org/asynchttpclient/test/EventCollectingHandler.java
@@ -130,6 +130,7 @@ public class EventCollectingHandler extends AsyncCompletionHandlerBase {
 
   @Override
   public void onTlsHandshakeSuccess(SSLSession sslSession) {
+    Assert.assertNotNull(sslSession);
     firedEvents.add(TLS_HANDSHAKE_SUCCESS_EVENT);
   }
 


### PR DESCRIPTION
The goal of this change is to expose underlying SSLSession object once handshake is successful. This seems like a feature that can be useful to anyone that needs to retrieve session and/or certificate information from the connection.

A quick search for the feature yielded this conversation in google groups from 2014 so it seems people have been trying to do this for a while:

https://groups.google.com/forum/#!msg/asynchttpclient/7ySVbKqntgc/_pycVfrwiVMJ

