### PR TITLE
Support Netty kqueue transport

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -57,6 +57,11 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-kqueue</artifactId>
+      <classifier>osx-x86_64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-resolver-dns</artifactId>
     </dependency>
     <dependency>

--- a/client/src/main/java/org/asynchttpclient/netty/channel/EpollTransportFactory.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/EpollTransportFactory.java
@@ -13,13 +13,32 @@
  */
 package org.asynchttpclient.netty.channel;
 
-import io.netty.channel.ChannelFactory;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollSocketChannel;
 
-class EpollSocketChannelFactory implements ChannelFactory<EpollSocketChannel> {
+import java.util.concurrent.ThreadFactory;
+
+class EpollTransportFactory implements TransportFactory<EpollSocketChannel, EpollEventLoopGroup> {
+
+  EpollTransportFactory() {
+    try {
+      Class.forName("io.netty.channel.epoll.Epoll");
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException("The epoll transport is not available");
+    }
+    if (!Epoll.isAvailable()) {
+      throw new IllegalStateException("The epoll transport is not supported");
+    }
+  }
 
   @Override
   public EpollSocketChannel newChannel() {
     return new EpollSocketChannel();
+  }
+
+  @Override
+  public EpollEventLoopGroup newEventLoopGroup(int ioThreadsCount, ThreadFactory threadFactory) {
+    return new EpollEventLoopGroup(ioThreadsCount, threadFactory);
   }
 }

--- a/client/src/main/java/org/asynchttpclient/netty/channel/KQueueTransportFactory.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/KQueueTransportFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.netty.channel;
+
+import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.kqueue.KQueueSocketChannel;
+
+import java.util.concurrent.ThreadFactory;
+
+class KQueueTransportFactory implements TransportFactory<KQueueSocketChannel, KQueueEventLoopGroup> {
+
+  KQueueTransportFactory() {
+    try {
+      Class.forName("io.netty.channel.kqueue.KQueue");
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException("The kqueue transport is not available");
+    }
+    if (!KQueue.isAvailable()) {
+      throw new IllegalStateException("The kqueue transport is not supported");
+    }
+  }
+
+  @Override
+  public KQueueSocketChannel newChannel() {
+    return new KQueueSocketChannel();
+  }
+
+  @Override
+  public KQueueEventLoopGroup newEventLoopGroup(int ioThreadsCount, ThreadFactory threadFactory) {
+    return new KQueueEventLoopGroup(ioThreadsCount, threadFactory);
+  }
+}

--- a/client/src/main/java/org/asynchttpclient/netty/channel/NioTransportFactory.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/NioTransportFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.netty.channel;
+
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioSocketChannel;
+
+import java.util.concurrent.ThreadFactory;
+
+enum NioTransportFactory implements TransportFactory<NioSocketChannel, NioEventLoopGroup> {
+
+  INSTANCE;
+
+  @Override
+  public NioSocketChannel newChannel() {
+    return new NioSocketChannel();
+  }
+
+  @Override
+  public NioEventLoopGroup newEventLoopGroup(int ioThreadsCount, ThreadFactory threadFactory) {
+    return new NioEventLoopGroup(ioThreadsCount, threadFactory);
+  }
+}

--- a/client/src/main/java/org/asynchttpclient/netty/channel/TransportFactory.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/TransportFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 AsyncHttpClient Project. All rights reserved.
+ * Copyright (c) 2019 AsyncHttpClient Project. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -13,15 +13,14 @@
  */
 package org.asynchttpclient.netty.channel;
 
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFactory;
-import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.channel.EventLoopGroup;
 
-enum NioSocketChannelFactory implements ChannelFactory<NioSocketChannel> {
+import java.util.concurrent.ThreadFactory;
 
-  INSTANCE;
+public interface TransportFactory<C extends Channel, L extends EventLoopGroup> extends ChannelFactory<C> {
 
-  @Override
-  public NioSocketChannel newChannel() {
-    return new NioSocketChannel();
-  }
+  L newEventLoopGroup(int ioThreadsCount, ThreadFactory threadFactory);
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -300,6 +300,13 @@
         <optional>true</optional>
       </dependency>
       <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-kqueue</artifactId>
+        <classifier>osx-x86_64</classifier>
+        <version>${netty.version}</version>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
         <groupId>org.reactivestreams</groupId>
         <artifactId>reactive-streams</artifactId>
         <version>${reactive-streams.version}</version>


### PR DESCRIPTION
Resolves #1575. I've tested this on macOS 10.14.6 and Ubuntu 18.04 LTS.

I did a bit more reshuffling than was strictly necessary so that it will be easier for AHC to support any native transports that Netty may introduce in the future.