### PR TITLE
Support for OpenSslEngine with no finalizer

### DIFF
--- a/client/src/main/java/org/asynchttpclient/SslEngineFactory.java
+++ b/client/src/main/java/org/asynchttpclient/SslEngineFactory.java
@@ -39,4 +39,12 @@ public interface SslEngineFactory {
   default void init(AsyncHttpClientConfig config) throws SSLException {
     // no op
   }
+
+  /**
+   * Perform any necessary cleanup.
+   */
+  default void destroy() {
+    // no op
+  }
+
 }

--- a/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
@@ -18,6 +18,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.*;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.ChannelGroupFuture;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -287,8 +288,9 @@ public class ChannelManager {
   }
 
   private void doClose() {
-    openChannels.close();
+    ChannelGroupFuture groupFuture = openChannels.close();
     channelPool.destroy();
+    groupFuture.addListener(future -> sslEngineFactory.destroy());
   }
 
   public void close() {

--- a/client/src/main/java/org/asynchttpclient/netty/ssl/DefaultSslEngineFactory.java
+++ b/client/src/main/java/org/asynchttpclient/netty/ssl/DefaultSslEngineFactory.java
@@ -19,6 +19,7 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.util.ReferenceCountUtil;
 import org.asynchttpclient.AsyncHttpClientConfig;
 
 import javax.net.ssl.SSLEngine;
@@ -71,6 +72,11 @@ public class DefaultSslEngineFactory extends SslEngineFactoryBase {
   @Override
   public void init(AsyncHttpClientConfig config) throws SSLException {
     sslContext = buildSslContext(config);
+  }
+
+  @Override
+  public void destroy() {
+    ReferenceCountUtil.release(sslContext);
   }
 
   /**


### PR DESCRIPTION
Motivation:

Support for Netty SslProvider.OPENSSL_REFCNT (OpenSSL-based implementation which does not have finalizers and instead implements ReferenceCounted).

Modification:

Add destroy method to SslEngineFactory to allow cleaning up reference counted SslContext.

Result:

Users can opt-in to a finalizer free OpenSslEngine and OpenSslContext.