### PR TITLE
make NettyWebSocket.sendCloseFrame(int statusCode, String reasonText) actually respect its arguments

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/ws/NettyWebSocket.java
+++ b/client/src/main/java/org/asynchttpclient/netty/ws/NettyWebSocket.java
@@ -155,7 +155,7 @@ public final class NettyWebSocket implements WebSocket {
   @Override
   public Future<Void> sendCloseFrame(int statusCode, String reasonText) {
     if (channel.isOpen()) {
-      return channel.writeAndFlush(new CloseWebSocketFrame(1000, "normal closure"));
+      return channel.writeAndFlush(new CloseWebSocketFrame(statusCode, reasonText));
     }
     return ImmediateEventExecutor.INSTANCE.newSucceededFuture(null);
   }


### PR DESCRIPTION
as opposed to hard-coding 1000 and "normal closure"
Signed-off-by: radai-rosenblatt <radai.rosenblatt@gmail.com>