### PR TITLE
Fixed NPE in OAuth1 implementation when one of the parameters has no value

### DIFF
--- a/client/src/main/java/org/asynchttpclient/oauth/OAuthSignatureCalculatorInstance.java
+++ b/client/src/main/java/org/asynchttpclient/oauth/OAuthSignatureCalculatorInstance.java
@@ -156,6 +156,9 @@ public class OAuthSignatureCalculatorInstance {
     }
 
     private static String percentEncodeAlreadyFormUrlEncoded(String s) {
+        if (s == null) {
+            return "";
+        }
         s = STAR_CHAR_PATTERN.matcher(s).replaceAll("%2A");
         s = PLUS_CHAR_PATTERN.matcher(s).replaceAll("%20");
         s = ENCODED_TILDE_PATTERN.matcher(s).replaceAll("~");

--- a/client/src/test/java/org/asynchttpclient/oauth/OAuthSignatureCalculatorTest.java
+++ b/client/src/test/java/org/asynchttpclient/oauth/OAuthSignatureCalculatorTest.java
@@ -20,6 +20,7 @@ import org.asynchttpclient.Param;
 import org.asynchttpclient.Request;
 import org.asynchttpclient.RequestBuilder;
 import org.asynchttpclient.util.Utf8UrlEncoder;
+import org.junit.jupiter.api.Test;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -124,6 +125,20 @@ public class OAuthSignatureCalculatorTest {
         // note: we don't know how to fix a = that should have been encoded as
         // %3D but who would be stupid enough to do that?
         Request request = post("http://example.com/request?b5=%3D%253D&a3=a&c%40=&a2=r b")
+                .addFormParam("c2", "")
+                .addFormParam("a3", "2 q")
+                .build();
+
+        testSignatureBaseString(request);
+        testSignatureBaseStringWithEncodableOAuthToken(request);
+    }
+
+    @Test
+    public void testSignatureBaseStringWithNoValueQueryParameter() throws NoSuchAlgorithmException {
+        // Query parameter with no value in OAuth1 should be treated the same as query parameter with an empty value.
+        // i.e."http://example.com/request?b5" == "http://example.com/request?b5="
+        // Tested with http://lti.tools/oauth/
+        Request request = post("http://example.com/request?b5=%3D%253D&a3=a&c%40&a2=r%20b")
                 .addFormParam("c2", "")
                 .addFormParam("a3", "2 q")
                 .build();


### PR DESCRIPTION
While enabling NullAway for root `org.asynchttpclient` package, I noticed that [DefaultRequest#getQueryParams](https://github.com/AsyncHttpClient/async-http-client/blob/main/client/src/main/java/org/asynchttpclient/DefaultRequest.java#L262) in case of query param with no value (i.e. `http://example.com/request?abc`) will create `Param` instance with the value set to `null`.

But `OAuthSignatureCalculatorInstance#encodedParams` doesn't check for null-values when calling  [percentEncodeAlreadyFormUrlEncoded()](https://github.com/AsyncHttpClient/async-http-client/blob/main/client/src/main/java/org/asynchttpclient/oauth/OAuthSignatureCalculatorInstance.java#L158-L163) resulting in `NullPointerException`.

I didn't change the way `Param` instances are created because according to [this SO answer](https://stackoverflow.com/questions/9864888/empty-uri-query-string-parameters-a-b-versus-ab) RFC 3986 doesn't specify the structure of the query string, so technically speaking `http://example.com/request?abc` and `http://example.com/request?abc=` are different URLs. 

Instead I added null-check to `percentEncodeAlreadyFormUrlEncoded()` method because RFC 5849 `The OAuth 1.0 Protocol` [says](https://datatracker.ietf.org/doc/html/rfc5849#section-3.4.1.3) that query parameters should be treated the same way as `application/x-www-form-urlencoded` parameters as defined in [HTML 4.0 Specification](https://www.w3.org/TR/1998/REC-html40-19980424/interact/forms.html#h-17.13) - a list of `name=value` pairs created from valid HTML elements (i.e. `input`, `textarea`, `select`, etc), and HTML elements `input type="text"` and `textarea` use an empty string instead of null values.

And I also tested this fix against http://lti.tools/oauth/ just in case, and both current implementation and that site produce the same result.