### PR TITLE
Fix NPE race in NettyResponseFuture.cancel (#2042)

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/NettyResponseFuture.java
+++ b/client/src/main/java/org/asynchttpclient/netty/NettyResponseFuture.java
@@ -187,7 +187,7 @@ public final class NettyResponseFuture<V> implements ListenableFuture<V> {
             return false;
         }
 
-        Channel ch = channel; //atomic read, so that it won't end up in TOCTOU
+        final Channel ch = channel; //atomic read, so that it won't end up in TOCTOU
         if (ch != null) {
             Channels.setDiscard(ch);
             Channels.silentlyCloseChannel(ch);

--- a/client/src/main/java/org/asynchttpclient/netty/NettyResponseFuture.java
+++ b/client/src/main/java/org/asynchttpclient/netty/NettyResponseFuture.java
@@ -187,10 +187,10 @@ public final class NettyResponseFuture<V> implements ListenableFuture<V> {
             return false;
         }
 
-        // cancel could happen before channel was attached
-        if (channel != null) {
-            Channels.setDiscard(channel);
-            Channels.silentlyCloseChannel(channel);
+        Channel ch = channel; //atomic read, so that it won't end up in TOCTOU
+        if (ch != null) {
+            Channels.setDiscard(ch);
+            Channels.silentlyCloseChannel(ch);
         }
 
         if (ON_THROWABLE_CALLED_FIELD.getAndSet(this, 1) == 0) {


### PR DESCRIPTION
Fixes #2042 

This is a typical TOCTOU (time-of-check/time-of-use) race https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use. 
The NPE was occurring because the channel field could be set to null by another thread between the check and its use:

if (channel != null) {                 // time-of-check
    Channels.setDiscard(channel);      //  time-of-use
    Channels.silentlyCloseChannel(channel);
}

By copying channel into a local variable in one atomic read, we ensure that—even if another thread changes the field—the local reference remains valid.

P.S. It is hard to write a deterministic test that fails consistently, so this PR only includes the code fix.