### PR TITLE
web socket dose not work in socks5 proxy 

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
@@ -33,6 +33,8 @@ import io.netty.handler.proxy.Socks4ProxyHandler;
 import io.netty.handler.proxy.Socks5ProxyHandler;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
+import io.netty.resolver.AddressResolver;
+import io.netty.resolver.AddressResolverGroup;
 import io.netty.resolver.NameResolver;
 import io.netty.util.Timer;
 import io.netty.util.concurrent.*;
@@ -56,6 +58,7 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ThreadFactory;
@@ -430,6 +433,10 @@ public class ChannelManager {
               channel.pipeline().addFirst(SOCKS_HANDLER, socksProxyHandler);
             }
           });
+          AddressResolver<SocketAddress> addressResolver = proxy.getAddressResolver();
+          if (addressResolver != null) {
+            socksBootstrap.resolver((AddressResolverGroup<?>) addressResolver);
+          }
           promise.setSuccess(socksBootstrap);
 
         } else {

--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
@@ -344,7 +344,7 @@ public final class NettyRequestSender {
       InetSocketAddress unresolvedRemoteAddress = InetSocketAddress.createUnresolved(proxy.getHost(), port);
       scheduleRequestTimeout(future, unresolvedRemoteAddress);
       return RequestHostnameResolver.INSTANCE.resolve(request.getNameResolver(), unresolvedRemoteAddress, asyncHandler);
-    } else if (proxy != null && proxy.isResolveDomain() && ProxyType.SOCKS_V5 == proxy.getProxyType()) {
+    } else if (proxy != null && proxy.isResolveDomain() && proxy.getProxyType().isSocks()) {
       // resolve domain in socks 5 server
       int port = uri.getExplicitPort();
       InetSocketAddress unresolvedRemoteAddress = InetSocketAddress.createUnresolved(uri.getHost(), port);

--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
@@ -351,6 +351,7 @@ public final class NettyRequestSender {
       final Promise<List<InetSocketAddress>> unResolvedPromise = ImmediateEventExecutor.INSTANCE.newPromise();
       List<InetSocketAddress> unresolvedLiWrapper = new ArrayList<>(1);
       unresolvedLiWrapper.add(unresolvedRemoteAddress);
+      scheduleRequestTimeout(future, unresolvedRemoteAddress);
       unResolvedPromise.trySuccess(unresolvedLiWrapper);
       return unResolvedPromise;
     } else {

--- a/client/src/main/java/org/asynchttpclient/proxy/ProxyServer.java
+++ b/client/src/main/java/org/asynchttpclient/proxy/ProxyServer.java
@@ -16,8 +16,10 @@
  */
 package org.asynchttpclient.proxy;
 
+import io.netty.resolver.AddressResolver;
 import org.asynchttpclient.Realm;
 
+import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -36,6 +38,8 @@ public class ProxyServer {
   private final Realm realm;
   private final List<String> nonProxyHosts;
   private final ProxyType proxyType;
+  private AddressResolver<SocketAddress> addressResolver;
+  // server can resolve domain in socks 5
 
   public ProxyServer(String host, int port, int securedPort, Realm realm, List<String> nonProxyHosts,
                      ProxyType proxyType) {
@@ -45,6 +49,12 @@ public class ProxyServer {
     this.realm = realm;
     this.nonProxyHosts = nonProxyHosts;
     this.proxyType = proxyType;
+  }
+
+  public ProxyServer(String host, int port, int securedPort, Realm realm, List<String> nonProxyHosts,
+                     ProxyType proxyType, AddressResolver<SocketAddress> addressResolver) {
+    this(host, port, securedPort, realm, nonProxyHosts, proxyType);
+    this.addressResolver = addressResolver;
   }
 
   public String getHost() {
@@ -69,6 +79,14 @@ public class ProxyServer {
 
   public ProxyType getProxyType() {
     return proxyType;
+  }
+
+  public AddressResolver<SocketAddress> getAddressResolver() {
+    return addressResolver;
+  }
+
+  public boolean isResolveDomain() {
+    return addressResolver != null;
   }
 
   /**
@@ -118,6 +136,7 @@ public class ProxyServer {
     private Realm realm;
     private List<String> nonProxyHosts;
     private ProxyType proxyType;
+    private AddressResolver<SocketAddress> addressResolver;
 
     public Builder(String host, int port) {
       this.host = host;
@@ -157,11 +176,16 @@ public class ProxyServer {
       return this;
     }
 
+    public Builder setAddressResolver(AddressResolver<SocketAddress> addressResolver) {
+      this.addressResolver = addressResolver;
+      return this;
+    }
+
     public ProxyServer build() {
       List<String> nonProxyHosts = this.nonProxyHosts != null ? Collections.unmodifiableList(this.nonProxyHosts)
               : Collections.emptyList();
       ProxyType proxyType = this.proxyType != null ? this.proxyType : ProxyType.HTTP;
-      return new ProxyServer(host, port, securedPort, realm, nonProxyHosts, proxyType);
+      return new ProxyServer(host, port, securedPort, realm, nonProxyHosts, proxyType, this.addressResolver);
     }
   }
 }

--- a/client/src/main/java/org/asynchttpclient/proxy/ProxyServer.java
+++ b/client/src/main/java/org/asynchttpclient/proxy/ProxyServer.java
@@ -16,10 +16,9 @@
  */
 package org.asynchttpclient.proxy;
 
-import io.netty.resolver.AddressResolver;
+import io.netty.resolver.AddressResolverGroup;
 import org.asynchttpclient.Realm;
 
-import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -38,7 +37,7 @@ public class ProxyServer {
   private final Realm realm;
   private final List<String> nonProxyHosts;
   private final ProxyType proxyType;
-  private AddressResolver<SocketAddress> addressResolver;
+  private AddressResolverGroup addressResolverGroup;
   // server can resolve domain in socks 5
 
   public ProxyServer(String host, int port, int securedPort, Realm realm, List<String> nonProxyHosts,
@@ -52,9 +51,9 @@ public class ProxyServer {
   }
 
   public ProxyServer(String host, int port, int securedPort, Realm realm, List<String> nonProxyHosts,
-                     ProxyType proxyType, AddressResolver<SocketAddress> addressResolver) {
+                     ProxyType proxyType, AddressResolverGroup addressResolverGroup) {
     this(host, port, securedPort, realm, nonProxyHosts, proxyType);
-    this.addressResolver = addressResolver;
+    this.addressResolverGroup = addressResolverGroup;
   }
 
   public String getHost() {
@@ -81,12 +80,12 @@ public class ProxyServer {
     return proxyType;
   }
 
-  public AddressResolver<SocketAddress> getAddressResolver() {
-    return addressResolver;
+  public AddressResolverGroup getAddressResolverGroup() {
+    return addressResolverGroup;
   }
 
   public boolean isResolveDomain() {
-    return addressResolver != null;
+    return addressResolverGroup != null;
   }
 
   /**
@@ -136,7 +135,7 @@ public class ProxyServer {
     private Realm realm;
     private List<String> nonProxyHosts;
     private ProxyType proxyType;
-    private AddressResolver<SocketAddress> addressResolver;
+    private AddressResolverGroup addressResolverGroup;
 
     public Builder(String host, int port) {
       this.host = host;
@@ -176,8 +175,8 @@ public class ProxyServer {
       return this;
     }
 
-    public Builder setAddressResolver(AddressResolver<SocketAddress> addressResolver) {
-      this.addressResolver = addressResolver;
+    public Builder setAddressResolverGroup(AddressResolverGroup addressResolverGroup) {
+      this.addressResolverGroup = addressResolverGroup;
       return this;
     }
 
@@ -185,7 +184,7 @@ public class ProxyServer {
       List<String> nonProxyHosts = this.nonProxyHosts != null ? Collections.unmodifiableList(this.nonProxyHosts)
               : Collections.emptyList();
       ProxyType proxyType = this.proxyType != null ? this.proxyType : ProxyType.HTTP;
-      return new ProxyServer(host, port, securedPort, realm, nonProxyHosts, proxyType, this.addressResolver);
+      return new ProxyServer(host, port, securedPort, realm, nonProxyHosts, proxyType, this.addressResolverGroup);
     }
   }
 }


### PR DESCRIPTION
I am in trouble when using web socket in socks5 proxy.

Motivation:
Here are 2 issues when I debug in code
1, when send request in socks5, client dose not send upgrade request because using http bootstrap , the http bootstrap dose not have wsHandler.
2, Can't not use socks5 domain resolve when client need.
I want write unit test for that but need a socks5 test server, it need spend some time. So I pull change first, others can check the code before it.
 
Modifications:
1, Modified ChannelManager getBootstrap logic when using socks proxy. Web socket using in socks proxy will use wsBootstrap for upgrade protocol handshake.
2, Proxy config add a domain resolver for setting bootstrap resolve. Use Netty NoopAddressResolverGroup for domain resolve in socks5 server, if you dose not set for this, it will use JDK default strategy for resolving.
 
Result:
After I mofidied those, my program run success 

Forgive my poor English, it's not my native language...