### PR TITLE
Add nullness annotations to org.asynchttpclient.channel

### DIFF
--- a/client/src/main/java/org/asynchttpclient/channel/ChannelPool.java
+++ b/client/src/main/java/org/asynchttpclient/channel/ChannelPool.java
@@ -16,6 +16,7 @@
 package org.asynchttpclient.channel;
 
 import io.netty.channel.Channel;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 import java.util.function.Predicate;
@@ -37,7 +38,7 @@ public interface ChannelPool {
      * @param partitionKey the partition used when invoking offer
      * @return the channel associated with the uri
      */
-    Channel poll(Object partitionKey);
+    @Nullable Channel poll(Object partitionKey);
 
     /**
      * Remove all channels from the cache. A channel might have been associated

--- a/client/src/main/java/org/asynchttpclient/channel/ChannelPoolPartitioning.java
+++ b/client/src/main/java/org/asynchttpclient/channel/ChannelPoolPartitioning.java
@@ -18,6 +18,7 @@ package org.asynchttpclient.channel;
 import org.asynchttpclient.proxy.ProxyServer;
 import org.asynchttpclient.proxy.ProxyType;
 import org.asynchttpclient.uri.Uri;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
@@ -31,7 +32,7 @@ public interface ChannelPoolPartitioning {
         INSTANCE;
 
         @Override
-        public Object getPartitionKey(Uri uri, String virtualHost, ProxyServer proxyServer) {
+        public Object getPartitionKey(Uri uri, @Nullable String virtualHost, @Nullable ProxyServer proxyServer) {
             String targetHostBaseUrl = uri.getBaseUrl();
             if (proxyServer == null) {
                 if (virtualHost == null) {
@@ -59,12 +60,13 @@ public interface ChannelPoolPartitioning {
 
     class CompositePartitionKey {
         private final String targetHostBaseUrl;
-        private final String virtualHost;
-        private final String proxyHost;
+        private final @Nullable String virtualHost;
+        private final @Nullable String proxyHost;
         private final int proxyPort;
-        private final ProxyType proxyType;
+        private final @Nullable ProxyType proxyType;
 
-        CompositePartitionKey(String targetHostBaseUrl, String virtualHost, String proxyHost, int proxyPort, ProxyType proxyType) {
+        CompositePartitionKey(String targetHostBaseUrl, @Nullable String virtualHost,
+                              @Nullable String proxyHost, int proxyPort, @Nullable ProxyType proxyType) {
             this.targetHostBaseUrl = targetHostBaseUrl;
             this.virtualHost = virtualHost;
             this.proxyHost = proxyHost;

--- a/client/src/main/java/org/asynchttpclient/channel/NoopChannelPool.java
+++ b/client/src/main/java/org/asynchttpclient/channel/NoopChannelPool.java
@@ -16,6 +16,7 @@
 package org.asynchttpclient.channel;
 
 import io.netty.channel.Channel;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.Map;
@@ -31,7 +32,7 @@ public enum NoopChannelPool implements ChannelPool {
     }
 
     @Override
-    public Channel poll(Object partitionKey) {
+    public @Nullable Channel poll(Object partitionKey) {
         return null;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,11 @@
             <artifactId>jakarta.activation</artifactId>
             <version>${activation.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>24.0.1</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -226,6 +231,9 @@
                             -Xep:NullablePrimitive:ERROR
                             -Xep:NullOptional:ERROR
                             -XepExcludedPaths:.*/src/test/java/.*
+                            -XepOpt:NullAway:AnnotatedPackages=org.asynchttpclient.channel
+                            -XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true
+                            -Xep:NullAway:ERROR
                         </arg>
                     </compilerArgs>
                     <annotationProcessorPaths>
@@ -233,6 +241,11 @@
                             <groupId>com.google.errorprone</groupId>
                             <artifactId>error_prone_core</artifactId>
                             <version>2.18.0</version>
+                        </path>
+                        <path>
+                            <groupId>com.uber.nullaway</groupId>
+                            <artifactId>nullaway</artifactId>
+                            <version>0.10.10</version>
                         </path>
                         <!-- Other annotation processors go here -->
                     </annotationProcessorPaths>


### PR DESCRIPTION
Adding `@Nullable` annotation to the entire project will take some time, so instead I want to make multiple PRs with one package annotated at a time.

Regarding which `@Nullable` annotation to use - there are no standard `@Nullable` annotation in Java. The closest we had to a standard implementation is JSR305, but it was never standardized and is basically dead. And there are also a bunch of other implementations: https://stackoverflow.com/q/4963300.

Ideally, I think, we should use implementation from JSpecify, since this implementation seems to be backed up by major Java players, including Oracle: https://jspecify.dev/about. But unfortunately this implementation is still in early development and is not recommended to use in libraries.

So for the time being I opted in to use implementation from JetBrains