### PR TITLE
Propagate original request user-agent in proxy CONNECT requests

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestFactory.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestFactory.java
@@ -140,6 +140,7 @@ public final class NettyRequestFactory {
     if (connect) {
       // assign proxy-auth as configured on request
       headers.set(PROXY_AUTHORIZATION, request.getHeaders().getAll(PROXY_AUTHORIZATION));
+      headers.set(USER_AGENT, request.getHeaders().getAll(USER_AGENT));
 
     } else {
       // assign headers as configured on request


### PR DESCRIPTION
Following https://github.com/AsyncHttpClient/async-http-client/issues/1730, it appears that when using a proxy server and a custom user-agent header, the user-agent of the CONNECT request to the proxy server is not correctly set to be the custom one, but instead the default one.

This makes sure the user-agent header is propagated down to the CONNECT request as well, and changes the BasicHTTPToHTTPSTest to account for this as well (since they're logically similar - they both test for the existence of specific headers in the flow).


BTW: Propagate? Percolate? Bubble down? Simmer through? Feel free to change the phrasing. 