### PR TITLE
Fix bug in Url encoding of QueryParams

### DIFF
--- a/client/src/main/java/org/asynchttpclient/util/Utf8UrlEncoder.java
+++ b/client/src/main/java/org/asynchttpclient/util/Utf8UrlEncoder.java
@@ -135,7 +135,7 @@ public final class Utf8UrlEncoder {
   }
 
   public static StringBuilder encodeAndAppendQueryElement(StringBuilder sb, CharSequence input) {
-    return appendEncoded(sb, input, FORM_URL_ENCODED_SAFE_CHARS, false);
+    return encodeAndAppendPercentEncoded(sb, input);
   }
 
   public static StringBuilder encodeAndAppendFormElement(StringBuilder sb, CharSequence input) {

--- a/client/src/test/java/org/asynchttpclient/RequestBuilderTest.java
+++ b/client/src/test/java/org/asynchttpclient/RequestBuilderTest.java
@@ -30,7 +30,7 @@ import static org.testng.Assert.assertTrue;
 
 public class RequestBuilderTest {
 
-  private final static String SAFE_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890-_*.";
+  private final static String SAFE_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890~-_.";
   private final static String HEX_CHARS = "0123456789ABCDEF";
 
   @Test

--- a/client/src/test/java/org/asynchttpclient/util/Utf8UrlEncoderTest.java
+++ b/client/src/test/java/org/asynchttpclient/util/Utf8UrlEncoderTest.java
@@ -31,4 +31,20 @@ public class Utf8UrlEncoderTest {
     assertEquals(Utf8UrlEncoder.percentEncodeQueryElement("foo*bar"), "foo%2Abar");
     assertEquals(Utf8UrlEncoder.percentEncodeQueryElement("foo~b_ar"), "foo~b_ar");
   }
+
+	@Test
+	public void testencodeAndAppendQueryElement() {
+		StringBuilder sb = new StringBuilder();
+		Utf8UrlEncoder.encodeAndAppendQueryElement(
+				sb,
+				"-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+		);
+		assertEquals( sb.toString(), "-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" );
+		sb = new StringBuilder();
+		Utf8UrlEncoder.encodeAndAppendQueryElement(
+				sb,
+				"foo*bar"
+		);
+		assertEquals( sb.toString(), "foo%2Abar" );
+	}
 }


### PR DESCRIPTION
This fixes the bug that unreserved characters (see RFC-3986) are also percent-encoded.