### PR TITLE
Support for OpenSslEngine with no finalizer

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/ssl/DefaultSslEngineFactory.java
+++ b/client/src/main/java/org/asynchttpclient/netty/ssl/DefaultSslEngineFactory.java
@@ -34,6 +34,7 @@ public class DefaultSslEngineFactory extends SslEngineFactoryBase {
 
   private SslContext buildSslContext(AsyncHttpClientConfig config) throws SSLException {
     if (config.getSslContext() != null) {
+      ReferenceCountUtil.retain(config.getSslContext());
       return config.getSslContext();
     }
 


### PR DESCRIPTION
Motivation:

Custom SslContext should be retained on init.

Modification:

Retain custom SslContext.

Result:

Externally managed SslContext refcount is managed correctly.