### PR TITLE
Update netty to 4.1.86.Final to resolve vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -466,7 +466,7 @@
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
     <source.property>1.8</source.property>
     <target.property>1.8</target.property>
-    <netty.version>4.1.60.Final</netty.version>
+    <netty.version>4.1.86.Final</netty.version>
     <slf4j.version>1.7.30</slf4j.version>
     <reactive-streams.version>1.0.3</reactive-streams.version>
     <activation.version>1.2.2</activation.version>


### PR DESCRIPTION
To resolve Vulnerabilities from dependencies:
[CVE-2022-41915](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-41915)
[CVE-2022-24823](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24823)
[CVE-2021-43797](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-43797)