### PR TITLE
fixed NPE caused by open but unconnected channels.

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
@@ -61,6 +61,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -490,7 +491,7 @@ public class ChannelManager {
   }
 
   public ClientStats getClientStats() {
-    Map<String, Long> totalConnectionsPerHost = openChannels.stream().map(Channel::remoteAddress).filter(a -> a.getClass() == InetSocketAddress.class)
+    Map<String, Long> totalConnectionsPerHost = openChannels.stream().map(Channel::remoteAddress).filter(Objects::nonNull).filter(a -> a.getClass() == InetSocketAddress.class)
             .map(a -> (InetSocketAddress) a).map(InetSocketAddress::getHostString).collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
     Map<String, Long> idleConnectionsPerHost = channelPool.getIdleChannelCountPerHost();
     Map<String, HostStats> statsPerHost = totalConnectionsPerHost.entrySet().stream().collect(Collectors.toMap(Entry::getKey, entry -> {

--- a/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
@@ -491,7 +491,7 @@ public class ChannelManager {
   }
 
   public ClientStats getClientStats() {
-    Map<String, Long> totalConnectionsPerHost = openChannels.stream().map(Channel::remoteAddress).filter(Objects::nonNull).filter(a -> a.getClass() == InetSocketAddress.class)
+    Map<String, Long> totalConnectionsPerHost = openChannels.stream().map(Channel::remoteAddress).filter(a -> a instanceof InetSocketAddress)
             .map(a -> (InetSocketAddress) a).map(InetSocketAddress::getHostString).collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
     Map<String, Long> idleConnectionsPerHost = channelPool.getIdleChannelCountPerHost();
     Map<String, HostStats> statsPerHost = totalConnectionsPerHost.entrySet().stream().collect(Collectors.toMap(Entry::getKey, entry -> {


### PR DESCRIPTION
This PR fixed a NullPointerException caused by open but unconnected channels. 
The issue is reported: https://github.com/AsyncHttpClient/async-http-client/issues/1710