### PR TITLE
Implemented reusable InputStreamPart

### DIFF
--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/InputStreamSupplierPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/InputStreamSupplierPart.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2018 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.request.body.multipart;
+
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.function.Supplier;
+
+import static org.asynchttpclient.util.Assertions.assertNotNull;
+
+public class InputStreamSupplierPart extends FileLikePart {
+
+  private final Supplier<InputStream> inputStreamSupplier;
+  private final long contentLength;
+
+  public InputStreamSupplierPart(String name, Supplier<InputStream> inputStreamSupplier, String fileName) {
+    this(name, inputStreamSupplier, fileName, -1);
+  }
+
+  public InputStreamSupplierPart(String name, Supplier<InputStream> inputStreamSupplier, String fileName, long contentLength) {
+    this(name, inputStreamSupplier, fileName, contentLength, null);
+  }
+
+  public InputStreamSupplierPart(String name, Supplier<InputStream> inputStreamSupplier, String fileName, long contentLength, String contentType) {
+    this(name, inputStreamSupplier, fileName, contentLength, contentType, null);
+  }
+
+  public InputStreamSupplierPart(String name, Supplier<InputStream> inputStreamSupplier, String fileName, long contentLength, String contentType, Charset charset) {
+    this(name, inputStreamSupplier, fileName, contentLength, contentType, charset, null);
+  }
+
+  public InputStreamSupplierPart(String name, Supplier<InputStream> inputStreamSupplier, String fileName, long contentLength, String contentType, Charset charset,
+                                 String contentId) {
+    this(name, inputStreamSupplier, fileName, contentLength, contentType, charset, contentId, null);
+  }
+
+  public InputStreamSupplierPart(String name, Supplier<InputStream> inputStreamSupplier, String fileName, long contentLength, String contentType, Charset charset,
+                                 String contentId, String transferEncoding) {
+    super(name,
+            contentType,
+            charset,
+            fileName,
+            contentId,
+            transferEncoding);
+    this.inputStreamSupplier = assertNotNull(inputStreamSupplier, "inputStreamSupplier");
+    this.contentLength = contentLength;
+  }
+
+  public InputStreamPart createInputStreamPart() {
+    return new InputStreamPart(getName(), inputStreamSupplier.get(), getFileName(), contentLength, getContentType(), getCharset(), getContentId(), getTransferEncoding());
+  }
+}

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/MultipartUtils.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/MultipartUtils.java
@@ -78,6 +78,10 @@ public class MultipartUtils {
       } else if (part instanceof InputStreamPart) {
         multipartParts.add(new InputStreamMultipartPart((InputStreamPart) part, boundary));
 
+      } else if (part instanceof InputStreamSupplierPart) {
+        InputStreamSupplierPart streamSupplierPart = (InputStreamSupplierPart)part;
+        multipartParts.add(new InputStreamMultipartPart(streamSupplierPart.createInputStreamPart(), boundary));
+
       } else {
         throw new IllegalArgumentException("Unknown part type: " + part);
       }

--- a/client/src/test/java/org/asynchttpclient/request/body/multipart/InputStreamSupplierPartTest.java
+++ b/client/src/test/java/org/asynchttpclient/request/body/multipart/InputStreamSupplierPartTest.java
@@ -1,0 +1,74 @@
+package org.asynchttpclient.request.body.multipart;
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+class InputStreamSupplierPartTest {
+
+    private byte counter = 0;
+    private final Supplier<InputStream> inputStreamSupplier = () -> new ByteArrayInputStream(new byte[]{counter++});
+
+    @BeforeTest
+    public void setup() {
+        counter = 0;
+    }
+
+    @Test
+    public void testParametersAreDelegated() {
+        String name = "testName";
+        String fileName = "testFileName";
+        long contentLength = 1;
+        String contentType = "text/plain";
+        Charset charset = StandardCharsets.UTF_8;
+        String contentId = "testContentId";
+        String transferEncoding = StandardCharsets.UTF_8.toString();
+
+        InputStreamSupplierPart part = new InputStreamSupplierPart(name, inputStreamSupplier, fileName, contentLength,
+                contentType, charset, contentId, transferEncoding);
+        InputStreamPart delegatedPart = part.createInputStreamPart();
+        assertEquals(delegatedPart.getName(), name);
+        assertEquals(delegatedPart.getFileName(), fileName);
+        assertEquals(delegatedPart.getContentLength(), contentLength);
+        assertEquals(delegatedPart.getContentType(), contentType);
+        assertEquals(delegatedPart.getCharset(), charset);
+        assertEquals(delegatedPart.getContentId(), contentId);
+        assertEquals(delegatedPart.getTransferEncoding(), transferEncoding);
+    }
+
+    @Test
+    public void testFreshInputStreamOnUse() throws IOException {
+        InputStreamSupplierPart part = new InputStreamSupplierPart("name", inputStreamSupplier, "fileName");
+
+        InputStreamPart firstCreatedPart = part.createInputStreamPart();
+        InputStreamPart secondCreatedPart = part.createInputStreamPart();
+        assertNotEquals(firstCreatedPart, secondCreatedPart);
+
+        InputStream firstInputStream = firstCreatedPart.getInputStream();
+        InputStream secondInputStream = secondCreatedPart.getInputStream();
+        try {
+            assertNotEquals(firstInputStream, secondInputStream);
+
+            assertEquals(readAll(firstInputStream), new byte[]{0});
+            assertEquals(readAll(secondInputStream), new byte[]{1});
+        } finally {
+            firstInputStream.close();
+            secondInputStream.close();
+        }
+    }
+
+    private byte[] readAll(InputStream inputStream) throws IOException {
+        byte[] targetArray = new byte[inputStream.available()];
+        inputStream.read(targetArray);
+        return targetArray;
+    }
+}


### PR DESCRIPTION
Referring to #1720 I've implemented a simple solution to provide an InputStreamSupplier as Multipart Body. Under the hood however the implementation just creates a new InputStream and then delegated everything else to the already existing InputStreamPart. Nevertheless I enhanced the MultipartUploadTest to be sure the logic is tested. Hope this is fine!