### PR TITLE
Updated maven-javadoc-plugin to 3.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
   - travis/before_script.sh
 
 script: 
-  - mvn test -Ptest-output
+  - mvn test javadoc:javadoc -Ptest-output
   - find $HOME/.m2 -name "_remote.repositories" | xargs rm
   - find $HOME/.m2 -name "resolver-status.properties" | xargs rm -f
   

--- a/pom.xml
+++ b/pom.xml
@@ -174,15 +174,15 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.0.1</version>
+        <configuration>
+          <doclint>none</doclint>
+        </configuration>
+      </plugin>
     </plugins>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.4</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
   <profiles>
     <profile>


### PR DESCRIPTION
Before this patch build was using outdated javadoc plugin which failed
build on OracleJDK 8 due to javadoc generation error on
`extras/retrofit2` module. Builds on OpenJDK 8 finished successfully.

Changes:

* maven-javadoc-plugin version bump to `3.0.1`
* added javadoc generation to travis build recipe