### PR TITLE
reenable osgi support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,28 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.0.1</version>
+        <extensions>true</extensions>
+        <configuration>
+          <manifestLocation>META-INF</manifestLocation>
+          <instructions>
+            <Bundle-Version>$(replace;$(project.version);-SNAPSHOT;.$(tstamp;yyyyMMdd-HHmm))</Bundle-Version>
+            <Bundle-Vendor>The AsyncHttpClient Project</Bundle-Vendor>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>osgi-bundle</id>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,7 @@
           <instructions>
             <Bundle-Version>$(replace;$(project.version);-SNAPSHOT;.$(tstamp;yyyyMMdd-HHmm))</Bundle-Version>
             <Bundle-Vendor>The AsyncHttpClient Project</Bundle-Vendor>
+            <Import-Package>javax.activation;version="[1.1,2)", *</Import-Package>
           </instructions>
         </configuration>
         <executions>


### PR DESCRIPTION
The OSGi support was removed due to https://github.com/AsyncHttpClient/async-http-client/issues/1091

This is a revert of https://github.com/AsyncHttpClient/async-http-client/commit/ed92e2a1932d8709b28d892606e57f7fe60bf820

I tested with a current karaf distribution and the bundle wires providing it the necessary dependencies (netty et. al)

I assume the package uses constraint violation does not exist anymore.

Best regards
Jens