### PR TITLE
Extend Response to support returning ByteBufs

### DIFF
--- a/client/src/main/java/org/asynchttpclient/HttpResponseBodyPart.java
+++ b/client/src/main/java/org/asynchttpclient/HttpResponseBodyPart.java
@@ -15,6 +15,7 @@
  */
 package org.asynchttpclient;
 
+import io.netty.buffer.ByteBuf;
 import java.nio.ByteBuffer;
 
 /**
@@ -43,6 +44,12 @@ public abstract class HttpResponseBodyPart {
      * The {@link ByteBuffer}'s capacity is equal to the number of bytes available.
      */
     public abstract ByteBuffer getBodyByteBuffer();
+
+    /**
+     * @return the {@link ByteBuf} of the bytes read from the response's chunk.
+     * The {@link ByteBuf}'s capacity is equal to the number of bytes available.
+     */
+    public abstract ByteBuf getBodyByteBuf();
 
     /**
      * @return true if this is the last part.

--- a/client/src/main/java/org/asynchttpclient/Response.java
+++ b/client/src/main/java/org/asynchttpclient/Response.java
@@ -16,6 +16,7 @@
  */
 package org.asynchttpclient;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.cookie.Cookie;
 import org.asynchttpclient.netty.NettyResponse;
@@ -60,6 +61,13 @@ public interface Response {
      * @return the entire response body as a ByteBuffer.
      */
     ByteBuffer getResponseBodyAsByteBuffer();
+
+    /**
+     * Return the entire response body as a ByteBuf.
+     *
+     * @return the entire response body as a ByteBuf.
+     */
+    ByteBuf getResponseBodyAsByteBuf();
 
     /**
      * Returns an input stream for the response body. Note that you should not try to get this more than once, and that you should not close the stream.

--- a/client/src/main/java/org/asynchttpclient/netty/EagerResponseBodyPart.java
+++ b/client/src/main/java/org/asynchttpclient/netty/EagerResponseBodyPart.java
@@ -17,6 +17,7 @@ package org.asynchttpclient.netty;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
 import org.asynchttpclient.HttpResponseBodyPart;
 
 import java.nio.ByteBuffer;
@@ -52,5 +53,10 @@ public class EagerResponseBodyPart extends HttpResponseBodyPart {
     @Override
     public ByteBuffer getBodyByteBuffer() {
         return ByteBuffer.wrap(bytes);
+    }
+
+    @Override
+    public ByteBuf getBodyByteBuf() {
+        return Unpooled.wrappedBuffer(bytes);
     }
 }

--- a/client/src/main/java/org/asynchttpclient/netty/LazyResponseBodyPart.java
+++ b/client/src/main/java/org/asynchttpclient/netty/LazyResponseBodyPart.java
@@ -33,7 +33,8 @@ public class LazyResponseBodyPart extends HttpResponseBodyPart {
         this.buf = buf;
     }
 
-    public ByteBuf getBuf() {
+    @Override
+    public ByteBuf getBodyByteBuf() {
         return buf;
     }
 

--- a/client/src/main/java/org/asynchttpclient/netty/NettyResponse.java
+++ b/client/src/main/java/org/asynchttpclient/netty/NettyResponse.java
@@ -15,6 +15,9 @@
  */
 package org.asynchttpclient.netty;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.cookie.ClientCookieDecoder;
@@ -190,6 +193,15 @@ public class NettyResponse implements Response {
 
         target.flip();
         return target;
+    }
+
+    @Override
+    public ByteBuf getResponseBodyAsByteBuf() {
+        CompositeByteBuf compositeByteBuf = ByteBufAllocator.DEFAULT.compositeBuffer(bodyParts.size());
+        for (HttpResponseBodyPart part : bodyParts) {
+            compositeByteBuf.addComponent(true, part.getBodyByteBuf());
+        }
+        return compositeByteBuf;
     }
 
     @Override

--- a/client/src/test/java/org/asynchttpclient/netty/NettyAsyncResponseTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/NettyAsyncResponseTest.java
@@ -13,15 +13,16 @@
 package org.asynchttpclient.netty;
 
 import io.github.artsok.RepeatedIfExceptionsTest;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.cookie.Cookie;
+import org.asynchttpclient.HttpResponseBodyPart;
 
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.TimeZone;
+import java.util.*;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.SET_COOKIE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -72,5 +73,17 @@ public class NettyAsyncResponseTest {
 
         Cookie cookie = cookies.get(0);
         assertEquals(Long.MIN_VALUE, cookie.maxAge());
+    }
+
+    @RepeatedIfExceptionsTest(repeats = 5)
+    public void testGetResponseBodyAsByteBuffer() {
+        List<HttpResponseBodyPart> bodyParts = new LinkedList<>();
+        bodyParts.add(new LazyResponseBodyPart(Unpooled.wrappedBuffer("Hello ".getBytes()), false));
+        bodyParts.add(new LazyResponseBodyPart(Unpooled.wrappedBuffer("World".getBytes()), true));
+        NettyResponse response = new NettyResponse(new NettyResponseStatus(null, null, null), null, bodyParts);
+
+        ByteBuf body = response.getResponseBodyAsByteBuf();
+        assertEquals("Hello World", body.toString(StandardCharsets.UTF_8));
+        body.release();
     }
 }


### PR DESCRIPTION
NettyResponse is already dealing with ByteBufs under the hood, this lets the caller access them cleanly. This allows callers that are already using Netty to use AHC much more efficiently.

Fixes #1953