### PR TITLE
Use original method in redirects for HEAD / OPTIONS requests

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Redirect30xInterceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Redirect30xInterceptor.java
@@ -38,6 +38,8 @@ import java.util.Set;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.*;
 import static org.asynchttpclient.util.HttpConstants.Methods.GET;
+import static org.asynchttpclient.util.HttpConstants.Methods.HEAD;
+import static org.asynchttpclient.util.HttpConstants.Methods.OPTIONS;
 import static org.asynchttpclient.util.HttpConstants.ResponseStatusCodes.*;
 import static org.asynchttpclient.util.HttpUtils.followRedirect;
 import static org.asynchttpclient.util.MiscUtils.isNonEmpty;
@@ -87,7 +89,7 @@ public class Redirect30xInterceptor {
 
         String originalMethod = request.getMethod();
         boolean switchToGet = !originalMethod.equals(GET)
-                && (statusCode == MOVED_PERMANENTLY_301 || statusCode == SEE_OTHER_303 || (statusCode == FOUND_302 && !config.isStrict302Handling()));
+                && !originalMethod.equals(OPTIONS) && !originalMethod.equals(HEAD) && (statusCode == MOVED_PERMANENTLY_301 || statusCode == SEE_OTHER_303 || (statusCode == FOUND_302 && !config.isStrict302Handling()));
         boolean keepBody = statusCode == TEMPORARY_REDIRECT_307 || statusCode == PERMANENT_REDIRECT_308 || (statusCode == FOUND_302 && config.isStrict302Handling());
 
         final RequestBuilder requestBuilder = new RequestBuilder(switchToGet ? GET : originalMethod)
@@ -126,7 +128,6 @@ public class Redirect30xInterceptor {
         HttpHeaders responseHeaders = response.headers();
         String location = responseHeaders.get(LOCATION);
         Uri newUri = Uri.create(future.getUri(), location);
-
         LOGGER.debug("Redirecting to {}", newUri);
 
         CookieStore cookieStore = config.getCookieStore();

--- a/client/src/test/java/org/asynchttpclient/AsyncStreamHandlerTest.java
+++ b/client/src/test/java/org/asynchttpclient/AsyncStreamHandlerTest.java
@@ -428,6 +428,8 @@ public class AsyncStreamHandlerTest extends HttpTest {
       }));
   }
 
+  // This test is flaky - see https://github.com/AsyncHttpClient/async-http-client/issues/1728#issuecomment-699962325
+  // For now, just run again if fails
   @Test(groups = "online")
   public void asyncOptionsTest() throws Throwable {
 


### PR DESCRIPTION
Originally, when setFollowRedirect is set to true (like in Head302Test), the expected flow is HEAD --> GET (based on the behaviour of Redirect30xInterceptor - see https://github.com/AsyncHttpClient/async-http-client/commit/3c25a42289bf679cfff40ca5ef0e77be85215deb for the reasoning).

Following a change to the interceptor (to fix https://github.com/AsyncHttpClient/async-http-client/issues/1728), Head302Test started going on an infinite loop caused by the way the handler in the test was set up (to account for the original HEAD --> GET flow and not the new HEAD --> HEAD --> HEAD.... flow).

This PR does 3 things:

* Changes Redirect30xInterceptor to set all redirects of a HEAD request to be HEADs as well
* Change Head302Test to account for the new flow
* Notes a flaky test in AsyncStreamHandlerTest that was found during work on the PR