### PR TITLE
Added toBuilder methods to Request

### DIFF
--- a/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClient.java
+++ b/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClient.java
@@ -194,7 +194,7 @@ public class DefaultAsyncHttpClient implements AsyncHttpClient {
       try {
         List<Cookie> cookies = config.getCookieStore().get(request.getUri());
         if (!cookies.isEmpty()) {
-          RequestBuilder requestBuilder = new RequestBuilder(request);
+          RequestBuilder requestBuilder = request.toBuilder();
           for (Cookie cookie : cookies) {
             requestBuilder.addOrReplaceCookie(cookie);
           }
@@ -264,7 +264,7 @@ public class DefaultAsyncHttpClient implements AsyncHttpClient {
     }
 
     if (request.getRangeOffset() != 0) {
-      RequestBuilder builder = new RequestBuilder(request);
+      RequestBuilder builder = request.toBuilder();
       builder.setHeader("Range", "bytes=" + request.getRangeOffset() + "-");
       request = builder.build();
     }

--- a/client/src/main/java/org/asynchttpclient/DefaultRequest.java
+++ b/client/src/main/java/org/asynchttpclient/DefaultRequest.java
@@ -247,16 +247,6 @@ public class DefaultRequest implements Request {
   }
 
   @Override
-  public RequestBuilder toBuilder() {
-    return new RequestBuilder(this);
-  }
-
-  @Override
-  public RequestBuilder toBuilder(boolean disableUrlEncoding, boolean validateHeaders) {
-    return new RequestBuilder(this, disableUrlEncoding, validateHeaders);
-  }
-
-  @Override
   public List<Param> getQueryParams() {
     if (queryParams == null)
       // lazy load

--- a/client/src/main/java/org/asynchttpclient/DefaultRequest.java
+++ b/client/src/main/java/org/asynchttpclient/DefaultRequest.java
@@ -247,6 +247,16 @@ public class DefaultRequest implements Request {
   }
 
   @Override
+  public RequestBuilder toBuilder() {
+    return new RequestBuilder(this);
+  }
+
+  @Override
+  public RequestBuilder toBuilder(boolean disableUrlEncoding, boolean validateHeaders) {
+    return new RequestBuilder(this, disableUrlEncoding, validateHeaders);
+  }
+
+  @Override
   public List<Param> getQueryParams() {
     if (queryParams == null)
       // lazy load

--- a/client/src/main/java/org/asynchttpclient/Request.java
+++ b/client/src/main/java/org/asynchttpclient/Request.java
@@ -184,12 +184,8 @@ public interface Request {
   /**
    * @return a new request builder using this request as a prototype
    */
-  RequestBuilder toBuilder();
-
-  /**
-   * @param disableUrlEncoding whether to disable url encoding or not
-   * @param validateHeaders whether to enable header validation or not
-   * @return a new request builder using this request as a prototype
-   */
-  RequestBuilder toBuilder(boolean disableUrlEncoding, boolean validateHeaders);
+  @SuppressWarnings("deprecation")
+  default RequestBuilder toBuilder() {
+    return new RequestBuilder(this);
+  }
 }

--- a/client/src/main/java/org/asynchttpclient/Request.java
+++ b/client/src/main/java/org/asynchttpclient/Request.java
@@ -180,4 +180,16 @@ public interface Request {
    * @return the NameResolver to be used to resolve hostnams's IP
    */
   NameResolver<InetAddress> getNameResolver();
+
+  /**
+   * @return a new request builder using this request as a prototype
+   */
+  RequestBuilder toBuilder();
+
+  /**
+   * @param disableUrlEncoding whether to disable url encoding or not
+   * @param validateHeaders whether to enable header validation or not
+   * @return a new request builder using this request as a prototype
+   */
+  RequestBuilder toBuilder(boolean disableUrlEncoding, boolean validateHeaders);
 }

--- a/client/src/main/java/org/asynchttpclient/RequestBuilder.java
+++ b/client/src/main/java/org/asynchttpclient/RequestBuilder.java
@@ -39,10 +39,15 @@ public class RequestBuilder extends RequestBuilderBase<RequestBuilder> {
     super(method, disableUrlEncoding, validateHeaders);
   }
 
+  /**
+   * @deprecated Use request.toBuilder() instead
+   */
+  @Deprecated
   public RequestBuilder(Request prototype) {
     super(prototype);
   }
 
+  @Deprecated
   public RequestBuilder(Request prototype, boolean disableUrlEncoding, boolean validateHeaders) {
     super(prototype, disableUrlEncoding, validateHeaders);
   }

--- a/client/src/main/java/org/asynchttpclient/handler/resumable/ResumableAsyncHandler.java
+++ b/client/src/main/java/org/asynchttpclient/handler/resumable/ResumableAsyncHandler.java
@@ -198,7 +198,7 @@ public class ResumableAsyncHandler implements AsyncHandler<Response> {
       byteTransferred.set(resumableListener.length());
     }
 
-    RequestBuilder builder = new RequestBuilder(request);
+    RequestBuilder builder = request.toBuilder();
     if (request.getHeaders().get(RANGE) == null && byteTransferred.get() != 0) {
       builder.setHeader(RANGE, "bytes=" + byteTransferred.get() + "-");
     }

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ConnectSuccessInterceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ConnectSuccessInterceptor.java
@@ -52,7 +52,7 @@ public class ConnectSuccessInterceptor {
 
     future.setReuseChannel(true);
     future.setConnectAllowed(false);
-    Request targetRequest = new RequestBuilder(future.getTargetRequest()).build();
+    Request targetRequest = future.getTargetRequest().toBuilder().build();
     if (whenHandshaked == null) {
       requestSender.drainChannelAndExecuteNextRequest(channel, future, targetRequest);
     } else {

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ProxyUnauthorized407Interceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ProxyUnauthorized407Interceptor.java
@@ -163,7 +163,7 @@ public class ProxyUnauthorized407Interceptor {
         throw new IllegalStateException("Invalid Authentication scheme " + proxyRealm.getScheme());
     }
 
-    RequestBuilder nextRequestBuilder = new RequestBuilder(future.getCurrentRequest()).setHeaders(requestHeaders);
+    RequestBuilder nextRequestBuilder = future.getCurrentRequest().toBuilder().setHeaders(requestHeaders);
     if (future.getCurrentRequest().getUri().isSecured()) {
       nextRequestBuilder.setMethod(CONNECT);
     }

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Unauthorized401Interceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Unauthorized401Interceptor.java
@@ -162,7 +162,7 @@ public class Unauthorized401Interceptor {
         throw new IllegalStateException("Invalid Authentication scheme " + realm.getScheme());
     }
 
-    final Request nextRequest = new RequestBuilder(future.getCurrentRequest()).setHeaders(requestHeaders).build();
+    final Request nextRequest = future.getCurrentRequest().toBuilder().setHeaders(requestHeaders).build();
 
     LOGGER.debug("Sending authentication to {}", request.getUri());
     if (future.isKeepAlive()

--- a/client/src/test/java/org/asynchttpclient/RequestBuilderTest.java
+++ b/client/src/test/java/org/asynchttpclient/RequestBuilderTest.java
@@ -72,7 +72,7 @@ public class RequestBuilderTest {
   public void testChaining() {
     Request request = get("http://foo.com").addQueryParam("x", "value").build();
 
-    Request request2 = new RequestBuilder(request).build();
+    Request request2 = request.toBuilder().build();
 
     assertEquals(request2.getUri(), request.getUri());
   }

--- a/client/src/test/java/org/asynchttpclient/filter/FilterTest.java
+++ b/client/src/test/java/org/asynchttpclient/filter/FilterTest.java
@@ -101,7 +101,7 @@ public class FilterTest extends AbstractBasicTest {
     ResponseFilter responseFilter = new ResponseFilter() {
       public <T> FilterContext<T> filter(FilterContext<T> ctx) {
         if (replay.getAndSet(false)) {
-          Request request = new RequestBuilder(ctx.getRequest()).addHeader("X-Replay", "true").build();
+          Request request = ctx.getRequest().toBuilder().addHeader("X-Replay", "true").build();
           return new FilterContext.FilterContextBuilder<T>().asyncHandler(ctx.getAsyncHandler()).request(request).replayRequest(true).build();
         }
         return ctx;
@@ -123,7 +123,7 @@ public class FilterTest extends AbstractBasicTest {
     ResponseFilter responseFilter = new ResponseFilter() {
       public <T> FilterContext<T> filter(FilterContext<T> ctx) {
         if (ctx.getResponseStatus() != null && ctx.getResponseStatus().getStatusCode() == 200 && replay.getAndSet(false)) {
-          Request request = new RequestBuilder(ctx.getRequest()).addHeader("X-Replay", "true").build();
+          Request request = ctx.getRequest().toBuilder().addHeader("X-Replay", "true").build();
           return new FilterContext.FilterContextBuilder<T>().asyncHandler(ctx.getAsyncHandler()).request(request).replayRequest(true).build();
         }
         return ctx;
@@ -145,7 +145,7 @@ public class FilterTest extends AbstractBasicTest {
     ResponseFilter responseFilter = new ResponseFilter() {
       public <T> FilterContext<T> filter(FilterContext<T> ctx) {
         if (ctx.getResponseHeaders() != null && ctx.getResponseHeaders().get("Ping").equals("Pong") && replay.getAndSet(false)) {
-          Request request = new RequestBuilder(ctx.getRequest()).addHeader("Ping", "Pong").build();
+          Request request = ctx.getRequest().toBuilder().addHeader("Ping", "Pong").build();
           return new FilterContext.FilterContextBuilder<T>().asyncHandler(ctx.getAsyncHandler()).request(request).replayRequest(true).build();
         }
         return ctx;

--- a/extras/simple/src/main/java/org/asynchttpclient/extras/simple/SimpleAsyncHttpClient.java
+++ b/extras/simple/src/main/java/org/asynchttpclient/extras/simple/SimpleAsyncHttpClient.java
@@ -275,7 +275,7 @@ public class SimpleAsyncHttpClient implements Closeable {
   }
 
   private RequestBuilder rebuildRequest(Request rb) {
-    return new RequestBuilder(rb);
+    return rb.toBuilder();
   }
 
   private Future<Response> execute(RequestBuilder rb, BodyConsumer bodyConsumer, ThrowableHandler throwableHandler) throws IOException {
@@ -422,7 +422,7 @@ public class SimpleAsyncHttpClient implements Closeable {
     }
 
     private Builder(SimpleAsyncHttpClient client) {
-      this.requestBuilder = new RequestBuilder(client.requestBuilder.build());
+      this.requestBuilder = client.requestBuilder.build().toBuilder();
       this.defaultThrowableHandler = client.defaultThrowableHandler;
       this.errorDocumentBehaviour = client.errorDocumentBehaviour;
       this.enableResumableDownload = client.resumeEnabled;


### PR DESCRIPTION
Changes for https://github.com/AsyncHttpClient/async-http-client/issues/1672

@slandelle These are the simple/minimum changes. 

But there is the fact that the constructors of RequestBuilder that take a prototype remain and could be used directly, breaking again the purpose of this change. 
But in order to overcome that a more impactful change (backwards incompatible) has to be made. But I would leave that decision to you or your opinion on it.
- Ideal: moving the RequestBuilder as an inner class of Request or DefaultRequest and restricting access to those methods 
- Not ideal: Making those constructors protected at least to reduce the chances of usage directly, but still poses a risk

Bonus question:
Do you prefer the implementation of toBuilder methods as default implementation on the interface or as it is now on the DefaultRequest.java?