### PR TITLE
Enable JaCoCo and update it to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
                 <version>2.22.2</version>
                 <configuration>
                     <argLine>
-                        --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+                        ${argLine} --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
                     </argLine>
                 </configuration>
             </plugin>
@@ -228,7 +228,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.9</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
                 <version>2.22.2</version>
                 <configuration>
                     <argLine>
-                        ${argLine} --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+                        @{argLine} --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
                     </argLine>
                 </configuration>
             </plugin>


### PR DESCRIPTION
I noticed that JaCoCo reports are not generated due to this issue https://stackoverflow.com/q/18107375
Adding `@{argLine}` as described in the answer and JaCoCo documentation seems to fix the issue and report is generated again.

I also updated JaCoCo version to the latest available.