### PR TITLE
Cookiejar optimization

### DIFF
--- a/client/src/main/java/org/asynchttpclient/AsyncHttpClientConfig.java
+++ b/client/src/main/java/org/asynchttpclient/AsyncHttpClientConfig.java
@@ -199,6 +199,13 @@ public interface AsyncHttpClientConfig {
   CookieStore getCookieStore();
 
   /**
+   * Return the delay in milliseconds to evict expired cookies from {@linkplain CookieStore}
+   *
+   * @return the delay in milliseconds to evict expired cookies from {@linkplain CookieStore}
+   */
+  int expiredCookieEvictionDelay();
+
+  /**
    * Return the number of time the library will retry when an {@link java.io.IOException} is throw by the remote server
    *
    * @return the number of time the library will retry when an {@link java.io.IOException} is throw by the remote server

--- a/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClient.java
+++ b/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClient.java
@@ -31,6 +31,7 @@ import org.asynchttpclient.netty.request.NettyRequestSender;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -112,6 +113,13 @@ public class DefaultAsyncHttpClient implements AsyncHttpClient {
           nettyTimer.stop();
         } catch (Throwable t) {
           LOGGER.warn("Unexpected error on HashedWheelTimer close", t);
+        }
+      }
+      if (config.getCookieStore() != null) {
+        try {
+          config.getCookieStore().close();
+        } catch (IOException e) {
+          LOGGER.warn("IOException closing CookieStore", e);
         }
       }
     }

--- a/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClientConfig.java
+++ b/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClientConfig.java
@@ -109,6 +109,7 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
 
   // cookie store
   private final CookieStore cookieStore;
+  private final int expiredCookieEvictionDelay;
 
   // internals
   private final String threadPoolName;
@@ -192,6 +193,7 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
 
                                        // cookie store
                                        CookieStore cookieStore,
+                                       int expiredCookieEvictionDelay,
 
                                        // tuning
                                        boolean tcpNoDelay,
@@ -283,6 +285,7 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
 
     // cookie store
     this.cookieStore = cookieStore;
+    this.expiredCookieEvictionDelay = expiredCookieEvictionDelay;
 
     // tuning
     this.tcpNoDelay = tcpNoDelay;
@@ -558,6 +561,11 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
     return cookieStore;
   }
 
+  @Override
+  public int expiredCookieEvictionDelay() {
+    return expiredCookieEvictionDelay;
+  }
+
   // tuning
   @Override
   public boolean isTcpNoDelay() {
@@ -746,6 +754,7 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
 
     // cookie store
     private CookieStore cookieStore = new ThreadSafeCookieStore();
+    private int expiredCookieEvictionDelay = defaultExpiredCookieEvictionDelay();
 
     // tuning
     private boolean tcpNoDelay = defaultTcpNoDelay();
@@ -1146,6 +1155,11 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
       return this;
     }
 
+    public Builder setExpiredCookieEvictionDelay(int expiredCookieEvictionDelay) {
+      this.expiredCookieEvictionDelay = expiredCookieEvictionDelay;
+      return this;
+    }
+
     // tuning
     public Builder setTcpNoDelay(boolean tcpNoDelay) {
       this.tcpNoDelay = tcpNoDelay;
@@ -1330,6 +1344,7 @@ public class DefaultAsyncHttpClientConfig implements AsyncHttpClientConfig {
               responseFilters.isEmpty() ? Collections.emptyList() : Collections.unmodifiableList(responseFilters),
               ioExceptionFilters.isEmpty() ? Collections.emptyList() : Collections.unmodifiableList(ioExceptionFilters),
               cookieStore,
+              expiredCookieEvictionDelay,
               tcpNoDelay,
               soReuseAddress,
               soKeepAlive,

--- a/client/src/main/java/org/asynchttpclient/config/AsyncHttpClientConfigDefaults.java
+++ b/client/src/main/java/org/asynchttpclient/config/AsyncHttpClientConfigDefaults.java
@@ -73,6 +73,7 @@ public final class AsyncHttpClientConfigDefaults {
   public static final String IO_THREADS_COUNT_CONFIG = "ioThreadsCount";
   public static final String HASHED_WHEEL_TIMER_TICK_DURATION = "hashedWheelTimerTickDuration";
   public static final String HASHED_WHEEL_TIMER_SIZE = "hashedWheelTimerSize";
+  public static final String EXPIRED_COOKIE_EVICTION_DELAY = "expiredCookieEvictionDelay";
 
   public static final String AHC_VERSION;
 
@@ -303,5 +304,9 @@ public final class AsyncHttpClientConfigDefaults {
 
   public static int defaultHashedWheelTimerSize() {
     return AsyncHttpClientConfigHelper.getAsyncHttpClientConfig().getInt(ASYNC_CLIENT_CONFIG_ROOT + HASHED_WHEEL_TIMER_SIZE);
+  }
+
+  public static int defaultExpiredCookieEvictionDelay() {
+    return AsyncHttpClientConfigHelper.getAsyncHttpClientConfig().getInt(ASYNC_CLIENT_CONFIG_ROOT + EXPIRED_COOKIE_EVICTION_DELAY);
   }
 }

--- a/client/src/main/java/org/asynchttpclient/cookie/CookieEvictionTask.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/CookieEvictionTask.java
@@ -9,13 +9,13 @@ import io.netty.util.TimerTask;
 
 /**
  * Evicts expired cookies from the {@linkplain CookieStore} periodically.
- * The default delay is 30 seconds. Ypu may override the default using
+ * The default delay is 30 seconds. You may override the default using
  * {@linkplain AsyncHttpClientConfig#expiredCookieEvictionDelay()}.
  */
 public class CookieEvictionTask implements TimerTask {
 
-    private long evictDelayInMs;
-    private CookieStore cookieStore;
+    private final long evictDelayInMs;
+    private final CookieStore cookieStore;
 
     public CookieEvictionTask(long evictDelayInMs, CookieStore cookieStore) {
         this.evictDelayInMs = evictDelayInMs;

--- a/client/src/main/java/org/asynchttpclient/cookie/CookieEvictionTask.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/CookieEvictionTask.java
@@ -1,0 +1,30 @@
+package org.asynchttpclient.cookie;
+
+import java.util.concurrent.TimeUnit;
+
+import org.asynchttpclient.AsyncHttpClientConfig;
+
+import io.netty.util.Timeout;
+import io.netty.util.TimerTask;
+
+/**
+ * Evicts expired cookies from the {@linkplain CookieStore} periodically.
+ * The default delay is 30 seconds. Ypu may override the default using
+ * {@linkplain AsyncHttpClientConfig#expiredCookieEvictionDelay()}.
+ */
+public class CookieEvictionTask implements TimerTask {
+
+    private long evictDelayInMs;
+    private CookieStore cookieStore;
+
+    public CookieEvictionTask(long evictDelayInMs, CookieStore cookieStore) {
+        this.evictDelayInMs = evictDelayInMs;
+        this.cookieStore = cookieStore;
+    }
+
+    @Override
+    public void run(Timeout timeout) throws Exception {
+        cookieStore.evictExpired();
+        timeout.timer().newTimeout(this, evictDelayInMs, TimeUnit.MILLISECONDS);
+    }
+}

--- a/client/src/main/java/org/asynchttpclient/cookie/CookieStore.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/CookieStore.java
@@ -16,6 +16,7 @@ package org.asynchttpclient.cookie;
 
 import io.netty.handler.codec.http.cookie.Cookie;
 import org.asynchttpclient.uri.Uri;
+import org.asynchttpclient.util.Counted;
 
 import java.net.CookieManager;
 import java.util.List;
@@ -31,7 +32,7 @@ import java.util.function.Predicate;
  *
  * @since 2.1
  */
-public interface CookieStore {
+public interface CookieStore extends Counted {
   /**
    * Adds one {@link Cookie} to the store. This is called for every incoming HTTP response.
    * If the given cookie has already expired it will not be added.

--- a/client/src/main/java/org/asynchttpclient/cookie/CookieStore.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/CookieStore.java
@@ -32,10 +32,10 @@ import java.util.function.Predicate;
  *
  * @since 2.1
  */
-public interface CookieStore extends Closeable {
+public interface CookieStore {
   /**
    * Adds one {@link Cookie} to the store. This is called for every incoming HTTP response.
-   * If the given cookie has already expired it will not be added, but existing values will still be removed.
+   * If the given cookie has already expired it will not be added.
    *
    * <p>A cookie to store may or may not be associated with an URI. If it
    * is not associated with an URI, the cookie's domain and path attribute
@@ -83,4 +83,9 @@ public interface CookieStore extends Closeable {
    * @return true if any cookies were purged.
    */
   boolean clear();
+
+  /**
+   * Evicts all the cookies that expired as of the time this method is run.
+   */
+  void evictExpired();
 }

--- a/client/src/main/java/org/asynchttpclient/cookie/CookieStore.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/CookieStore.java
@@ -17,6 +17,7 @@ package org.asynchttpclient.cookie;
 import io.netty.handler.codec.http.cookie.Cookie;
 import org.asynchttpclient.uri.Uri;
 
+import java.io.Closeable;
 import java.net.CookieManager;
 import java.util.List;
 import java.util.function.Predicate;
@@ -31,7 +32,7 @@ import java.util.function.Predicate;
  *
  * @since 2.1
  */
-public interface CookieStore {
+public interface CookieStore extends Closeable {
   /**
    * Adds one {@link Cookie} to the store. This is called for every incoming HTTP response.
    * If the given cookie has already expired it will not be added, but existing values will still be removed.

--- a/client/src/main/java/org/asynchttpclient/cookie/CookieStore.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/CookieStore.java
@@ -17,7 +17,6 @@ package org.asynchttpclient.cookie;
 import io.netty.handler.codec.http.cookie.Cookie;
 import org.asynchttpclient.uri.Uri;
 
-import java.io.Closeable;
 import java.net.CookieManager;
 import java.util.List;
 import java.util.function.Predicate;

--- a/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
@@ -21,7 +21,6 @@ import org.asynchttpclient.util.MiscUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;

--- a/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
@@ -82,7 +82,6 @@ public final class ThreadSafeCookieStore implements CookieStore {
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  // Visible for test
   public Map<String, Map<CookieKey, StoredCookie>> getUnderlying() {
     return new HashMap<>(cookieJar);
   }

--- a/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-public final class ThreadSafeCookieStore implements CookieStore, Closeable {
+public final class ThreadSafeCookieStore implements CookieStore {
   private static final Logger log = LoggerFactory.getLogger(ThreadSafeCookieStore.class);
 
   private final Map<String, Map<CookieKey, StoredCookie>> cookieJar = new ConcurrentHashMap<>();

--- a/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
@@ -15,7 +15,6 @@
 package org.asynchttpclient.cookie;
 
 import io.netty.handler.codec.http.cookie.Cookie;
-
 import org.asynchttpclient.uri.Uri;
 import org.asynchttpclient.util.Assertions;
 import org.asynchttpclient.util.MiscUtils;

--- a/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
@@ -21,12 +21,14 @@ import org.asynchttpclient.util.MiscUtils;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public final class ThreadSafeCookieStore implements CookieStore {
 
   private final Map<String, Map<CookieKey, StoredCookie>> cookieJar = new ConcurrentHashMap<>();
+  private final AtomicInteger counter = new AtomicInteger();
 
   @Override
   public void add(Uri uri, Cookie cookie) {
@@ -78,6 +80,22 @@ public final class ThreadSafeCookieStore implements CookieStore {
   @Override
   public void evictExpired() {
     removeExpired();
+  }
+
+
+  @Override
+  public int incrementAndGet() {
+    return counter.incrementAndGet();
+  }
+
+  @Override
+  public int decrementAndGet() {
+    return counter.decrementAndGet();
+  }
+
+  @Override
+  public int count() {
+    return counter.get();
   }
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
@@ -84,6 +84,9 @@ public final class ThreadSafeCookieStore implements CookieStore {
         removed[0] = value.entrySet().removeIf(v -> predicate.test(v.getValue().cookie));
       }
     });
+    if (removed[0]) {
+      cookieJar.entrySet().removeIf(entry -> entry.getValue() == null || entry.getValue().isEmpty());
+    }
     return removed[0];
   }
 
@@ -202,10 +205,15 @@ public final class ThreadSafeCookieStore implements CookieStore {
   }
 
   private void removeExpired() {
+    final boolean[] removed = {false};
     cookieJar.values().forEach(cookieMap -> {
-      cookieMap.entrySet().removeIf(v -> hasCookieExpired(v.getValue().cookie, v.getValue().createdAt));
+      if (!removed[0]) {
+        removed[0] = cookieMap.entrySet().removeIf(v -> hasCookieExpired(v.getValue().cookie, v.getValue().createdAt));
+      }
     });
-    cookieJar.entrySet().removeIf(entry -> entry.getValue() == null || entry.getValue().isEmpty());
+    if (removed[0]) {
+      cookieJar.entrySet().removeIf(entry -> entry.getValue() == null || entry.getValue().isEmpty());
+    }
   }
 
   @Override

--- a/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
@@ -21,8 +21,6 @@ import org.asynchttpclient.util.MiscUtils;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 

--- a/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
@@ -24,8 +24,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import javax.print.attribute.standard.NumberUp;
-
 public final class ThreadSafeCookieStore implements CookieStore {
 
   private final Map<String, Map<CookieKey, StoredCookie>> cookieJar = new ConcurrentHashMap<>();

--- a/client/src/main/java/org/asynchttpclient/util/Counted.java
+++ b/client/src/main/java/org/asynchttpclient/util/Counted.java
@@ -1,0 +1,13 @@
+package org.asynchttpclient.util;
+
+/**
+ * A contract that has methods to represent how many AHC instances
+ * the implementation is shared with.
+ */
+public interface Counted {
+    int incrementAndGet();
+
+    int decrementAndGet();
+
+    int count();
+}

--- a/client/src/main/java/org/asynchttpclient/util/Counted.java
+++ b/client/src/main/java/org/asynchttpclient/util/Counted.java
@@ -1,13 +1,23 @@
 package org.asynchttpclient.util;
 
 /**
- * A contract that has methods to represent how many AHC instances
- * the implementation is shared with.
+ * An interface that defines useful methods to check how many {@linkplain org.asynchttpclient.AsyncHttpClient}
+ * instances this particular implementation is shared with.
  */
 public interface Counted {
+
+    /**
+     * Increment counter and return the incremented value
+     */
     int incrementAndGet();
 
+    /**
+     * Decrement counter and return the decremented value
+     */
     int decrementAndGet();
 
+    /**
+     * Return the current counter
+     */
     int count();
 }

--- a/client/src/main/resources/org/asynchttpclient/config/ahc-default.properties
+++ b/client/src/main/resources/org/asynchttpclient/config/ahc-default.properties
@@ -52,3 +52,4 @@ org.asynchttpclient.useNativeTransport=false
 org.asynchttpclient.ioThreadsCount=0
 org.asynchttpclient.hashedWheelTimerTickDuration=100
 org.asynchttpclient.hashedWheelTimerSize=512
+org.asynchttpclient.expiredCookieEvictionDelay=30000

--- a/client/src/test/java/org/asynchttpclient/CookieStoreTest.java
+++ b/client/src/test/java/org/asynchttpclient/CookieStoreTest.java
@@ -27,6 +27,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.testng.Assert.assertTrue;
 
@@ -284,8 +285,9 @@ public class CookieStoreTest {
     assertTrue(cookies1.size() == 2);
     assertTrue(cookies1.stream().filter(c -> c.value().equals("FOO") || c.value().equals("BAR")).count() == 2);
 
-    String result = ClientCookieEncoder.LAX.encode(cookies1.get(0), cookies1.get(1));
-    assertTrue(result.equals("JSESSIONID=FOO; JSESSIONID=BAR"));
+    List<String> encodedCookieStrings = cookies1.stream().map(ClientCookieEncoder.LAX::encode).collect(Collectors.toList());
+    assertTrue(encodedCookieStrings.contains("JSESSIONID=FOO"));
+    assertTrue(encodedCookieStrings.contains("JSESSIONID=BAR"));
   }
 
   // rfc6265#section-1 Cookies for a given host are shared  across all the ports on that host

--- a/client/src/test/java/org/asynchttpclient/CookieStoreTest.java
+++ b/client/src/test/java/org/asynchttpclient/CookieStoreTest.java
@@ -17,6 +17,8 @@ package org.asynchttpclient;
 import io.netty.handler.codec.http.cookie.ClientCookieDecoder;
 import io.netty.handler.codec.http.cookie.ClientCookieEncoder;
 import io.netty.handler.codec.http.cookie.Cookie;
+import io.netty.handler.codec.http.cookie.DefaultCookie;
+
 import org.asynchttpclient.cookie.CookieStore;
 import org.asynchttpclient.cookie.ThreadSafeCookieStore;
 import org.asynchttpclient.uri.Uri;
@@ -26,10 +28,13 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.Sets;
 
 public class CookieStoreTest {
 
@@ -47,7 +52,7 @@ public class CookieStoreTest {
   }
 
   @Test
-  public void runAllSequentiallyBecauseNotThreadSafe() {
+  public void runAllSequentiallyBecauseNotThreadSafe() throws Exception {
     addCookieWithEmptyPath();
     dontReturnCookieForAnotherDomain();
     returnCookieWhenItWasSetOnSamePath();
@@ -78,6 +83,7 @@ public class CookieStoreTest {
     shouldAlsoServeNonSecureCookiesBasedOnTheUriScheme();
     shouldNotServeSecureCookiesForDefaultRetrievedHttpUriScheme();
     shouldServeSecureCookiesForSpecificallyRetrievedHttpUriScheme();
+    shouldCleanExpiredCookieFromUnderlyingDataStructure();
   }
 
   private void addCookieWithEmptyPath() {
@@ -338,5 +344,27 @@ public class CookieStoreTest {
     assertTrue(store.get(uri).size() == 1);
     assertTrue(store.get(uri).get(0).value().equals("VALUE3"));
     assertTrue(store.get(uri).get(0).isSecure());
+  }
+
+  private void shouldCleanExpiredCookieFromUnderlyingDataStructure() throws Exception {
+    ThreadSafeCookieStore store = new ThreadSafeCookieStore();
+    store.add(Uri.create("https://foo.org/moodle/"), getCookie("JSESSIONID", "FOO", 1));
+    store.add(Uri.create("https://bar.org/moodle/"), getCookie("JSESSIONID", "BAR", 1));
+    store.add(Uri.create("https://bar.org/moodle/"), new DefaultCookie("UNEXPIRED_BAR", "BAR"));
+    store.add(Uri.create("https://foobar.org/moodle/"), new DefaultCookie("UNEXPIRED_FOOBAR", "FOOBAR"));
+
+
+    assertTrue(store.getAll().size() == 4);
+    Thread.sleep(2000);
+    store.evictExpired();
+    assertTrue(store.getUnderlying().size() == 2);
+    Collection<String> unexpiredCookieNames = store.getAll().stream().map(Cookie::name).collect(Collectors.toList());
+    assertTrue(unexpiredCookieNames.containsAll(Sets.newHashSet("UNEXPIRED_BAR", "UNEXPIRED_FOOBAR")));
+  }
+
+  private static Cookie getCookie(String key, String value, int maxAge) {
+    DefaultCookie cookie = new DefaultCookie(key, value);
+    cookie.setMaxAge(maxAge);
+    return cookie;
   }
 }

--- a/client/src/test/java/org/asynchttpclient/DefaultAsyncHttpClientTest.java
+++ b/client/src/test/java/org/asynchttpclient/DefaultAsyncHttpClientTest.java
@@ -1,0 +1,65 @@
+package org.asynchttpclient;
+
+import io.netty.util.HashedWheelTimer;
+import io.netty.util.Timer;
+import org.asynchttpclient.DefaultAsyncHttpClientConfig.Builder;
+import org.asynchttpclient.cookie.CookieEvictionTask;
+import org.asynchttpclient.cookie.CookieStore;
+import org.asynchttpclient.cookie.ThreadSafeCookieStore;
+import org.testng.annotations.Test;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.assertEquals;
+
+public class DefaultAsyncHttpClientTest {
+
+  @Test
+  public void testWithSharedNettyTimerShouldScheduleCookieEvictionOnlyOnce() throws IOException {
+    final Timer nettyTimer = mock(HashedWheelTimer.class);
+    final CookieStore cookieStore = new ThreadSafeCookieStore();
+    final DefaultAsyncHttpClientConfig config = new Builder().setNettyTimer(nettyTimer).setCookieStore(cookieStore).build();
+    final AsyncHttpClient client1 = new DefaultAsyncHttpClient(config);
+    final AsyncHttpClient client2 = new DefaultAsyncHttpClient(config);
+
+    try {
+      assertEquals(cookieStore.count(), 2);
+      verify(nettyTimer, times(1)).newTimeout(any(CookieEvictionTask.class), anyLong(), any(TimeUnit.class));
+    } finally {
+      closeSilently(client1);
+      closeSilently(client2);
+    }
+  }
+
+  @Test
+  public void testWithNonNettyTimerShouldScheduleCookieEvictionForEachAHC() throws IOException {
+    final AsyncHttpClientConfig config1 = new DefaultAsyncHttpClientConfig.Builder().build();
+    final DefaultAsyncHttpClient client1 = new DefaultAsyncHttpClient(config1);
+
+    final AsyncHttpClientConfig config2 = new DefaultAsyncHttpClientConfig.Builder().build();
+    final DefaultAsyncHttpClient client2 = new DefaultAsyncHttpClient(config2);
+
+    try {
+      assertEquals(config1.getCookieStore().count(), 1);
+      assertEquals(config2.getCookieStore().count(), 1);
+    } finally {
+      closeSilently(client1);
+      closeSilently(client2);
+    }
+  }
+
+  private static void closeSilently(Closeable closeable) {
+    if (closeable != null) {
+      try {
+        closeable.close();
+      } catch (IOException e) {
+        // swallow
+      }
+    }
+  }
+}

--- a/client/src/test/java/org/asynchttpclient/DefaultAsyncHttpClientTest.java
+++ b/client/src/test/java/org/asynchttpclient/DefaultAsyncHttpClientTest.java
@@ -1,6 +1,5 @@
 package org.asynchttpclient;
 
-import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timer;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig.Builder;
 import org.asynchttpclient.cookie.CookieEvictionTask;
@@ -21,36 +20,53 @@ public class DefaultAsyncHttpClientTest {
 
   @Test
   public void testWithSharedNettyTimerShouldScheduleCookieEvictionOnlyOnce() throws IOException {
-    final Timer nettyTimer = mock(HashedWheelTimer.class);
+    final Timer nettyTimerMock = mock(Timer.class);
     final CookieStore cookieStore = new ThreadSafeCookieStore();
-    final DefaultAsyncHttpClientConfig config = new Builder().setNettyTimer(nettyTimer).setCookieStore(cookieStore).build();
+    final DefaultAsyncHttpClientConfig config = new Builder().setNettyTimer(nettyTimerMock).setCookieStore(cookieStore).build();
     final AsyncHttpClient client1 = new DefaultAsyncHttpClient(config);
     final AsyncHttpClient client2 = new DefaultAsyncHttpClient(config);
 
-    try {
-      assertEquals(cookieStore.count(), 2);
-      verify(nettyTimer, times(1)).newTimeout(any(CookieEvictionTask.class), anyLong(), any(TimeUnit.class));
-    } finally {
-      closeSilently(client1);
-      closeSilently(client2);
-    }
+    assertEquals(cookieStore.count(), 2);
+    verify(nettyTimerMock, times(1)).newTimeout(any(CookieEvictionTask.class), anyLong(), any(TimeUnit.class));
+
+    closeSilently(client1);
+    closeSilently(client2);
   }
 
   @Test
-  public void testWithNonNettyTimerShouldScheduleCookieEvictionForEachAHC() throws IOException {
+  public void testWitDefaultConfigShouldScheduleCookieEvictionForEachAHC() throws IOException {
     final AsyncHttpClientConfig config1 = new DefaultAsyncHttpClientConfig.Builder().build();
     final DefaultAsyncHttpClient client1 = new DefaultAsyncHttpClient(config1);
 
     final AsyncHttpClientConfig config2 = new DefaultAsyncHttpClientConfig.Builder().build();
     final DefaultAsyncHttpClient client2 = new DefaultAsyncHttpClient(config2);
 
-    try {
-      assertEquals(config1.getCookieStore().count(), 1);
-      assertEquals(config2.getCookieStore().count(), 1);
-    } finally {
-      closeSilently(client1);
-      closeSilently(client2);
-    }
+    assertEquals(config1.getCookieStore().count(), 1);
+    assertEquals(config2.getCookieStore().count(), 1);
+
+    closeSilently(client1);
+    closeSilently(client2);
+  }
+
+  @Test
+  public void testWithSharedCookieStoreButNonSharedTimerShouldScheduleCookieEvictionForFirstAHC() throws IOException {
+    final CookieStore cookieStore = new ThreadSafeCookieStore();
+    final Timer nettyTimerMock1 = mock(Timer.class);
+    final AsyncHttpClientConfig config1 = new DefaultAsyncHttpClientConfig.Builder()
+            .setCookieStore(cookieStore).setNettyTimer(nettyTimerMock1).build();
+    final DefaultAsyncHttpClient client1 = new DefaultAsyncHttpClient(config1);
+
+    final Timer nettyTimerMock2 = mock(Timer.class);
+    final AsyncHttpClientConfig config2 = new DefaultAsyncHttpClientConfig.Builder()
+            .setCookieStore(cookieStore).setNettyTimer(nettyTimerMock2).build();
+    final DefaultAsyncHttpClient client2 = new DefaultAsyncHttpClient(config2);
+
+    assertEquals(config1.getCookieStore().count(), 2);
+    verify(nettyTimerMock1, times(1)).newTimeout(any(CookieEvictionTask.class), anyLong(), any(TimeUnit.class));
+    verify(nettyTimerMock2, never()).newTimeout(any(CookieEvictionTask.class), anyLong(), any(TimeUnit.class));
+
+    closeSilently(client1);
+    closeSilently(client2);
   }
 
   private static void closeSilently(Closeable closeable) {

--- a/extras/typesafeconfig/src/main/java/org/asynchttpclient/extras/typesafeconfig/AsyncHttpClientTypesafeConfig.java
+++ b/extras/typesafeconfig/src/main/java/org/asynchttpclient/extras/typesafeconfig/AsyncHttpClientTypesafeConfig.java
@@ -165,6 +165,11 @@ public class AsyncHttpClientTypesafeConfig implements AsyncHttpClientConfig {
   }
 
   @Override
+  public int expiredCookieEvictionDelay() {
+    return getIntegerOpt(EXPIRED_COOKIE_EVICTION_DELAY).orElse(defaultExpiredCookieEvictionDelay());
+  }
+
+  @Override
   public int getMaxRequestRetry() {
     return getIntegerOpt(MAX_REQUEST_RETRY_CONFIG).orElse(defaultMaxRequestRetry());
   }


### PR DESCRIPTION
Closes: https://github.com/AsyncHttpClient/async-http-client/issues/1580

Changes:
1. Segmented map based on domain names. So instead of traversing all the domains it traverses the domains that are of interest.
2. Use NettyTimer to clean up the expired cookies asynchronously. The timer task that provides this functionality is CookieEvictionTask.