### PR TITLE
Extend Request to support ByteBuf inputs

### DIFF
--- a/client/src/main/java/org/asynchttpclient/DefaultRequest.java
+++ b/client/src/main/java/org/asynchttpclient/DefaultRequest.java
@@ -15,6 +15,7 @@
  */
 package org.asynchttpclient;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.resolver.NameResolver;
@@ -51,6 +52,7 @@ public class DefaultRequest implements Request {
     private final @Nullable List<byte[]> compositeByteData;
     private final @Nullable String stringData;
     private final @Nullable ByteBuffer byteBufferData;
+    private final @Nullable ByteBuf byteBufData;
     private final @Nullable InputStream streamData;
     private final @Nullable BodyGenerator bodyGenerator;
     private final List<Param> formParams;
@@ -79,6 +81,7 @@ public class DefaultRequest implements Request {
                           @Nullable List<byte[]> compositeByteData,
                           @Nullable String stringData,
                           @Nullable ByteBuffer byteBufferData,
+                          @Nullable ByteBuf byteBufData,
                           @Nullable InputStream streamData,
                           @Nullable BodyGenerator bodyGenerator,
                           List<Param> formParams,
@@ -104,6 +107,7 @@ public class DefaultRequest implements Request {
         this.compositeByteData = compositeByteData;
         this.stringData = stringData;
         this.byteBufferData = byteBufferData;
+        this.byteBufData = byteBufData;
         this.streamData = streamData;
         this.bodyGenerator = bodyGenerator;
         this.formParams = formParams;
@@ -174,6 +178,11 @@ public class DefaultRequest implements Request {
     @Override
     public @Nullable ByteBuffer getByteBufferData() {
         return byteBufferData;
+    }
+
+    @Override
+    public @Nullable ByteBuf getByteBufData() {
+        return byteBufData;
     }
 
     @Override

--- a/client/src/main/java/org/asynchttpclient/Request.java
+++ b/client/src/main/java/org/asynchttpclient/Request.java
@@ -16,6 +16,7 @@
  */
 package org.asynchttpclient;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.resolver.NameResolver;
@@ -102,6 +103,11 @@ public interface Request {
      * @return the request's body ByteBuffer (only non-null if it was set this way)
      */
     @Nullable ByteBuffer getByteBufferData();
+
+    /**
+     * @return the request's body ByteBuf (only non-null if it was set this way)
+     */
+    @Nullable ByteBuf getByteBufData();
 
     /**
      * @return the request's body InputStream (only non-null if it was set this way)

--- a/client/src/main/java/org/asynchttpclient/RequestBuilderBase.java
+++ b/client/src/main/java/org/asynchttpclient/RequestBuilderBase.java
@@ -15,6 +15,7 @@
  */
 package org.asynchttpclient;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.cookie.Cookie;
@@ -76,6 +77,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
     protected @Nullable List<byte[]> compositeByteData;
     protected @Nullable String stringData;
     protected @Nullable ByteBuffer byteBufferData;
+    protected @Nullable ByteBuf byteBufData;
     protected @Nullable InputStream streamData;
     protected @Nullable BodyGenerator bodyGenerator;
     protected @Nullable List<Param> formParams;
@@ -121,6 +123,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
         compositeByteData = prototype.getCompositeByteData();
         stringData = prototype.getStringData();
         byteBufferData = prototype.getByteBufferData();
+        byteBufData = prototype.getByteBufData();
         streamData = prototype.getStreamData();
         bodyGenerator = prototype.getBodyGenerator();
         if (isNonEmpty(prototype.getFormParams())) {
@@ -361,6 +364,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
         byteData = null;
         compositeByteData = null;
         byteBufferData = null;
+        byteBufData = null;
         stringData = null;
         streamData = null;
         bodyGenerator = null;
@@ -402,6 +406,12 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
     public T setBody(ByteBuffer data) {
         resetBody();
         byteBufferData = data;
+        return asDerivedType();
+    }
+
+    public T setBody(ByteBuf data) {
+        resetBody();
+        byteBufData = data;
         return asDerivedType();
     }
 
@@ -586,6 +596,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
         rb.compositeByteData = compositeByteData;
         rb.stringData = stringData;
         rb.byteBufferData = byteBufferData;
+        rb.byteBufData = byteBufData;
         rb.streamData = streamData;
         rb.bodyGenerator = bodyGenerator;
         rb.virtualHost = virtualHost;
@@ -647,6 +658,7 @@ public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
                 rb.compositeByteData,
                 rb.stringData,
                 rb.byteBufferData,
+                rb.byteBufData,
                 rb.streamData,
                 rb.bodyGenerator,
                 formParamsCopy,

--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestFactory.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestFactory.java
@@ -32,6 +32,7 @@ import org.asynchttpclient.Request;
 import org.asynchttpclient.netty.request.body.NettyBody;
 import org.asynchttpclient.netty.request.body.NettyBodyBody;
 import org.asynchttpclient.netty.request.body.NettyByteArrayBody;
+import org.asynchttpclient.netty.request.body.NettyByteBufBody;
 import org.asynchttpclient.netty.request.body.NettyByteBufferBody;
 import org.asynchttpclient.netty.request.body.NettyCompositeByteArrayBody;
 import org.asynchttpclient.netty.request.body.NettyDirectBody;
@@ -96,6 +97,8 @@ public final class NettyRequestFactory {
             nettyBody = new NettyByteBufferBody(StringUtils.charSequence2ByteBuffer(request.getStringData(), bodyCharset));
         } else if (request.getByteBufferData() != null) {
             nettyBody = new NettyByteBufferBody(request.getByteBufferData());
+        } else if (request.getByteBufData() != null) {
+            nettyBody = new NettyByteBufBody(request.getByteBufData());
         } else if (request.getStreamData() != null) {
             nettyBody = new NettyInputStreamBody(request.getStreamData());
         } else if (isNonEmpty(request.getFormParams())) {

--- a/client/src/main/java/org/asynchttpclient/netty/request/body/NettyByteBufBody.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/body/NettyByteBufBody.java
@@ -1,0 +1,50 @@
+/*
+ *    Copyright (c) 2015-2023 AsyncHttpClient Project. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.asynchttpclient.netty.request.body;
+
+import io.netty.buffer.ByteBuf;
+
+public class NettyByteBufBody extends NettyDirectBody {
+
+    private final ByteBuf bb;
+    private final CharSequence contentTypeOverride;
+    private final long length;
+
+    public NettyByteBufBody(ByteBuf bb) {
+        this(bb, null);
+    }
+
+    public NettyByteBufBody(ByteBuf bb, CharSequence contentTypeOverride) {
+        this.bb = bb;
+        length = bb.readableBytes();
+        this.contentTypeOverride = contentTypeOverride;
+    }
+
+    @Override
+    public long getContentLength() {
+        return length;
+    }
+
+    @Override
+    public CharSequence getContentTypeOverride() {
+        return contentTypeOverride;
+    }
+
+    @Override
+    public ByteBuf byteBuf() {
+        return bb;
+    }
+}

--- a/client/src/test/java/org/asynchttpclient/request/body/PutByteBufTest.java
+++ b/client/src/test/java/org/asynchttpclient/request/body/PutByteBufTest.java
@@ -15,7 +15,6 @@ package org.asynchttpclient.request.body;
 import io.github.artsok.RepeatedIfExceptionsTest;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.asynchttpclient.AbstractBasicTest;
@@ -24,10 +23,10 @@ import org.asynchttpclient.Response;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 
-import java.io.*;
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.time.Duration;
-import java.util.Random;
+import java.util.Arrays;
 
 import static org.asynchttpclient.Dsl.asyncHttpClient;
 import static org.asynchttpclient.Dsl.config;
@@ -51,8 +50,8 @@ public class PutByteBufTest extends AbstractBasicTest {
 
     @RepeatedIfExceptionsTest(repeats = 5)
     public void testPutBigBody() throws Exception {
-        byte[] array = new byte[2048]; // length is bounded by 7
-        new Random().nextBytes(array);
+        byte[] array = new byte[2048];
+        Arrays.fill(array, (byte) 97);
         String longString = new String(array, Charset.forName("UTF-8"));
 
         put(longString);
@@ -63,7 +62,7 @@ public class PutByteBufTest extends AbstractBasicTest {
         return new AbstractHandler() {
 
             @Override
-            public void handle(String s, Request request, HttpServletRequest httpRequest, HttpServletResponse response) throws IOException, ServletException {
+            public void handle(String s, Request request, HttpServletRequest httpRequest, HttpServletResponse response) throws IOException {
                 int size = 1024;
                 if (request.getContentLength() > 0) {
                     size = request.getContentLength();

--- a/client/src/test/java/org/asynchttpclient/request/body/PutByteBufTest.java
+++ b/client/src/test/java/org/asynchttpclient/request/body/PutByteBufTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2010-2012 Sonatype, Inc. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.asynchttpclient.request.body;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.asynchttpclient.AbstractBasicTest;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.Response;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+
+import java.io.*;
+import java.nio.charset.Charset;
+import java.time.Duration;
+import java.util.Random;
+
+import static org.asynchttpclient.Dsl.asyncHttpClient;
+import static org.asynchttpclient.Dsl.config;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PutByteBufTest extends AbstractBasicTest {
+
+    private void put(String message) throws Exception {
+        ByteBuf byteBuf = Unpooled.wrappedBuffer(message.getBytes());
+        try (AsyncHttpClient client = asyncHttpClient(config().setRequestTimeout(Duration.ofSeconds(2)))) {
+            Response response = client.preparePut(getTargetUrl()).setBody(byteBuf).execute().get();
+            assertEquals(response.getStatusCode(), 200);
+            assertEquals(response.getResponseBody(), message);
+        }
+    }
+
+    @RepeatedIfExceptionsTest(repeats = 5)
+    public void testPutSmallBody() throws Exception {
+        put("Hello Test");
+    }
+
+    @RepeatedIfExceptionsTest(repeats = 5)
+    public void testPutBigBody() throws Exception {
+        byte[] array = new byte[2048]; // length is bounded by 7
+        new Random().nextBytes(array);
+        String longString = new String(array, Charset.forName("UTF-8"));
+
+        put(longString);
+    }
+
+    @Override
+    public AbstractHandler configureHandler() throws Exception {
+        return new AbstractHandler() {
+
+            @Override
+            public void handle(String s, Request request, HttpServletRequest httpRequest, HttpServletResponse response) throws IOException, ServletException {
+                int size = 1024;
+                if (request.getContentLength() > 0) {
+                    size = request.getContentLength();
+                }
+                byte[] bytes = new byte[size];
+                if (bytes.length > 0) {
+                    final int read = request.getInputStream().read(bytes);
+                    response.getOutputStream().write(bytes, 0, read);
+                }
+
+                response.setStatus(200);
+                response.getOutputStream().flush();
+            }
+        };
+    }
+}


### PR DESCRIPTION
This extends RequestBuilderBase+Request+NettyRequestFactory to allow providing a Netty ByteBuf as input in an efficient manner, avoiding having to convert that ByteBuf to a ByteBuffer and then back.

Fixes #1951