### PR TITLE
Package level constructor for AsyncHttpClientState to be changed to public

### DIFF
--- a/client/src/main/java/org/asynchttpclient/AsyncHttpClientState.java
+++ b/client/src/main/java/org/asynchttpclient/AsyncHttpClientState.java
@@ -19,7 +19,7 @@ public class AsyncHttpClientState {
 
   private final AtomicBoolean closed;
 
-  AsyncHttpClientState(AtomicBoolean closed) {
+  public AsyncHttpClientState(AtomicBoolean closed) {
     this.closed = closed;
   }
 


### PR DESCRIPTION
We have the following requirement : 

- We use client certificate authentication. However, we want to have the client certificate dynamic and can be changed at runtime.
- For that, in the 1.9.x versions, we extended AsyncHttpClient and created a new client config object with a new SSLContext and use that to create a NettyAsyncHttpProvider instance and execute the request.
- NettyAsyncHttpProvider is not available in 2.x versions.
- Hence, we are trying to use NettyRequestSender.
- NettyRequestSender constructor needs a AsyncHttpClientState object.
- Since, AsyncHttpClientState constructor is package, we are unable to proceed.
- If we keep clientState as null, execute method won't work in NettyRequestSender due to isClosed check.

Thanks,
Suyash