### PR TITLE
Remove unused dependency

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -61,10 +61,6 @@
       <classifier>osx-x86_64</classifier>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-resolver-dns</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.reactivestreams</groupId>
       <artifactId>reactive-streams</artifactId>
     </dependency>


### PR DESCRIPTION
Hello, I noticed that dependency `netty-resolver-dns` is declared in module `async-http-client`. However, this dependency is not used and can be safely removed to make the library slimmer and the dependency tree less complex. 