### PR TITLE
Bump netty.version for vulnerability fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -466,7 +466,7 @@
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
     <source.property>1.8</source.property>
     <target.property>1.8</target.property>
-    <netty.version>4.1.51.Final</netty.version>
+    <netty.version>4.1.53.Final</netty.version>
     <slf4j.version>1.7.30</slf4j.version>
     <reactive-streams.version>1.0.3</reactive-streams.version>
     <activation.version>1.2.2</activation.version>


### PR DESCRIPTION
Specifically because out vulnerability scanner is reporting https://app.snyk.io/vuln/SNYK-JAVA-IONETTY-1020439 which is fixed in this version.