### PR TITLE
Retrofit http client supplier npe fix

### DIFF
--- a/extras/retrofit2/pom.xml
+++ b/extras/retrofit2/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <retrofit2.version>2.5.0</retrofit2.version>
-    <lombok.version>1.16.20</lombok.version>
+    <lombok.version>1.18.6</lombok.version>
   </properties>
 
   <dependencies>

--- a/extras/retrofit2/src/main/java/org/asynchttpclient/extras/retrofit/AsyncHttpClientCallFactory.java
+++ b/extras/retrofit2/src/main/java/org/asynchttpclient/extras/retrofit/AsyncHttpClientCallFactory.java
@@ -18,29 +18,22 @@ import okhttp3.Request;
 import org.asynchttpclient.AsyncHttpClient;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static org.asynchttpclient.extras.retrofit.AsyncHttpClientCall.runConsumers;
 
 /**
- * {@link AsyncHttpClient} implementation of Retrofit2 {@link Call.Factory}
+ * {@link AsyncHttpClient} implementation of <a href="http://square.github.io/retrofit/">Retrofit2</a>
+ * {@link Call.Factory}.
  */
 @Value
 @Builder(toBuilder = true)
 public class AsyncHttpClientCallFactory implements Call.Factory {
   /**
-   * {@link AsyncHttpClient} in use.
-   *
-   * @see #httpClientSupplier
+   * Supplier of {@link AsyncHttpClient}.
    */
-  @Getter(AccessLevel.NONE)
-  AsyncHttpClient httpClient;
-
-  /**
-   * Supplier of {@link AsyncHttpClient}, takes precedence over {@link #httpClient}.
-   */
+  @NonNull
   @Getter(AccessLevel.NONE)
   Supplier<AsyncHttpClient> httpClientSupplier;
 
@@ -48,12 +41,13 @@ public class AsyncHttpClientCallFactory implements Call.Factory {
    * List of {@link Call} builder customizers that are invoked just before creating it.
    */
   @Singular("callCustomizer")
+  @Getter(AccessLevel.PACKAGE)
   List<Consumer<AsyncHttpClientCall.AsyncHttpClientCallBuilder>> callCustomizers;
 
   @Override
   public Call newCall(Request request) {
     val callBuilder = AsyncHttpClientCall.builder()
-            .httpClient(httpClient)
+            .httpClientSupplier(httpClientSupplier)
             .request(request);
 
     // customize builder before creating a call
@@ -64,15 +58,33 @@ public class AsyncHttpClientCallFactory implements Call.Factory {
   }
 
   /**
-   * {@link AsyncHttpClient} in use by this factory.
+   * Returns {@link AsyncHttpClient} from {@link #httpClientSupplier}.
    *
-   * @return
+   * @return http client.
    */
-  public AsyncHttpClient getHttpClient() {
-    return Optional.ofNullable(httpClientSupplier)
-            .map(Supplier::get)
-            .map(Optional::of)
-            .orElseGet(() -> Optional.ofNullable(httpClient))
-            .orElseThrow(() -> new IllegalStateException("HTTP client is not set."));
+  AsyncHttpClient getHttpClient() {
+    return httpClientSupplier.get();
+  }
+
+  /**
+   * Builder for {@link AsyncHttpClientCallFactory}.
+   */
+  public static class AsyncHttpClientCallFactoryBuilder {
+    /**
+     * {@link AsyncHttpClient} supplier that returns http client to be used to execute HTTP requests.
+     */
+    private Supplier<AsyncHttpClient> httpClientSupplier;
+
+    /**
+     * Sets concrete http client to be used by the factory to execute HTTP requests. Invocation of this method
+     * overrides any previous http client supplier set by {@link #httpClientSupplier(Supplier)}!
+     *
+     * @param httpClient http client
+     * @return reference to itself.
+     * @see #httpClientSupplier(Supplier)
+     */
+    public AsyncHttpClientCallFactoryBuilder httpClient(@NonNull AsyncHttpClient httpClient) {
+      return httpClientSupplier(() -> httpClient);
+    }
   }
 }

--- a/extras/retrofit2/src/test/java/org/asynchttpclient/extras/retrofit/AsyncHttpClientCallFactoryTest.java
+++ b/extras/retrofit2/src/test/java/org/asynchttpclient/extras/retrofit/AsyncHttpClientCallFactoryTest.java
@@ -14,23 +14,34 @@ package org.asynchttpclient.extras.retrofit;
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import okhttp3.MediaType;
 import okhttp3.Request;
+import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.RequestBuilder;
 import org.testng.annotations.Test;
 
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-import static org.asynchttpclient.extras.retrofit.AsyncHttpClientCallTest.REQUEST;
 import static org.asynchttpclient.extras.retrofit.AsyncHttpClientCallTest.createConsumer;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.*;
 
 @Slf4j
 public class AsyncHttpClientCallFactoryTest {
+  private static final MediaType MEDIA_TYPE = MediaType.parse("application/json");
+  private static final String JSON_BODY = "{\"foo\": \"bar\"}";
+  private static final RequestBody BODY = RequestBody.create(MEDIA_TYPE, JSON_BODY);
+  private static final String URL = "http://localhost:11000/foo/bar?a=b&c=d";
+  private static final Request REQUEST = new Request.Builder()
+          .post(BODY)
+          .addHeader("X-Foo", "Bar")
+          .url(URL)
+          .build();
   @Test
   void newCallShouldProduceExpectedResult() {
     // given
@@ -152,7 +163,8 @@ public class AsyncHttpClientCallFactoryTest {
     assertTrue(call.getRequestCustomizers().size() == 2);
   }
 
-  @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "HTTP client is not set.")
+  @Test(expectedExceptions = NullPointerException.class,
+          expectedExceptionsMessageRegExp = "httpClientSupplier is marked @NonNull but is null")
   void shouldThrowISEIfHttpClientIsNotDefined() {
     // given
     val factory = AsyncHttpClientCallFactory.builder()
@@ -168,17 +180,23 @@ public class AsyncHttpClientCallFactoryTest {
   @Test
   void shouldUseHttpClientInstanceIfSupplierIsNotAvailable() {
     // given
-    val httpClientA = mock(AsyncHttpClient.class);
+    val httpClient = mock(AsyncHttpClient.class);
 
     val factory = AsyncHttpClientCallFactory.builder()
-            .httpClient(httpClientA)
+            .httpClient(httpClient)
             .build();
 
     // when
     val usedHttpClient = factory.getHttpClient();
 
     // then
-    assertTrue(usedHttpClient == httpClientA);
+    assertTrue(usedHttpClient == httpClient);
+
+    // when
+    val call = (AsyncHttpClientCall) factory.newCall(REQUEST);
+
+    // then: call should contain correct http client
+    assertTrue(call.getHttpClient()== httpClient);
   }
 
   @Test
@@ -197,5 +215,12 @@ public class AsyncHttpClientCallFactoryTest {
 
     // then
     assertTrue(usedHttpClient == httpClientB);
+
+    // when: try to create new call
+    val call = (AsyncHttpClientCall) factory.newCall(REQUEST);
+
+    // then: call should contain correct http client
+    assertNotNull(call);
+    assertTrue(call.getHttpClient() == httpClientB);
   }
 }


### PR DESCRIPTION
This patch addresses issue that resulted in NPE if http client supplier
was specified in `Call.Factory` builder and concrete http client was not,
because `getHttpClient()` method was not invoked while constructing
retrofit `Call` instance.

New, obviously less error prone approach is that http client supplier
gets constructed behind the scenes even if user specifies concrete http
client instance at call factory creation time and http client supplier
is being used exclusively also by `Call` instance. This way there are no
hard references to http client instance dangling around in case some
component creates a `Call` instance and never issues `newCall()` on it.

Fixes #1616.