### PR TITLE
Always remove subscriber from pipeline when completing a reactive stream

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/handler/StreamedResponsePublisher.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/StreamedResponsePublisher.java
@@ -64,8 +64,8 @@ public class StreamedResponsePublisher extends HandlerPublisher<HttpResponseBody
 
   @Override
   public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-    hasOutstandingRequest = false;
     super.channelReadComplete(ctx);
+    hasOutstandingRequest = false;
   }
 
   @Override

--- a/client/src/main/java/org/asynchttpclient/netty/request/body/NettyReactiveStreamsBody.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/body/NettyReactiveStreamsBody.java
@@ -112,15 +112,11 @@ public class NettyReactiveStreamsBody implements NettyBody {
     @Override
     protected void complete() {
       if (channel.isActive()) {
-        if (channel.eventLoop().inEventLoop()) {
+          //Always remove, as we are no longer caring about this subscriber
+          removeFromPipeline();
+          //No need to schedule this on the event thread, this is done by the caller.
           channel.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
-
-        } else {
-          channel.eventLoop().execute(() -> channel.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT));
-        }
       }
-      //Always remove, as we are no longer caring about this subscriber
-      removeFromPipeline();
     }
 
     @Override


### PR DESCRIPTION
* Only send LastHttpContent if channel is active
* Avoid async scheduling if possible