### PR TITLE
Added bnd instructions for optional native transports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
           <instructions>
             <Bundle-Version>$(replace;$(project.version);-SNAPSHOT;.$(tstamp;yyyyMMdd-HHmm))</Bundle-Version>
             <Bundle-Vendor>The AsyncHttpClient Project</Bundle-Vendor>
-            <Import-Package>javax.activation;version="[1.1,2)", *</Import-Package>
+            <Import-Package>javax.activation;version="[1.1,2)", io.netty.channel.kqueue;resolution:=optional, io.netty.channel.epoll;resolution:=optional, *</Import-Package>
           </instructions>
         </configuration>
         <executions>


### PR DESCRIPTION
Added bnd instructions to the maven-bundle-plugin to mark the native transports as optional imports.


Fixes #1717 