### PR TITLE
Add support for Netty's io_uring transport

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -61,6 +61,13 @@
       <classifier>osx-x86_64</classifier>
     </dependency>
     <dependency>
+      <groupId>io.netty.incubator</groupId>
+      <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+      <version>0.0.8.Final</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.reactivestreams</groupId>
       <artifactId>reactive-streams</artifactId>
     </dependency>

--- a/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
@@ -141,6 +141,9 @@ public class ChannelManager {
         transportFactory = new EpollTransportFactory();
       } else if (eventLoopGroup instanceof KQueueEventLoopGroup) {
         transportFactory = new KQueueTransportFactory();
+      } else if (eventLoopGroup.getClass().getSimpleName().equals("IOUringEventLoopGroup")) {
+        // NOTE: instanceof is not used since this is an optional dependency
+        transportFactory = new IOUringTransportFactory();
       } else {
         throw new IllegalArgumentException("Unknown event loop group " + eventLoopGroup.getClass().getSimpleName());
       }

--- a/client/src/main/java/org/asynchttpclient/netty/channel/IOUringTransportFactory.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/IOUringTransportFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.netty.channel;
+
+import io.netty.incubator.channel.uring.IOUring;
+import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
+import io.netty.incubator.channel.uring.IOUringSocketChannel;
+
+import java.util.concurrent.ThreadFactory;
+
+class IOUringTransportFactory implements TransportFactory<IOUringSocketChannel, IOUringEventLoopGroup> {
+
+  IOUringTransportFactory() {
+    try {
+      Class.forName("io.netty.incubator.channel.uring.IOUring");
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException("The io_uring transport is not available");
+    }
+    if (!IOUring.isAvailable()) {
+      throw new IllegalStateException("The io_uring transport is not supported");
+    }
+  }
+
+  @Override
+  public IOUringSocketChannel newChannel() {
+    return new IOUringSocketChannel();
+  }
+
+  @Override
+  public IOUringEventLoopGroup newEventLoopGroup(int ioThreadsCount, ThreadFactory threadFactory) {
+    return new IOUringEventLoopGroup(ioThreadsCount, threadFactory);
+  }
+}


### PR DESCRIPTION
Netty has recently added support for an experimental new type of transport which used Linux's io_uring facility. This PR allows users to pass in a IOUringEventLoopGroup without getting the "Unknown event loop group" exception. Given this is incubating within Netty, I added a optional, provided dependency if folks want to use it, they will have to include the proper dependency on their own. I used the epoll transport factory as a starting point (hence the copyright message).