### PR TITLE
Added Automatic-Module-Name

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -9,6 +9,10 @@
   <name>Asynchronous Http Client</name>
   <description>The Async Http Client (AHC) classes.</description>
 
+  <properties>
+    <javaModuleName>org.asynchttpclient.client</javaModuleName>
+  </properties>
+
   <build>
     <plugins>
       <plugin>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -11,6 +11,11 @@
   <description>
     The Async Http Client example.
   </description>
+
+  <properties>
+    <javaModuleName>org.asynchttpclient.example</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.asynchttpclient</groupId>

--- a/extras/guava/pom.xml
+++ b/extras/guava/pom.xml
@@ -11,6 +11,10 @@
     The Async Http Client Guava Extras.
   </description>
 
+  <properties>
+    <javaModuleName>org.asynchttpclient.extras.guava</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/extras/jdeferred/pom.xml
+++ b/extras/jdeferred/pom.xml
@@ -23,6 +23,11 @@
   <artifactId>async-http-client-extras-jdeferred</artifactId>
   <name>Asynchronous Http Client JDeferred Extras</name>
   <description>The Async Http Client jDeffered Extras.</description>
+
+  <properties>
+    <javaModuleName>org.asynchttpclient.extras.jdeferred</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.jdeferred</groupId>

--- a/extras/registry/pom.xml
+++ b/extras/registry/pom.xml
@@ -10,4 +10,9 @@
   <description>
     The Async Http Client Registry Extras.
   </description>
+
+  <properties>
+    <javaModuleName>org.asynchttpclient.extras.registry</javaModuleName>
+  </properties>
+
 </project>

--- a/extras/retrofit2/pom.xml
+++ b/extras/retrofit2/pom.xml
@@ -14,6 +14,7 @@
   <properties>
     <retrofit2.version>2.5.0</retrofit2.version>
     <lombok.version>1.18.6</lombok.version>
+    <javaModuleName>org.asynchttpclient.extras.retrofit2</javaModuleName>
   </properties>
 
   <dependencies>

--- a/extras/rxjava/pom.xml
+++ b/extras/rxjava/pom.xml
@@ -8,6 +8,11 @@
   <artifactId>async-http-client-extras-rxjava</artifactId>
   <name>Asynchronous Http Client RxJava Extras</name>
   <description>The Async Http Client RxJava Extras.</description>
+
+  <properties>
+    <javaModuleName>org.asynchttpclient.extras.rxjava</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.reactivex</groupId>

--- a/extras/rxjava2/pom.xml
+++ b/extras/rxjava2/pom.xml
@@ -8,6 +8,11 @@
   <artifactId>async-http-client-extras-rxjava2</artifactId>
   <name>Asynchronous Http Client RxJava2 Extras</name>
   <description>The Async Http Client RxJava2 Extras.</description>
+
+  <properties>
+    <javaModuleName>org.asynchttpclient.extras.rxjava2</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.reactivex.rxjava2</groupId>

--- a/extras/simple/pom.xml
+++ b/extras/simple/pom.xml
@@ -8,4 +8,9 @@
   <artifactId>async-http-client-extras-simple</artifactId>
   <name>Asynchronous Http Simple Client</name>
   <description>The Async Http Simple Client.</description>
+
+  <properties>
+    <javaModuleName>org.asynchttpclient.extras.simple</javaModuleName>
+  </properties>
+
 </project>

--- a/extras/typesafeconfig/pom.xml
+++ b/extras/typesafeconfig/pom.xml
@@ -13,6 +13,7 @@
 
   <properties>
     <typesafeconfig.version>1.3.3</typesafeconfig.version>
+    <javaModuleName>org.asynchttpclient.extras.typesafeconfig</javaModuleName>
   </properties>
 
   <dependencies>

--- a/netty-utils/pom.xml
+++ b/netty-utils/pom.xml
@@ -8,6 +8,10 @@
   <artifactId>async-http-client-netty-utils</artifactId>
   <name>Asynchronous Http Client Netty Utils</name>
 
+  <properties>
+    <javaModuleName>org.asynchttpclient.utils</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,14 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.1.2</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.asynchttpclient</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -137,13 +137,18 @@
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.1.2</version>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>org.asynchttpclient</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <manifestEntries>
+                  <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
Add `Automatic-Module-Name` to the manifest of builded jar and updated the `maven-jar-plugin` version. This is required to avoid warnings during the build of the systems that switched to the Java 9 modules.