### PR TITLE
Swap jfarcand dead blog post links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,9 +301,10 @@ Response response = c.executeRequest(propFindRequest, new AsyncHandler() {
 You can find more information on Jean-François Arcand's blog.  Jean-François is the original author of this library.
 Code is sometimes not up-to-date but gives a pretty good idea of advanced features.
 
-* https://jfarcand.wordpress.com/2010/12/21/going-asynchronous-using-asynchttpclient-the-basic/
-* https://jfarcand.wordpress.com/2011/01/04/going-asynchronous-using-asynchttpclient-the-complex/
-* https://jfarcand.wordpress.com/2011/12/21/writing-websocket-clients-using-asynchttpclient/
+* http://web.archive.org/web/20111224171448/http://jfarcand.wordpress.com/2011/01/12/going-asynchronous-using-asynchttpclient-for-dummies/
+* http://web.archive.org/web/20111224171241/http://jfarcand.wordpress.com/2010/12/21/going-asynchronous-using-asynchttpclient-the-basic/
+* http://web.archive.org/web/20111224162752/http://jfarcand.wordpress.com/2011/01/04/going-asynchronous-using-asynchttpclient-the-complex/
+* http://web.archive.org/web/20120218183108/http://jfarcand.wordpress.com/2011/12/21/writing-websocket-clients-using-asynchttpclient/
 
 ## User Group
 


### PR DESCRIPTION
The links in the README point to the original blog, which is dead. Added internet archive ones instead.