### PR TITLE
Harmonize and enhance Javadoc comments across entire codebase

### DIFF
--- a/client/src/main/java/org/asynchttpclient/AsyncCompletionHandlerBase.java
+++ b/client/src/main/java/org/asynchttpclient/AsyncCompletionHandlerBase.java
@@ -18,11 +18,31 @@ package org.asynchttpclient;
 
 
 /**
- * Simple {@link AsyncHandler} of type {@link Response}
+ * A simple {@link AsyncCompletionHandler} implementation that returns the complete {@link Response}.
+ * <p>
+ * This is the simplest way to execute an HTTP request and get the complete response back.
+ * The response body will be fully buffered in memory.
+ * </p>
+ * <p><b>Usage Example:</b></p>
+ * <pre>{@code
+ * AsyncHttpClient client = Dsl.asyncHttpClient();
+ * Future<Response> future = client.prepareGet("http://example.com")
+ *     .execute(new AsyncCompletionHandlerBase());
+ * Response response = future.get();
+ * System.out.println(response.getResponseBody());
+ * }</pre>
+ * <p>
+ * Note: You can also use {@link AsyncHttpClient#executeRequest(Request)} directly,
+ * which uses this handler internally.
+ * </p>
  */
 public class AsyncCompletionHandlerBase extends AsyncCompletionHandler<Response> {
   /**
-   * {@inheritDoc}
+   * Returns the complete response as-is.
+   *
+   * @param response the fully assembled HTTP response
+   * @return the same response object
+   * @throws Exception if an error occurs during processing
    */
   @Override
   public Response onCompleted(Response response) throws Exception {

--- a/client/src/main/java/org/asynchttpclient/AsyncHttpClient.java
+++ b/client/src/main/java/org/asynchttpclient/AsyncHttpClient.java
@@ -131,172 +131,184 @@ import java.util.function.Predicate;
 public interface AsyncHttpClient extends Closeable {
 
   /**
-   * Return true if closed
+   * Checks if this client has been closed.
    *
-   * @return true if closed
+   * @return true if the client has been closed, false otherwise
    */
   boolean isClosed();
 
   /**
-   * Set default signature calculator to use for requests built by this client instance
+   * Sets the default signature calculator to use for all requests built by this client instance.
+   * The signature calculator is used to sign requests for authentication purposes.
    *
-   * @param signatureCalculator a signature calculator
-   * @return {@link RequestBuilder}
+   * @param signatureCalculator the signature calculator to use for request signing
+   * @return this AsyncHttpClient instance for method chaining
    */
   AsyncHttpClient setSignatureCalculator(SignatureCalculator signatureCalculator);
 
   /**
-   * Prepare an HTTP client request.
+   * Prepares an HTTP request with the specified method and URL.
    *
-   * @param method HTTP request method type. MUST BE in upper case
-   * @param url A well formed URL.
-   * @return {@link RequestBuilder}
+   * @param method the HTTP request method (e.g., "GET", "POST"). MUST be in uppercase
+   * @param url a well-formed URL string
+   * @return a {@link BoundRequestBuilder} for configuring and executing the request
    */
   BoundRequestBuilder prepare(String method, String url);
 
 
   /**
-   * Prepare an HTTP client GET request.
+   * Prepares an HTTP GET request for the specified URL.
    *
-   * @param url A well formed URL.
-   * @return {@link RequestBuilder}
+   * @param url a well-formed URL string
+   * @return a {@link BoundRequestBuilder} for configuring and executing the request
    */
   BoundRequestBuilder prepareGet(String url);
 
   /**
-   * Prepare an HTTP client CONNECT request.
+   * Prepares an HTTP CONNECT request for the specified URL.
    *
-   * @param url A well formed URL.
-   * @return {@link RequestBuilder}
+   * @param url a well-formed URL string
+   * @return a {@link BoundRequestBuilder} for configuring and executing the request
    */
   BoundRequestBuilder prepareConnect(String url);
 
   /**
-   * Prepare an HTTP client OPTIONS request.
+   * Prepares an HTTP OPTIONS request for the specified URL.
    *
-   * @param url A well formed URL.
-   * @return {@link RequestBuilder}
+   * @param url a well-formed URL string
+   * @return a {@link BoundRequestBuilder} for configuring and executing the request
    */
   BoundRequestBuilder prepareOptions(String url);
 
   /**
-   * Prepare an HTTP client HEAD request.
+   * Prepares an HTTP HEAD request for the specified URL.
    *
-   * @param url A well formed URL.
-   * @return {@link RequestBuilder}
+   * @param url a well-formed URL string
+   * @return a {@link BoundRequestBuilder} for configuring and executing the request
    */
   BoundRequestBuilder prepareHead(String url);
 
   /**
-   * Prepare an HTTP client POST request.
+   * Prepares an HTTP POST request for the specified URL.
    *
-   * @param url A well formed URL.
-   * @return {@link RequestBuilder}
+   * @param url a well-formed URL string
+   * @return a {@link BoundRequestBuilder} for configuring and executing the request
    */
   BoundRequestBuilder preparePost(String url);
 
   /**
-   * Prepare an HTTP client PUT request.
+   * Prepares an HTTP PUT request for the specified URL.
    *
-   * @param url A well formed URL.
-   * @return {@link RequestBuilder}
+   * @param url a well-formed URL string
+   * @return a {@link BoundRequestBuilder} for configuring and executing the request
    */
   BoundRequestBuilder preparePut(String url);
 
   /**
-   * Prepare an HTTP client DELETE request.
+   * Prepares an HTTP DELETE request for the specified URL.
    *
-   * @param url A well formed URL.
-   * @return {@link RequestBuilder}
+   * @param url a well-formed URL string
+   * @return a {@link BoundRequestBuilder} for configuring and executing the request
    */
   BoundRequestBuilder prepareDelete(String url);
 
   /**
-   * Prepare an HTTP client PATCH request.
+   * Prepares an HTTP PATCH request for the specified URL.
    *
-   * @param url A well formed URL.
-   * @return {@link RequestBuilder}
+   * @param url a well-formed URL string
+   * @return a {@link BoundRequestBuilder} for configuring and executing the request
    */
   BoundRequestBuilder preparePatch(String url);
 
   /**
-   * Prepare an HTTP client TRACE request.
+   * Prepares an HTTP TRACE request for the specified URL.
    *
-   * @param url A well formed URL.
-   * @return {@link RequestBuilder}
+   * @param url a well-formed URL string
+   * @return a {@link BoundRequestBuilder} for configuring and executing the request
    */
   BoundRequestBuilder prepareTrace(String url);
 
   /**
-   * Construct a {@link RequestBuilder} using a {@link Request}
+   * Prepares a request using an existing {@link Request} instance as a template.
+   * This allows modification of an existing request before execution.
    *
-   * @param request a {@link Request}
-   * @return {@link RequestBuilder}
+   * @param request the request to use as a template
+   * @return a {@link BoundRequestBuilder} for further configuring and executing the request
    */
   BoundRequestBuilder prepareRequest(Request request);
 
   /**
-   * Construct a {@link RequestBuilder} using a {@link RequestBuilder}
+   * Prepares a request using an existing {@link RequestBuilder} instance.
+   * This allows binding a request builder to this client for execution.
    *
-   * @param requestBuilder a {@link RequestBuilder}
-   * @return {@link RequestBuilder}
+   * @param requestBuilder the request builder containing the request configuration
+   * @return a {@link BoundRequestBuilder} for further configuring and executing the request
    */
   BoundRequestBuilder prepareRequest(RequestBuilder requestBuilder);
 
   /**
-   * Execute an HTTP request.
+   * Executes an HTTP request asynchronously with a custom response handler.
+   * The handler processes the response as it arrives (status, headers, body parts).
    *
-   * @param request {@link Request}
-   * @param handler an instance of {@link AsyncHandler}
-   * @param <T>     Type of the value that will be returned by the associated {@link java.util.concurrent.Future}
-   * @return a {@link Future} of type T
+   * @param request the HTTP request to execute
+   * @param handler the async handler to process the response
+   * @param <T>     the type of value returned by the handler's onCompleted method
+   * @return a {@link ListenableFuture} that will contain the result of type T
    */
   <T> ListenableFuture<T> executeRequest(Request request, AsyncHandler<T> handler);
 
   /**
-   * Execute an HTTP request.
+   * Executes an HTTP request asynchronously with a custom response handler.
+   * The request is built from the provided RequestBuilder before execution.
    *
-   * @param requestBuilder {@link RequestBuilder}
-   * @param handler        an instance of {@link AsyncHandler}
-   * @param <T>            Type of the value that will be returned by the associated {@link java.util.concurrent.Future}
-   * @return a {@link Future} of type T
+   * @param requestBuilder the request builder containing the request configuration
+   * @param handler        the async handler to process the response
+   * @param <T>            the type of value returned by the handler's onCompleted method
+   * @return a {@link ListenableFuture} that will contain the result of type T
    */
   <T> ListenableFuture<T> executeRequest(RequestBuilder requestBuilder, AsyncHandler<T> handler);
 
   /**
-   * Execute an HTTP request.
+   * Executes an HTTP request asynchronously and returns the complete response.
+   * The entire response body will be buffered in memory.
    *
-   * @param request {@link Request}
-   * @return a {@link Future} of type Response
+   * @param request the HTTP request to execute
+   * @return a {@link ListenableFuture} containing the complete {@link Response}
    */
   ListenableFuture<Response> executeRequest(Request request);
 
   /**
-   * Execute an HTTP request.
+   * Executes an HTTP request asynchronously and returns the complete response.
+   * The request is built from the provided RequestBuilder before execution.
+   * The entire response body will be buffered in memory.
    *
-   * @param requestBuilder {@link RequestBuilder}
-   * @return a {@link Future} of type Response
+   * @param requestBuilder the request builder containing the request configuration
+   * @return a {@link ListenableFuture} containing the complete {@link Response}
    */
   ListenableFuture<Response> executeRequest(RequestBuilder requestBuilder);
 
-  /***
-   * Return details about pooled connections.
+  /**
+   * Returns statistics about the pooled connections managed by this client.
+   * This includes information about open connections, idle connections, and connection counts.
    *
-   * @return a {@link ClientStats}
+   * @return a {@link ClientStats} object containing connection pool statistics
    */
   ClientStats getClientStats();
 
   /**
-   * Flush ChannelPool partitions based on a predicate
+   * Flushes (removes) channel pool partitions that match the given predicate.
+   * This is useful for selectively clearing connections based on custom criteria.
    *
-   * @param predicate the predicate
+   * @param predicate the predicate to test each partition key; partitions matching will be flushed
    */
   void flushChannelPoolPartitions(Predicate<Object> predicate);
 
   /**
-   * Return the config associated to this client.
+   * Returns the configuration associated with this client.
+   * The configuration contains settings such as timeouts, connection pool parameters,
+   * and other behavioral options.
    *
-   * @return the config associated to this client.
+   * @return the {@link AsyncHttpClientConfig} used by this client
    */
   AsyncHttpClientConfig getConfig();
 }

--- a/client/src/main/java/org/asynchttpclient/AsyncHttpClientConfig.java
+++ b/client/src/main/java/org/asynchttpclient/AsyncHttpClientConfig.java
@@ -235,120 +235,341 @@ public interface AsyncHttpClientConfig {
    */
   int getConnectionTtl();
 
+  /**
+   * Returns whether OpenSSL should be used instead of the JDK SSL implementation.
+   * OpenSSL can provide better performance in some scenarios.
+   *
+   * @return {@code true} if OpenSSL should be used, {@code false} to use JDK SSL
+   */
   boolean isUseOpenSsl();
 
+  /**
+   * Returns whether to use an insecure trust manager that accepts all certificates.
+   * This should only be used for testing purposes and never in production.
+   *
+   * @return {@code true} if insecure trust manager is enabled, {@code false} otherwise
+   */
   boolean isUseInsecureTrustManager();
 
   /**
-   * @return true to disable all HTTPS behaviors AT ONCE, such as hostname verification and SNI
+   * Returns whether to disable HTTPS endpoint identification algorithm.
+   * When enabled, this disables hostname verification and SNI.
+   * This should only be used for testing and never in production.
+   *
+   * @return {@code true} to disable all HTTPS endpoint identification, {@code false} otherwise
    */
   boolean isDisableHttpsEndpointIdentificationAlgorithm();
 
   /**
-   * @return the array of enabled protocols
+   * Returns the array of enabled SSL/TLS protocols.
+   *
+   * @return the array of enabled protocols, or {@code null} to use defaults
    */
   String[] getEnabledProtocols();
 
   /**
-   * @return the array of enabled cipher suites
+   * Returns the array of enabled cipher suites for SSL/TLS connections.
+   *
+   * @return the array of enabled cipher suites, or {@code null} to use defaults
    */
   String[] getEnabledCipherSuites();
 
   /**
-   * @return if insecure cipher suites must be filtered out (only used when not explicitly passing enabled cipher suites)
+   * Returns whether insecure cipher suites should be filtered out.
+   * This is only used when enabled cipher suites are not explicitly set.
+   *
+   * @return {@code true} if insecure cipher suites must be filtered out, {@code false} otherwise
    */
   boolean isFilterInsecureCipherSuites();
 
   /**
-   * @return the size of the SSL session cache, 0 means using the default value
+   * Returns the size of the SSL session cache.
+   *
+   * @return the size of the SSL session cache, or 0 to use the default value
    */
   int getSslSessionCacheSize();
 
   /**
-   * @return the SSL session timeout in seconds, 0 means using the default value
+   * Returns the SSL session timeout in seconds.
+   *
+   * @return the SSL session timeout in seconds, or 0 to use the default value
    */
   int getSslSessionTimeout();
 
+  /**
+   * Returns the maximum length of the initial line in the HTTP codec.
+   *
+   * @return the maximum initial line length in bytes
+   */
   int getHttpClientCodecMaxInitialLineLength();
 
+  /**
+   * Returns the maximum size of HTTP headers in the HTTP codec.
+   *
+   * @return the maximum header size in bytes
+   */
   int getHttpClientCodecMaxHeaderSize();
 
+  /**
+   * Returns the maximum size of HTTP chunks in the HTTP codec.
+   *
+   * @return the maximum chunk size in bytes
+   */
   int getHttpClientCodecMaxChunkSize();
 
+  /**
+   * Returns the initial buffer size for the HTTP codec.
+   *
+   * @return the initial buffer size in bytes
+   */
   int getHttpClientCodecInitialBufferSize();
 
+  /**
+   * Returns whether zero-copy file transfer is disabled.
+   * Zero-copy can improve performance but may not work in all scenarios.
+   *
+   * @return {@code true} if zero-copy is disabled, {@code false} if enabled
+   */
   boolean isDisableZeroCopy();
 
+  /**
+   * Returns the SSL/TLS handshake timeout in milliseconds.
+   *
+   * @return the handshake timeout in milliseconds
+   */
   int getHandshakeTimeout();
 
+  /**
+   * Returns the factory for creating SSL engines.
+   *
+   * @return the {@link SslEngineFactory}, or {@code null} if not configured
+   */
   SslEngineFactory getSslEngineFactory();
 
+  /**
+   * Returns the chunk size for chunked file uploads.
+   *
+   * @return the chunk size in bytes
+   */
   int getChunkedFileChunkSize();
 
+  /**
+   * Returns the maximum buffer size for WebSocket connections.
+   *
+   * @return the maximum WebSocket buffer size in bytes
+   */
   int getWebSocketMaxBufferSize();
 
+  /**
+   * Returns the maximum frame size for WebSocket connections.
+   *
+   * @return the maximum WebSocket frame size in bytes
+   */
   int getWebSocketMaxFrameSize();
 
+  /**
+   * Returns whether the encoding header should be kept when compression is enabled.
+   *
+   * @return {@code true} if encoding header should be kept, {@code false} otherwise
+   */
   boolean isKeepEncodingHeader();
 
+  /**
+   * Returns the quiet period for graceful shutdown in milliseconds.
+   * During the quiet period, no new tasks will be accepted.
+   *
+   * @return the shutdown quiet period in milliseconds
+   */
   int getShutdownQuietPeriod();
 
+  /**
+   * Returns the maximum time to wait for shutdown to complete in milliseconds.
+   *
+   * @return the shutdown timeout in milliseconds
+   */
   int getShutdownTimeout();
 
+  /**
+   * Returns the Netty channel options to be applied to all channels.
+   *
+   * @return a map of channel options and their values
+   */
   Map<ChannelOption<Object>, Object> getChannelOptions();
 
+  /**
+   * Returns the Netty event loop group to be used.
+   * If {@code null}, a default event loop group will be created.
+   *
+   * @return the {@link EventLoopGroup}, or {@code null} to use default
+   */
   EventLoopGroup getEventLoopGroup();
 
+  /**
+   * Returns whether native transport should be used when available.
+   * Native transports can provide better performance on supported platforms.
+   *
+   * @return {@code true} to use native transport, {@code false} to use NIO
+   */
   boolean isUseNativeTransport();
 
+  /**
+   * Returns the additional channel initializer for HTTP channels.
+   *
+   * @return the channel initializer consumer, or {@code null} if not configured
+   */
   Consumer<Channel> getHttpAdditionalChannelInitializer();
 
+  /**
+   * Returns the additional channel initializer for WebSocket channels.
+   *
+   * @return the channel initializer consumer, or {@code null} if not configured
+   */
   Consumer<Channel> getWsAdditionalChannelInitializer();
 
+  /**
+   * Returns the factory for creating response body part objects.
+   *
+   * @return the {@link ResponseBodyPartFactory}
+   */
   ResponseBodyPartFactory getResponseBodyPartFactory();
 
+  /**
+   * Returns the custom channel pool implementation.
+   *
+   * @return the {@link ChannelPool}, or {@code null} to use default
+   */
   ChannelPool getChannelPool();
 
+  /**
+   * Returns the factory for creating connection semaphores.
+   *
+   * @return the {@link ConnectionSemaphoreFactory}, or {@code null} if not configured
+   */
   ConnectionSemaphoreFactory getConnectionSemaphoreFactory();
 
+  /**
+   * Returns the Netty timer to be used for timeouts.
+   *
+   * @return the {@link Timer}, or {@code null} to create a default timer
+   */
   Timer getNettyTimer();
 
   /**
-   * @return the duration between tick of {@link io.netty.util.HashedWheelTimer}
+   * Returns the duration between ticks of the hashed wheel timer in milliseconds.
+   * The hashed wheel timer is used for managing timeouts efficiently.
+   *
+   * @return the duration between ticks of {@link io.netty.util.HashedWheelTimer} in milliseconds
    */
   long getHashedWheelTimerTickDuration();
 
   /**
+   * Returns the size of the hashed wheel timer.
+   * A larger size can handle more concurrent timeouts but uses more memory.
+   *
    * @return the size of the hashed wheel {@link io.netty.util.HashedWheelTimer}
    */
   int getHashedWheelTimerSize();
 
+  /**
+   * Returns the strategy for determining whether connections should be kept alive.
+   *
+   * @return the {@link KeepAliveStrategy}
+   */
   KeepAliveStrategy getKeepAliveStrategy();
 
+  /**
+   * Returns whether response headers should be validated for correctness.
+   *
+   * @return {@code true} if response headers should be validated, {@code false} otherwise
+   */
   boolean isValidateResponseHeaders();
 
+  /**
+   * Returns whether WebSocket frame fragments should be aggregated.
+   *
+   * @return {@code true} if fragments should be aggregated, {@code false} otherwise
+   */
   boolean isAggregateWebSocketFrameFragments();
 
+  /**
+   * Returns whether WebSocket compression extension is enabled.
+   *
+   * @return {@code true} if WebSocket compression is enabled, {@code false} otherwise
+   */
   boolean isEnableWebSocketCompression();
 
+  /**
+   * Returns whether TCP_NODELAY socket option is enabled.
+   * When enabled, small packets are sent immediately without buffering (Nagle's algorithm disabled).
+   *
+   * @return {@code true} if TCP_NODELAY is enabled, {@code false} otherwise
+   */
   boolean isTcpNoDelay();
 
+  /**
+   * Returns whether SO_REUSEADDR socket option is enabled.
+   * When enabled, allows reusing local addresses and ports.
+   *
+   * @return {@code true} if SO_REUSEADDR is enabled, {@code false} otherwise
+   */
   boolean isSoReuseAddress();
 
+  /**
+   * Returns whether SO_KEEPALIVE socket option is enabled.
+   * When enabled, TCP keepalive probes are sent to detect dead connections.
+   *
+   * @return {@code true} if SO_KEEPALIVE is enabled, {@code false} otherwise
+   */
   boolean isSoKeepAlive();
 
+  /**
+   * Returns the SO_LINGER socket option value in seconds.
+   * Controls the behavior when closing a socket with unsent data.
+   *
+   * @return the SO_LINGER value in seconds, or -1 if disabled
+   */
   int getSoLinger();
 
+  /**
+   * Returns the SO_SNDBUF socket option value.
+   * Specifies the size of the TCP send buffer.
+   *
+   * @return the send buffer size in bytes, or -1 to use system default
+   */
   int getSoSndBuf();
 
+  /**
+   * Returns the SO_RCVBUF socket option value.
+   * Specifies the size of the TCP receive buffer.
+   *
+   * @return the receive buffer size in bytes, or -1 to use system default
+   */
   int getSoRcvBuf();
 
+  /**
+   * Returns the Netty ByteBuf allocator to use for buffer allocation.
+   *
+   * @return the {@link ByteBufAllocator}, or {@code null} to use default
+   */
   ByteBufAllocator getAllocator();
 
+  /**
+   * Returns the number of I/O threads to use in the event loop group.
+   *
+   * @return the number of I/O threads
+   */
   int getIoThreadsCount();
 
+  /**
+   * Factory for creating {@link HttpResponseBodyPart} instances.
+   * Determines how response body data is buffered and processed.
+   */
   enum ResponseBodyPartFactory {
 
+    /**
+     * Creates eager response body parts that immediately copy the data from the Netty buffer.
+     * This is safer but uses more memory as data is copied immediately.
+     */
     EAGER {
       @Override
       public HttpResponseBodyPart newResponseBodyPart(ByteBuf buf, boolean last) {
@@ -356,6 +577,10 @@ public interface AsyncHttpClientConfig {
       }
     },
 
+    /**
+     * Creates lazy response body parts that hold a reference to the Netty buffer.
+     * This is more memory efficient but requires careful buffer lifecycle management.
+     */
     LAZY {
       @Override
       public HttpResponseBodyPart newResponseBodyPart(ByteBuf buf, boolean last) {
@@ -363,6 +588,13 @@ public interface AsyncHttpClientConfig {
       }
     };
 
+    /**
+     * Creates a new response body part from the given buffer.
+     *
+     * @param buf the buffer containing response body data
+     * @param last {@code true} if this is the last body part, {@code false} otherwise
+     * @return a new {@link HttpResponseBodyPart}
+     */
     public abstract HttpResponseBodyPart newResponseBodyPart(ByteBuf buf, boolean last);
   }
 }

--- a/client/src/main/java/org/asynchttpclient/AsyncHttpClientState.java
+++ b/client/src/main/java/org/asynchttpclient/AsyncHttpClientState.java
@@ -15,6 +15,20 @@ package org.asynchttpclient;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * Represents the lifecycle state of an {@link AsyncHttpClient} instance.
+ * This class provides thread-safe access to the client's closed state.
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * AsyncHttpClient client = Dsl.asyncHttpClient();
+ * AsyncHttpClientState state = client.getState();
+ * if (!state.isClosed()) {
+ *     // Safe to use client
+ *     client.prepareGet("http://example.com").execute();
+ * }
+ * }</pre>
+ */
 public class AsyncHttpClientState {
 
   private final AtomicBoolean closed;
@@ -23,6 +37,12 @@ public class AsyncHttpClientState {
     this.closed = closed;
   }
 
+  /**
+   * Returns whether the associated {@link AsyncHttpClient} has been closed.
+   * Once closed, the client cannot be used to execute new requests.
+   *
+   * @return {@code true} if the client has been closed, {@code false} otherwise
+   */
   public boolean isClosed() {
     return closed.get();
   }

--- a/client/src/main/java/org/asynchttpclient/BoundRequestBuilder.java
+++ b/client/src/main/java/org/asynchttpclient/BoundRequestBuilder.java
@@ -12,29 +12,94 @@
  */
 package org.asynchttpclient;
 
+/**
+ * A {@link RequestBuilder} that is bound to an {@link AsyncHttpClient} instance.
+ * <p>
+ * This builder combines request configuration with immediate execution capabilities.
+ * Unlike {@link RequestBuilder}, this class is tied to a specific client and can
+ * execute requests directly via the {@link #execute()} and {@link #execute(AsyncHandler)} methods.
+ * </p>
+ * <p><b>Usage Example:</b></p>
+ * <pre>{@code
+ * AsyncHttpClient client = Dsl.asyncHttpClient();
+ *
+ * // Direct execution with default handler
+ * Future<Response> future = client.prepareGet("http://example.com")
+ *     .setHeader("Accept", "application/json")
+ *     .execute();
+ * Response response = future.get();
+ *
+ * // Execution with custom handler
+ * Future<String> bodyFuture = client.preparePost("http://example.com/api")
+ *     .setBody("{\"key\":\"value\"}")
+ *     .execute(new AsyncCompletionHandler<String>() {
+ *         @Override
+ *         public String onCompleted(Response response) throws Exception {
+ *             return response.getResponseBody();
+ *         }
+ *     });
+ * }</pre>
+ *
+ * @see AsyncHttpClient
+ * @see RequestBuilder
+ */
 public class BoundRequestBuilder extends RequestBuilderBase<BoundRequestBuilder> {
 
   private final AsyncHttpClient client;
 
+  /**
+   * Constructs a BoundRequestBuilder with URL encoding and header validation options.
+   *
+   * @param client the client instance this builder is bound to
+   * @param method the HTTP method
+   * @param isDisableUrlEncoding whether to disable URL encoding
+   * @param validateHeaders whether to validate header names and values
+   */
   public BoundRequestBuilder(AsyncHttpClient client, String method, boolean isDisableUrlEncoding, boolean validateHeaders) {
     super(method, isDisableUrlEncoding, validateHeaders);
     this.client = client;
   }
 
+  /**
+   * Constructs a BoundRequestBuilder with URL encoding option.
+   *
+   * @param client the client instance this builder is bound to
+   * @param method the HTTP method
+   * @param isDisableUrlEncoding whether to disable URL encoding
+   */
   public BoundRequestBuilder(AsyncHttpClient client, String method, boolean isDisableUrlEncoding) {
     super(method, isDisableUrlEncoding);
     this.client = client;
   }
 
+  /**
+   * Constructs a BoundRequestBuilder from an existing request.
+   *
+   * @param client the client instance this builder is bound to
+   * @param prototype the request to use as a template
+   */
   public BoundRequestBuilder(AsyncHttpClient client, Request prototype) {
     super(prototype);
     this.client = client;
   }
 
+  /**
+   * Executes the request asynchronously with a custom response handler.
+   *
+   * @param handler the async handler to process the response
+   * @param <T> the type of value returned by the handler
+   * @return a {@link ListenableFuture} that will contain the result
+   */
   public <T> ListenableFuture<T> execute(AsyncHandler<T> handler) {
     return client.executeRequest(build(), handler);
   }
 
+  /**
+   * Executes the request asynchronously and returns the complete response.
+   * The response body will be fully buffered in memory.
+   *
+   * @return a {@link ListenableFuture} containing the complete {@link Response}
+   */
   public ListenableFuture<Response> execute() {
     return client.executeRequest(build(), new AsyncCompletionHandlerBase());
   }

--- a/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClient.java
+++ b/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClient.java
@@ -42,7 +42,38 @@ import java.util.function.Predicate;
 import static org.asynchttpclient.util.Assertions.assertNotNull;
 
 /**
- * Default and threadsafe implementation of {@link AsyncHttpClient}.
+ * Default thread-safe implementation of {@link AsyncHttpClient}.
+ * <p>
+ * This is the primary implementation class for making asynchronous HTTP requests.
+ * It manages connection pooling, timeouts, and request execution using Netty as
+ * the underlying I/O provider.
+ * </p>
+ * <p>
+ * Instances can be created directly or via {@link Dsl#asyncHttpClient()}. When done,
+ * clients should be closed to release resources like connection pools and timers.
+ * </p>
+ * <p><b>Usage Example:</b></p>
+ * <pre>{@code
+ * // Using default configuration
+ * AsyncHttpClient client = new DefaultAsyncHttpClient();
+ * try {
+ *     Future<Response> future = client.prepareGet("http://example.com").execute();
+ *     Response response = future.get();
+ *     System.out.println(response.getResponseBody());
+ * } finally {
+ *     client.close();
+ * }
+ *
+ * // With custom configuration
+ * DefaultAsyncHttpClientConfig config = new DefaultAsyncHttpClientConfig.Builder()
+ *     .setConnectTimeout(5000)
+ *     .setRequestTimeout(10000)
+ *     .build();
+ * AsyncHttpClient client = new DefaultAsyncHttpClient(config);
+ * }</pre>
+ *
+ * @see AsyncHttpClient
+ * @see Dsl#asyncHttpClient()
  */
 public class DefaultAsyncHttpClient implements AsyncHttpClient {
 
@@ -62,25 +93,24 @@ public class DefaultAsyncHttpClient implements AsyncHttpClient {
   private SignatureCalculator signatureCalculator;
 
   /**
-   * Create a new HTTP Asynchronous Client using the default
-   * {@link DefaultAsyncHttpClientConfig} configuration. The default
-   * {@link AsyncHttpClient} that will be used will be based on the classpath
-   * configuration.
+   * Creates a new HTTP asynchronous client with default configuration.
    * <p>
-   * If none of those providers are found, then the engine will throw an
-   * IllegalStateException.
+   * The default configuration uses Netty as the underlying provider with
+   * standard timeout and connection pool settings.
+   * </p>
    */
   public DefaultAsyncHttpClient() {
     this(new DefaultAsyncHttpClientConfig.Builder().build());
   }
 
   /**
-   * Create a new HTTP Asynchronous Client using the specified
-   * {@link DefaultAsyncHttpClientConfig} configuration. This configuration
-   * will be passed to the default {@link AsyncHttpClient} that will be
-   * selected based on the classpath configuration.
+   * Creates a new HTTP asynchronous client with the specified configuration.
+   * <p>
+   * The configuration controls behavior such as timeouts, connection pooling,
+   * proxy settings, SSL/TLS options, and more.
+   * </p>
    *
-   * @param config a {@link DefaultAsyncHttpClientConfig}
+   * @param config the client configuration to use
    */
   public DefaultAsyncHttpClient(AsyncHttpClientConfig config) {
 

--- a/client/src/main/java/org/asynchttpclient/DefaultRequest.java
+++ b/client/src/main/java/org/asynchttpclient/DefaultRequest.java
@@ -34,6 +34,21 @@ import java.util.Map;
 
 import static org.asynchttpclient.util.MiscUtils.isNonEmpty;
 
+/**
+ * Default immutable implementation of {@link Request}.
+ * <p>
+ * This class is constructed by {@link RequestBuilder} and contains all the
+ * information needed to execute an HTTP request. Once built, instances are
+ * immutable and thread-safe.
+ * </p>
+ * <p>
+ * Applications typically don't create instances directly but use {@link RequestBuilder}
+ * or the various prepare methods on {@link AsyncHttpClient}.
+ * </p>
+ *
+ * @see Request
+ * @see RequestBuilder
+ */
 public class DefaultRequest implements Request {
 
   public final ProxyServer proxyServer;

--- a/client/src/main/java/org/asynchttpclient/Dsl.java
+++ b/client/src/main/java/org/asynchttpclient/Dsl.java
@@ -18,72 +18,208 @@ import org.asynchttpclient.proxy.ProxyServer;
 
 import static org.asynchttpclient.util.HttpConstants.Methods.*;
 
+/**
+ * Domain Specific Language (DSL) for creating async-http-client instances and builders.
+ * <p>
+ * This class provides static factory methods for conveniently creating clients, requests,
+ * realms, and proxy servers. It serves as the primary entry point for most applications
+ * using async-http-client.
+ * </p>
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Create a client with default configuration
+ * AsyncHttpClient client = Dsl.asyncHttpClient();
+ *
+ * // Create a client with custom configuration
+ * AsyncHttpClient client = Dsl.asyncHttpClient(
+ *     Dsl.config()
+ *         .setConnectTimeout(5000)
+ *         .setRequestTimeout(10000)
+ * );
+ *
+ * // Build a request
+ * Request request = Dsl.get("http://example.com")
+ *     .setHeader("Accept", "application/json")
+ *     .build();
+ *
+ * // Create a proxy
+ * ProxyServer proxy = Dsl.proxyServer("proxy.example.com", 8080)
+ *     .setProxyType(ProxyType.HTTP)
+ *     .build();
+ *
+ * // Create authentication realm
+ * Realm realm = Dsl.basicAuthRealm("username", "password")
+ *     .setUsePreemptiveAuth(true)
+ *     .build();
+ * }</pre>
+ *
+ * @see AsyncHttpClient
+ * @see RequestBuilder
+ * @see Realm
+ * @see ProxyServer
+ */
 public final class Dsl {
 
   private Dsl() {
+    // Utility class, prevent instantiation
   }
 
   // /////////// Client ////////////////
+
+  /**
+   * Creates an {@link AsyncHttpClient} with default configuration.
+   *
+   * @return a new AsyncHttpClient instance
+   */
   public static AsyncHttpClient asyncHttpClient() {
     return new DefaultAsyncHttpClient();
   }
 
+  /**
+   * Creates an {@link AsyncHttpClient} with custom configuration.
+   *
+   * @param configBuilder the configuration builder
+   * @return a new AsyncHttpClient instance with the specified configuration
+   */
   public static AsyncHttpClient asyncHttpClient(DefaultAsyncHttpClientConfig.Builder configBuilder) {
     return new DefaultAsyncHttpClient(configBuilder.build());
   }
 
+  /**
+   * Creates an {@link AsyncHttpClient} with custom configuration.
+   *
+   * @param config the client configuration
+   * @return a new AsyncHttpClient instance with the specified configuration
+   */
   public static AsyncHttpClient asyncHttpClient(AsyncHttpClientConfig config) {
     return new DefaultAsyncHttpClient(config);
   }
 
   // /////////// Request ////////////////
+
+  /**
+   * Creates a GET request builder for the specified URL.
+   *
+   * @param url the target URL
+   * @return a RequestBuilder configured for a GET request
+   */
   public static RequestBuilder get(String url) {
     return request(GET, url);
   }
 
+  /**
+   * Creates a PUT request builder for the specified URL.
+   *
+   * @param url the target URL
+   * @return a RequestBuilder configured for a PUT request
+   */
   public static RequestBuilder put(String url) {
     return request(PUT, url);
   }
 
+  /**
+   * Creates a POST request builder for the specified URL.
+   *
+   * @param url the target URL
+   * @return a RequestBuilder configured for a POST request
+   */
   public static RequestBuilder post(String url) {
     return request(POST, url);
   }
 
+  /**
+   * Creates a DELETE request builder for the specified URL.
+   *
+   * @param url the target URL
+   * @return a RequestBuilder configured for a DELETE request
+   */
   public static RequestBuilder delete(String url) {
     return request(DELETE, url);
   }
 
+  /**
+   * Creates a HEAD request builder for the specified URL.
+   *
+   * @param url the target URL
+   * @return a RequestBuilder configured for a HEAD request
+   */
   public static RequestBuilder head(String url) {
     return request(HEAD, url);
   }
 
+  /**
+   * Creates an OPTIONS request builder for the specified URL.
+   *
+   * @param url the target URL
+   * @return a RequestBuilder configured for an OPTIONS request
+   */
   public static RequestBuilder options(String url) {
     return request(OPTIONS, url);
   }
 
+  /**
+   * Creates a PATCH request builder for the specified URL.
+   *
+   * @param url the target URL
+   * @return a RequestBuilder configured for a PATCH request
+   */
   public static RequestBuilder patch(String url) {
     return request(PATCH, url);
   }
 
+  /**
+   * Creates a TRACE request builder for the specified URL.
+   *
+   * @param url the target URL
+   * @return a RequestBuilder configured for a TRACE request
+   */
   public static RequestBuilder trace(String url) {
     return request(TRACE, url);
   }
 
+  /**
+   * Creates a request builder for the specified HTTP method and URL.
+   *
+   * @param method the HTTP method (e.g., "GET", "POST")
+   * @param url the target URL
+   * @return a RequestBuilder configured for the specified method and URL
+   */
   public static RequestBuilder request(String method, String url) {
     return new RequestBuilder(method).setUrl(url);
   }
 
   // /////////// ProxyServer ////////////////
+
+  /**
+   * Creates a proxy server builder.
+   *
+   * @param host the proxy server hostname
+   * @param port the proxy server port
+   * @return a ProxyServer.Builder for configuring the proxy
+   */
   public static ProxyServer.Builder proxyServer(String host, int port) {
     return new ProxyServer.Builder(host, port);
   }
 
   // /////////// Config ////////////////
+
+  /**
+   * Creates a configuration builder for customizing client behavior.
+   *
+   * @return a new DefaultAsyncHttpClientConfig.Builder
+   */
   public static DefaultAsyncHttpClientConfig.Builder config() {
     return new DefaultAsyncHttpClientConfig.Builder();
   }
 
   // /////////// Realm ////////////////
+
+  /**
+   * Creates a realm builder based on an existing realm prototype.
+   *
+   * @param prototype the realm to use as a template
+   * @return a Realm.Builder initialized with the prototype's values
+   */
   public static Realm.Builder realm(Realm prototype) {
     return new Realm.Builder(prototype.getPrincipal(), prototype.getPassword())
             .setRealmName(prototype.getRealmName())
@@ -106,19 +242,48 @@ public final class Dsl {
             .setLoginContextName(prototype.getLoginContextName());
   }
 
+  /**
+   * Creates a realm builder with the specified authentication scheme.
+   *
+   * @param scheme the authentication scheme to use
+   * @param principal the username
+   * @param password the password
+   * @return a Realm.Builder configured with the specified credentials and scheme
+   */
   public static Realm.Builder realm(AuthScheme scheme, String principal, String password) {
     return new Realm.Builder(principal, password)
             .setScheme(scheme);
   }
 
+  /**
+   * Creates a realm builder for HTTP Basic authentication.
+   *
+   * @param principal the username
+   * @param password the password
+   * @return a Realm.Builder configured for Basic authentication
+   */
   public static Realm.Builder basicAuthRealm(String principal, String password) {
     return realm(AuthScheme.BASIC, principal, password);
   }
 
+  /**
+   * Creates a realm builder for HTTP Digest authentication.
+   *
+   * @param principal the username
+   * @param password the password
+   * @return a Realm.Builder configured for Digest authentication
+   */
   public static Realm.Builder digestAuthRealm(String principal, String password) {
     return realm(AuthScheme.DIGEST, principal, password);
   }
 
+  /**
+   * Creates a realm builder for NTLM authentication.
+   *
+   * @param principal the username
+   * @param password the password
+   * @return a Realm.Builder configured for NTLM authentication
+   */
   public static Realm.Builder ntlmAuthRealm(String principal, String password) {
     return realm(AuthScheme.NTLM, principal, password);
   }

--- a/client/src/main/java/org/asynchttpclient/HttpResponseBodyPart.java
+++ b/client/src/main/java/org/asynchttpclient/HttpResponseBodyPart.java
@@ -18,7 +18,18 @@ package org.asynchttpclient;
 import java.nio.ByteBuffer;
 
 /**
- * A callback class used when an HTTP response body is received.
+ * Represents a chunk of the HTTP response body.
+ * <p>
+ * When using {@link AsyncHandler}, the response body is delivered incrementally as
+ * multiple HttpResponseBodyPart instances. This allows for streaming processing of
+ * large responses without buffering the entire body in memory.
+ * </p>
+ * <p>
+ * <b>Note:</b> Depending on the underlying provider (Netty), this callback may be
+ * invoked with empty body parts. Always check {@link #length()} before processing.
+ * </p>
+ *
+ * @see AsyncHandler#onBodyPartReceived(HttpResponseBodyPart)
  */
 public abstract class HttpResponseBodyPart {
 
@@ -29,23 +40,31 @@ public abstract class HttpResponseBodyPart {
   }
 
   /**
-   * @return length of this part in bytes
+   * Returns the length of this body part in bytes.
+   *
+   * @return the number of bytes in this body part
    */
   public abstract int length();
 
   /**
-   * @return the response body's part bytes received.
+   * Returns the body part content as a byte array.
+   *
+   * @return the bytes of this body part
    */
   public abstract byte[] getBodyPartBytes();
 
   /**
-   * @return a {@link ByteBuffer} that wraps the actual bytes read from the response's chunk.
-   * The {@link ByteBuffer}'s capacity is equal to the number of bytes available.
+   * Returns the body part content as a ByteBuffer.
+   * The ByteBuffer's capacity equals the number of bytes available in this part.
+   *
+   * @return a ByteBuffer wrapping the body part bytes
    */
   public abstract ByteBuffer getBodyByteBuffer();
 
   /**
-   * @return true if this is the last part.
+   * Indicates whether this is the last body part of the response.
+   *
+   * @return true if this is the last body part, false otherwise
    */
   public boolean isLast() {
     return last;

--- a/client/src/main/java/org/asynchttpclient/HttpResponseStatus.java
+++ b/client/src/main/java/org/asynchttpclient/HttpResponseStatus.java
@@ -21,7 +21,15 @@ import org.asynchttpclient.uri.Uri;
 import java.net.SocketAddress;
 
 /**
- * A class that represent the HTTP response' status line (code + text)
+ * Represents the HTTP response status line containing the status code and reason phrase.
+ * <p>
+ * This class is delivered to {@link AsyncHandler#onStatusReceived(HttpResponseStatus)}
+ * as the first callback when processing an HTTP response. It includes the status code
+ * (e.g., 200, 404), status text (e.g., "OK", "Not Found"), protocol information,
+ * and network addresses.
+ * </p>
+ *
+ * @see AsyncHandler#onStatusReceived(HttpResponseStatus)
  */
 public abstract class HttpResponseStatus {
 
@@ -32,7 +40,7 @@ public abstract class HttpResponseStatus {
   }
 
   /**
-   * Return the request {@link Uri}
+   * Returns the request URI associated with this response.
    *
    * @return the request {@link Uri}
    */
@@ -41,65 +49,65 @@ public abstract class HttpResponseStatus {
   }
 
   /**
-   * Return the response status code
+   * Returns the HTTP status code.
    *
-   * @return the response status code
+   * @return the status code (e.g., 200, 404, 500)
    */
   public abstract int getStatusCode();
 
   /**
-   * Return the response status text
+   * Returns the HTTP status text (reason phrase).
    *
-   * @return the response status text
+   * @return the status text (e.g., "OK", "Not Found", "Internal Server Error")
    */
   public abstract String getStatusText();
 
   /**
-   * Protocol name from status line.
+   * Returns the protocol name from the status line.
    *
-   * @return Protocol name.
+   * @return the protocol name (e.g., "HTTP")
    */
   public abstract String getProtocolName();
 
   /**
-   * Protocol major version.
+   * Returns the major version number of the protocol.
    *
-   * @return Major version.
+   * @return the major version (e.g., 1 for HTTP/1.1)
    */
   public abstract int getProtocolMajorVersion();
 
   /**
-   * Protocol minor version.
+   * Returns the minor version number of the protocol.
    *
-   * @return Minor version.
+   * @return the minor version (e.g., 1 for HTTP/1.1)
    */
   public abstract int getProtocolMinorVersion();
 
   /**
-   * Full protocol name + version
+   * Returns the complete protocol name and version.
    *
-   * @return protocol name + version
+   * @return the protocol text (e.g., "HTTP/1.1")
    */
   public abstract String getProtocolText();
 
   /**
-   * Get remote address client initiated request to.
+   * Returns the remote socket address that the client connected to.
    *
-   * @return remote address client initiated request to, may be {@code null}
-   * if asynchronous provider is unable to provide the remote address
+   * @return the remote address, or null if not available
    */
   public abstract SocketAddress getRemoteAddress();
 
   /**
-   * Get local address client initiated request from.
+   * Returns the local socket address that the client connected from.
    *
-   * @return local address client initiated request from, may be {@code null}
-   * if asynchronous provider is unable to provide the local address
+   * @return the local address, or null if not available
    */
   public abstract SocketAddress getLocalAddress();
 
   /**
-   * Code followed by text.
+   * Returns a string representation showing the status code and text.
+   *
+   * @return status code followed by status text (e.g., "200 OK")
    */
   @Override
   public String toString() {

--- a/client/src/main/java/org/asynchttpclient/Param.java
+++ b/client/src/main/java/org/asynchttpclient/Param.java
@@ -17,7 +17,19 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * A pair of (name, value) String
+ * Represents a name-value pair, typically used for query parameters or form data.
+ * This is an immutable class that holds a single parameter's name and value.
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Create a single parameter
+ * Param param = new Param("username", "john");
+ *
+ * // Convert a map to a list of parameters
+ * Map<String, List<String>> paramsMap = new HashMap<>();
+ * paramsMap.put("filter", Arrays.asList("active", "published"));
+ * List<Param> params = Param.map2ParamList(paramsMap);
+ * }</pre>
  *
  * @author slandelle
  */
@@ -26,11 +38,24 @@ public class Param {
   private final String name;
   private final String value;
 
+  /**
+   * Constructs a new parameter with the specified name and value.
+   *
+   * @param name the parameter name
+   * @param value the parameter value
+   */
   public Param(String name, String value) {
     this.name = name;
     this.value = value;
   }
 
+  /**
+   * Converts a map of parameter names to value lists into a flat list of {@link Param} objects.
+   * Each map entry with multiple values will generate multiple {@link Param} instances, one for each value.
+   *
+   * @param map the map to convert, where each key maps to a list of values
+   * @return a list of {@link Param} objects, or {@code null} if the input map is {@code null}
+   */
   public static List<Param> map2ParamList(Map<String, List<String>> map) {
     if (map == null)
       return null;
@@ -44,10 +69,20 @@ public class Param {
     return params;
   }
 
+  /**
+   * Returns the parameter name.
+   *
+   * @return the parameter name
+   */
   public String getName() {
     return name;
   }
 
+  /**
+   * Returns the parameter value.
+   *
+   * @return the parameter value
+   */
   public String getValue() {
     return value;
   }

--- a/client/src/main/java/org/asynchttpclient/Request.java
+++ b/client/src/main/java/org/asynchttpclient/Request.java
@@ -33,156 +33,226 @@ import java.nio.charset.Charset;
 import java.util.List;
 
 /**
- * The Request class can be used to construct HTTP request:
- * <blockquote><pre>
- *   Request r = new RequestBuilder()
- *      .setUrl("url")
- *      .setRealm(
- *          new Realm.Builder("principal", "password")
- *              .setRealmName("MyRealm")
- *              .setScheme(Realm.AuthScheme.BASIC)
- *      ).build();
- * </pre></blockquote>
+ * Represents an immutable HTTP request.
+ * <p>
+ * Request instances are built using {@link RequestBuilder} and contain all the information
+ * needed to execute an HTTP request including the URL, HTTP method, headers, body, and
+ * various configuration options.
+ * </p>
+ * <p><b>Usage Example:</b></p>
+ * <pre>{@code
+ * Request request = new RequestBuilder()
+ *     .setUrl("https://api.example.com/users")
+ *     .setMethod("POST")
+ *     .setHeader("Content-Type", "application/json")
+ *     .setBody("{\"name\":\"John\"}")
+ *     .setRealm(new Realm.Builder("username", "password")
+ *         .setScheme(Realm.AuthScheme.BASIC)
+ *         .build())
+ *     .build();
+ *
+ * AsyncHttpClient client = Dsl.asyncHttpClient();
+ * Future<Response> future = client.executeRequest(request);
+ * }</pre>
  */
 public interface Request {
 
   /**
-   * @return the request's HTTP method (GET, POST, etc.)
+   * Returns the HTTP method of this request.
+   *
+   * @return the HTTP method (e.g., "GET", "POST", "PUT", "DELETE")
    */
   String getMethod();
 
   /**
-   * @return the uri
+   * Returns the URI of this request.
+   *
+   * @return the parsed {@link Uri} object
    */
   Uri getUri();
 
   /**
-   * @return the url (the uri's String form)
+   * Returns the URL of this request as a string.
+   *
+   * @return the URL string representation
    */
   String getUrl();
 
   /**
-   * @return the InetAddress to be used to bypass uri's hostname resolution
+   * Returns the specific InetAddress to use for this request, bypassing DNS resolution.
+   *
+   * @return the InetAddress to connect to, or null to use normal DNS resolution
    */
   InetAddress getAddress();
 
   /**
-   * @return the local address to bind from
+   * Returns the local address to bind from when making this request.
+   *
+   * @return the local InetAddress to bind from, or null for default behavior
    */
   InetAddress getLocalAddress();
 
   /**
-   * @return the HTTP headers
+   * Returns the HTTP headers for this request.
+   *
+   * @return the HTTP headers collection
    */
   HttpHeaders getHeaders();
 
   /**
-   * @return the HTTP cookies
+   * Returns the cookies to be sent with this request.
+   *
+   * @return the list of cookies, or an empty list if none
    */
   List<Cookie> getCookies();
 
   /**
-   * @return the request's body byte array (only non null if it was set this way)
+   * Returns the request body as a byte array, if set.
+   *
+   * @return the request body byte array, or null if the body was not set this way
    */
   byte[] getByteData();
 
   /**
-   * @return the request's body array of byte arrays (only non null if it was set this way)
+   * Returns the request body as a composite list of byte arrays, if set.
+   *
+   * @return the list of byte arrays, or null if the body was not set this way
    */
   List<byte[]> getCompositeByteData();
 
   /**
-   * @return the request's body string (only non null if it was set this way)
+   * Returns the request body as a string, if set.
+   *
+   * @return the request body string, or null if the body was not set this way
    */
   String getStringData();
 
   /**
-   * @return the request's body ByteBuffer (only non null if it was set this way)
+   * Returns the request body as a ByteBuffer, if set.
+   *
+   * @return the request body ByteBuffer, or null if the body was not set this way
    */
   ByteBuffer getByteBufferData();
 
   /**
-   * @return the request's body InputStream (only non null if it was set this way)
+   * Returns the request body as an InputStream, if set.
+   *
+   * @return the request body InputStream, or null if the body was not set this way
    */
   InputStream getStreamData();
 
   /**
-   * @return the request's body BodyGenerator (only non null if it was set this way)
+   * Returns the request body generator, if set.
+   *
+   * @return the BodyGenerator, or null if the body was not set this way
    */
   BodyGenerator getBodyGenerator();
 
   /**
-   * @return the request's form parameters
+   * Returns the form parameters for this request.
+   *
+   * @return the list of form parameters, or an empty list if none
    */
   List<Param> getFormParams();
 
   /**
-   * @return the multipart parts
+   * Returns the multipart body parts for this request.
+   *
+   * @return the list of multipart parts, or an empty list if none
    */
   List<Part> getBodyParts();
 
   /**
-   * @return the virtual host to connect to
+   * Returns the virtual host header value for this request.
+   *
+   * @return the virtual host, or null if not set
    */
   String getVirtualHost();
 
   /**
-   * @return the query params resolved from the url/uri
+   * Returns the query parameters extracted from the URL.
+   *
+   * @return the list of query parameters, or an empty list if none
    */
   List<Param> getQueryParams();
 
   /**
-   * @return the proxy server to be used to perform this request (overrides the one defined in config)
+   * Returns the proxy server to use for this request.
+   * If set, this overrides the proxy server defined in the client configuration.
+   *
+   * @return the proxy server, or null to use the client's default configuration
    */
   ProxyServer getProxyServer();
 
   /**
-   * @return the realm to be used to perform this request (overrides the one defined in config)
+   * Returns the authentication realm for this request.
+   * If set, this overrides the realm defined in the client configuration.
+   *
+   * @return the authentication realm, or null to use the client's default configuration
    */
   Realm getRealm();
 
   /**
-   * @return the file to be uploaded
+   * Returns the file to be uploaded as the request body.
+   *
+   * @return the file to upload, or null if not set
    */
   File getFile();
 
   /**
-   * @return if this request is to follow redirects. Non null values means "override config value".
+   * Returns whether this request should follow redirects.
+   *
+   * @return true to follow redirects, false to not follow them, or null to use the client's default configuration
    */
   Boolean getFollowRedirect();
 
   /**
-   * @return the request timeout. Non zero values means "override config value".
+   * Returns the request timeout in milliseconds.
+   *
+   * @return the request timeout in milliseconds, or 0 to use the client's default configuration
    */
   int getRequestTimeout();
 
   /**
-   * @return the read timeout. Non zero values means "override config value".
+   * Returns the read timeout in milliseconds.
+   *
+   * @return the read timeout in milliseconds, or 0 to use the client's default configuration
    */
   int getReadTimeout();
 
   /**
-   * @return the range header value, or 0 is not set.
+   * Returns the byte offset for HTTP range requests.
+   *
+   * @return the range offset in bytes, or 0 if not set
    */
   long getRangeOffset();
 
   /**
-   * @return the charset value used when decoding the request's body.
+   * Returns the charset used for encoding/decoding the request body.
+   *
+   * @return the charset, or null to use the default charset
    */
   Charset getCharset();
 
   /**
-   * @return the strategy to compute ChannelPool's keys
+   * Returns the channel pool partitioning strategy for this request.
+   *
+   * @return the channel pool partitioning strategy
    */
   ChannelPoolPartitioning getChannelPoolPartitioning();
 
   /**
-   * @return the NameResolver to be used to resolve hostnams's IP
+   * Returns the name resolver to use for hostname resolution.
+   *
+   * @return the name resolver, or null to use the client's default resolver
    */
   NameResolver<InetAddress> getNameResolver();
 
   /**
-   * @return a new request builder using this request as a prototype
+   * Creates a new {@link RequestBuilder} initialized with this request's values.
+   * This allows modification of an existing request.
+   *
+   * @return a new RequestBuilder based on this request
    */
   @SuppressWarnings("deprecation")
   default RequestBuilder toBuilder() {

--- a/client/src/main/java/org/asynchttpclient/RequestBuilder.java
+++ b/client/src/main/java/org/asynchttpclient/RequestBuilder.java
@@ -18,8 +18,28 @@ package org.asynchttpclient;
 import static org.asynchttpclient.util.HttpConstants.Methods.GET;
 
 /**
- * Builder for a {@link Request}. Warning: mutable and not thread-safe! Beware that it holds a reference to the Request instance it builds, so modifying the builder will modify the
- * request even after it has been built.
+ * Builder for constructing {@link Request} instances.
+ * <p>
+ * <b>Warning:</b> This class is mutable and NOT thread-safe. Do not share instances across threads.
+ * </p>
+ * <p><b>Usage Example:</b></p>
+ * <pre>{@code
+ * Request request = new RequestBuilder()
+ *     .setUrl("https://api.example.com/users")
+ *     .setMethod("POST")
+ *     .setHeader("Content-Type", "application/json")
+ *     .setHeader("Authorization", "Bearer token123")
+ *     .setBody("{\"name\":\"John Doe\"}")
+ *     .setRequestTimeout(5000)
+ *     .build();
+ *
+ * AsyncHttpClient client = Dsl.asyncHttpClient();
+ * Future<Response> future = client.executeRequest(request);
+ * Response response = future.get();
+ * }</pre>
+ *
+ * @see Request
+ * @see BoundRequestBuilder
  */
 public class RequestBuilder extends RequestBuilderBase<RequestBuilder> {
 

--- a/client/src/main/java/org/asynchttpclient/RequestBuilderBase.java
+++ b/client/src/main/java/org/asynchttpclient/RequestBuilderBase.java
@@ -47,9 +47,28 @@ import static org.asynchttpclient.util.MiscUtils.isNonEmpty;
 import static org.asynchttpclient.util.MiscUtils.withDefault;
 
 /**
- * Builder for {@link Request}
+ * Abstract base class for building {@link Request} instances.
+ * <p>
+ * This class provides a fluent API for constructing HTTP requests with various options
+ * including headers, body, authentication, timeouts, and more. It uses the builder pattern
+ * with method chaining for convenient request configuration.
+ * </p>
+ * <p>
+ * <b>Important:</b> This builder is mutable and NOT thread-safe. Create a new instance
+ * for each request or ensure proper synchronization when reusing builders.
+ * </p>
+ * <p>
+ * Most applications should use the concrete subclasses:
+ * <ul>
+ *   <li>{@link RequestBuilder} - for building requests independently</li>
+ *   <li>{@link BoundRequestBuilder} - for building and executing requests with a client</li>
+ * </ul>
+ * </p>
  *
- * @param <T> the builder type
+ * @param <T> the concrete builder type (for method chaining)
+ * @see Request
+ * @see RequestBuilder
+ * @see BoundRequestBuilder
  */
 public abstract class RequestBuilderBase<T extends RequestBuilderBase<T>> {
 

--- a/client/src/main/java/org/asynchttpclient/Response.java
+++ b/client/src/main/java/org/asynchttpclient/Response.java
@@ -29,165 +29,233 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Represents the asynchronous HTTP response callback for an {@link AsyncCompletionHandler}
+ * Represents a complete HTTP response received from the server.
+ * <p>
+ * This interface provides access to all components of an HTTP response including
+ * status code, headers, body, and metadata. Response instances are typically obtained
+ * through {@link AsyncCompletionHandler} or by calling {@code Future.get()} on a request execution.
+ * </p>
+ * <p>
+ * <b>Note:</b> When using {@link AsyncCompletionHandlerBase} or similar handlers, the entire
+ * response body is buffered in memory. For streaming large responses, use {@link AsyncHandler}
+ * with {@link HttpResponseBodyPart} callbacks instead.
+ * </p>
+ * <p><b>Usage Example:</b></p>
+ * <pre>{@code
+ * AsyncHttpClient client = Dsl.asyncHttpClient();
+ * Future<Response> future = client.prepareGet("http://example.com").execute();
+ * Response response = future.get();
+ *
+ * int statusCode = response.getStatusCode();
+ * String contentType = response.getContentType();
+ * String body = response.getResponseBody();
+ * List<Cookie> cookies = response.getCookies();
+ * }</pre>
+ *
+ * @see AsyncCompletionHandler
+ * @see AsyncHttpClient
  */
 public interface Response {
   /**
-   * Returns the status code for the request.
+   * Returns the HTTP status code of the response.
    *
-   * @return The status code
+   * @return the HTTP status code (e.g., 200, 404, 500)
    */
   int getStatusCode();
 
   /**
-   * Returns the status text for the request.
+   * Returns the HTTP status text (reason phrase) of the response.
    *
-   * @return The status text
+   * @return the status text (e.g., "OK", "Not Found", "Internal Server Error")
    */
   String getStatusText();
 
   /**
-   * Return the entire response body as a byte[].
+   * Returns the entire response body as a byte array.
    *
-   * @return the entire response body as a byte[].
+   * @return the complete response body as a byte array
    */
   byte[] getResponseBodyAsBytes();
 
   /**
-   * Return the entire response body as a ByteBuffer.
+   * Returns the entire response body as a ByteBuffer.
    *
-   * @return the entire response body as a ByteBuffer.
+   * @return the complete response body as a ByteBuffer
    */
   ByteBuffer getResponseBodyAsByteBuffer();
 
   /**
-   * Returns an input stream for the response body. Note that you should not try to get this more than once, and that you should not close the stream.
+   * Returns an input stream for reading the response body.
+   * <p>
+   * <b>Important:</b> This stream should only be obtained once and should not be closed
+   * by the caller as it is managed internally.
+   * </p>
    *
-   * @return The input stream
+   * @return an InputStream for reading the response body
    */
   InputStream getResponseBodyAsStream();
 
   /**
-   * Return the entire response body as a String.
+   * Returns the entire response body decoded as a string using the specified charset.
    *
-   * @param charset the charset to use when decoding the stream
-   * @return the entire response body as a String.
+   * @param charset the charset to use for decoding the response body
+   * @return the response body as a string
    */
   String getResponseBody(Charset charset);
 
   /**
-   * Return the entire response body as a String.
+   * Returns the entire response body decoded as a string.
+   * The charset is determined from the Content-Type header, or UTF-8 is used as default.
    *
-   * @return the entire response body as a String.
+   * @return the response body as a string
    */
   String getResponseBody();
 
   /**
-   * Return the request {@link Uri}. Note that if the request got redirected, the value of the {@link Uri} will be the last valid redirect url.
+   * Returns the final URI of the request.
+   * <p>
+   * If the request was redirected, this returns the URI of the final destination,
+   * not the original request URI.
+   * </p>
    *
-   * @return the request {@link Uri}.
+   * @return the final request {@link Uri}
    */
   Uri getUri();
 
   /**
-   * Return the content-type header value.
+   * Returns the value of the Content-Type header.
    *
-   * @return the content-type header value.
+   * @return the Content-Type header value, or null if not present
    */
   String getContentType();
 
   /**
-   * @param name the header name
-   * @return the first response header value
+   * Returns the first value of the specified response header.
+   *
+   * @param name the header name (case-insensitive)
+   * @return the first header value, or null if the header is not present
    */
   String getHeader(CharSequence name);
 
   /**
-   * Return a {@link List} of the response header value.
+   * Returns all values of the specified response header.
    *
-   * @param name the header name
-   * @return the response header value
+   * @param name the header name (case-insensitive)
+   * @return a list of all header values, or an empty list if the header is not present
    */
   List<String> getHeaders(CharSequence name);
 
+  /**
+   * Returns all response headers.
+   *
+   * @return the complete collection of HTTP response headers
+   */
   HttpHeaders getHeaders();
 
   /**
-   * Return true if the response redirects to another object.
+   * Indicates whether the response was the result of a redirect.
    *
-   * @return True if the response redirects to another object.
+   * @return true if the request was redirected, false otherwise
    */
   boolean isRedirected();
 
   /**
-   * Subclasses SHOULD implement toString() in a way that identifies the response for logging.
+   * Returns a string representation of this response suitable for logging.
+   * Implementations should include key information like status code and URI.
    *
-   * @return the textual representation
+   * @return the textual representation of this response
    */
   String toString();
 
   /**
-   * @return the list of {@link Cookie}.
+   * Returns all cookies received in the response.
+   *
+   * @return the list of cookies, or an empty list if none
    */
   List<Cookie> getCookies();
 
   /**
-   * Return true if the response's status has been computed by an {@link AsyncHandler}
+   * Indicates whether the response status was received and processed.
    *
-   * @return true if the response's status has been computed by an {@link AsyncHandler}
+   * @return true if the status line was received, false if processing was aborted before receiving it
    */
   boolean hasResponseStatus();
 
   /**
-   * Return true if the response's headers has been computed by an {@link AsyncHandler} It will return false if the either
-   * {@link AsyncHandler#onStatusReceived(HttpResponseStatus)} or {@link AsyncHandler#onHeadersReceived(HttpHeaders)} returned {@link AsyncHandler.State#ABORT}
+   * Indicates whether the response headers were received and processed.
+   * Returns false if processing was aborted during
+   * {@link AsyncHandler#onStatusReceived(HttpResponseStatus)} or
+   * {@link AsyncHandler#onHeadersReceived(HttpHeaders)}.
    *
-   * @return true if the response's headers has been computed by an {@link AsyncHandler}
+   * @return true if the headers were received, false if processing was aborted before or during header reception
    */
   boolean hasResponseHeaders();
 
   /**
-   * Return true if the response's body has been computed by an {@link AsyncHandler}.
-   * It will return false if:
+   * Indicates whether the response body was received and processed.
+   * <p>
+   * Returns false if:
    * <ul>
-   *   <li>either the {@link AsyncHandler#onStatusReceived(HttpResponseStatus)} returned {@link AsyncHandler.State#ABORT}</li>
-   *   <li>or {@link AsyncHandler#onHeadersReceived(HttpHeaders)} returned {@link AsyncHandler.State#ABORT}</li>
-   *   <li>response body was empty</li>
+   *   <li>processing was aborted during {@link AsyncHandler#onStatusReceived(HttpResponseStatus)}, or</li>
+   *   <li>processing was aborted during {@link AsyncHandler#onHeadersReceived(HttpHeaders)}, or</li>
+   *   <li>the response body was empty</li>
    * </ul>
+   * </p>
    *
-   * @return true if the response's body has been computed by an {@link AsyncHandler} to new empty bytes
+   * @return true if a non-empty response body was received, false otherwise
    */
   boolean hasResponseBody();
 
   /**
-   * Get the remote address that the client initiated the request to.
+   * Returns the remote socket address that the client connected to.
    *
-   * @return The remote address that the client initiated the request to. May be {@code null} if asynchronous provider is unable to provide the remote address
+   * @return the remote socket address, or null if not available
    */
   SocketAddress getRemoteAddress();
 
   /**
-   * Get the local address that the client initiated the request from.
+   * Returns the local socket address that the client connected from.
    *
-   * @return The local address that the client initiated the request from. May be {@code null} if asynchronous provider is unable to provide the local address
+   * @return the local socket address, or null if not available
    */
   SocketAddress getLocalAddress();
 
+  /**
+   * Builder for accumulating response components and constructing a complete {@link Response}.
+   * <p>
+   * This builder is typically used internally by {@link AsyncCompletionHandler} to accumulate
+   * the HTTP status, headers, and body parts as they arrive, then build the final Response object.
+   * </p>
+   */
   class ResponseBuilder {
     private final List<HttpResponseBodyPart> bodyParts = new ArrayList<>(1);
     private HttpResponseStatus status;
     private HttpHeaders headers;
 
+    /**
+     * Accumulates the HTTP response status.
+     *
+     * @param status the HTTP response status to store
+     */
     public void accumulate(HttpResponseStatus status) {
       this.status = status;
     }
 
+    /**
+     * Accumulates HTTP response headers.
+     * If headers were previously accumulated, the new headers are added to them.
+     *
+     * @param headers the HTTP headers to accumulate
+     */
     public void accumulate(HttpHeaders headers) {
       this.headers = this.headers == null ? headers : this.headers.add(headers);
     }
 
     /**
-     * @param bodyPart a body part (possibly empty, but will be filtered out)
+     * Accumulates a response body part.
+     * Empty body parts are filtered out and not stored.
+     *
+     * @param bodyPart the body part to accumulate (empty parts are ignored)
      */
     public void accumulate(HttpResponseBodyPart bodyPart) {
       if (bodyPart.length() > 0)
@@ -195,16 +263,17 @@ public interface Response {
     }
 
     /**
-     * Build a {@link Response} instance
+     * Builds a complete {@link Response} from the accumulated components.
      *
-     * @return a {@link Response} instance
+     * @return a Response instance, or null if no status was accumulated
      */
     public Response build() {
       return status == null ? null : new NettyResponse(status, headers, bodyParts);
     }
 
     /**
-     * Reset the internal state of this builder.
+     * Resets this builder to its initial empty state.
+     * Clears all accumulated status, headers, and body parts.
      */
     public void reset() {
       bodyParts.clear();

--- a/client/src/main/java/org/asynchttpclient/channel/ChannelPoolPartitioning.java
+++ b/client/src/main/java/org/asynchttpclient/channel/ChannelPoolPartitioning.java
@@ -16,14 +16,77 @@ import org.asynchttpclient.proxy.ProxyServer;
 import org.asynchttpclient.proxy.ProxyType;
 import org.asynchttpclient.uri.Uri;
 
+/**
+ * Strategy interface for determining how channels are partitioned in the channel pool.
+ * <p>
+ * Channel pool partitioning allows different strategies for grouping and reusing
+ * persistent connections based on various criteria such as target host, virtual host,
+ * and proxy configuration.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Using the default per-host partitioning
+ * ChannelPoolPartitioning partitioning = PerHostChannelPoolPartitioning.INSTANCE;
+ *
+ * // Get partition key for a request
+ * Uri uri = new Uri("https", null, "example.com", 443, "/api", null);
+ * Object key = partitioning.getPartitionKey(uri, null, null);
+ * }</pre>
+ */
 public interface ChannelPoolPartitioning {
 
+  /**
+   * Computes a partition key for the given request parameters.
+   * <p>
+   * The partition key is used to group channels in the pool, allowing reuse of
+   * connections to the same destination. The key should uniquely identify the
+   * combination of target host, virtual host, and proxy configuration.
+   * </p>
+   *
+   * @param uri the target URI of the request
+   * @param virtualHost the virtual host header value, or {@code null} if not specified
+   * @param proxyServer the proxy server configuration, or {@code null} if no proxy is used
+   * @return a partition key object that uniquely identifies this connection configuration
+   */
   Object getPartitionKey(Uri uri, String virtualHost, ProxyServer proxyServer);
 
+  /**
+   * Default channel pool partitioning strategy that partitions channels by host.
+   * <p>
+   * This implementation creates partition keys based on:
+   * </p>
+   * <ul>
+   *   <li>Target host base URL (scheme, host, and port)</li>
+   *   <li>Virtual host header (if specified)</li>
+   *   <li>Proxy server configuration (if used)</li>
+   * </ul>
+   * <p>
+   * For simple requests without virtual hosts or proxies, the partition key is
+   * just the target host base URL. For more complex scenarios, a composite key
+   * is created that includes all relevant parameters.
+   * </p>
+   */
   enum PerHostChannelPoolPartitioning implements ChannelPoolPartitioning {
 
+    /**
+     * Singleton instance of the per-host channel pool partitioning strategy.
+     */
     INSTANCE;
 
+    /**
+     * Computes a partition key based on the target host, virtual host, and proxy configuration.
+     * <p>
+     * Returns a simple string key (the base URL) for basic requests, or a
+     * {@link CompositePartitionKey} for requests with virtual hosts or proxies.
+     * </p>
+     *
+     * @param uri the target URI of the request
+     * @param virtualHost the virtual host header value, or {@code null} if not specified
+     * @param proxyServer the proxy server configuration, or {@code null} if no proxy is used
+     * @return a partition key (String or CompositePartitionKey) uniquely identifying this connection
+     */
+    @Override
     public Object getPartitionKey(Uri uri, String virtualHost, ProxyServer proxyServer) {
       String targetHostBaseUrl = uri.getBaseUrl();
       if (proxyServer == null) {
@@ -50,6 +113,19 @@ public interface ChannelPoolPartitioning {
     }
   }
 
+  /**
+   * Composite partition key for complex connection scenarios.
+   * <p>
+   * This class represents a partition key that includes multiple components:
+   * target host, virtual host, and proxy configuration. It is used when
+   * requests require more than just the target host URL to uniquely identify
+   * a connection pool partition.
+   * </p>
+   * <p>
+   * Instances are immutable and implement proper {@code equals()} and
+   * {@code hashCode()} methods for use as map keys.
+   * </p>
+   */
   class CompositePartitionKey {
     private final String targetHostBaseUrl;
     private final String virtualHost;
@@ -57,6 +133,15 @@ public interface ChannelPoolPartitioning {
     private final int proxyPort;
     private final ProxyType proxyType;
 
+    /**
+     * Creates a new composite partition key.
+     *
+     * @param targetHostBaseUrl the base URL of the target host (scheme, host, and port)
+     * @param virtualHost the virtual host header value, or {@code null}
+     * @param proxyHost the proxy server hostname, or {@code null}
+     * @param proxyPort the proxy server port
+     * @param proxyType the type of proxy (HTTP, SOCKS, etc.), or {@code null}
+     */
     CompositePartitionKey(String targetHostBaseUrl, String virtualHost, String proxyHost, int proxyPort, ProxyType proxyType) {
       this.targetHostBaseUrl = targetHostBaseUrl;
       this.virtualHost = virtualHost;
@@ -65,6 +150,16 @@ public interface ChannelPoolPartitioning {
       this.proxyType = proxyType;
     }
 
+    /**
+     * Compares this composite key with another object for equality.
+     * <p>
+     * Two composite keys are equal if all their components (target host, virtual host,
+     * proxy host, proxy port, and proxy type) are equal.
+     * </p>
+     *
+     * @param o the object to compare with
+     * @return {@code true} if the objects are equal, {@code false} otherwise
+     */
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
@@ -80,6 +175,15 @@ public interface ChannelPoolPartitioning {
       return proxyType == that.proxyType;
     }
 
+    /**
+     * Returns a hash code value for this composite key.
+     * <p>
+     * The hash code is computed based on all components of the key to ensure
+     * proper behavior when used in hash-based collections.
+     * </p>
+     *
+     * @return a hash code value for this object
+     */
     @Override
     public int hashCode() {
       int result = targetHostBaseUrl != null ? targetHostBaseUrl.hashCode() : 0;
@@ -90,6 +194,14 @@ public interface ChannelPoolPartitioning {
       return result;
     }
 
+    /**
+     * Returns a string representation of this composite key.
+     * <p>
+     * The string includes all components of the key for debugging and logging purposes.
+     * </p>
+     *
+     * @return a string representation of this object
+     */
     @Override
     public String toString() {
       return "CompositePartitionKey(" +

--- a/client/src/main/java/org/asynchttpclient/channel/DefaultKeepAliveStrategy.java
+++ b/client/src/main/java/org/asynchttpclient/channel/DefaultKeepAliveStrategy.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright (c) 2014 AsyncHttpClient Project. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
 package org.asynchttpclient.channel;
 
 import io.netty.handler.codec.http.HttpRequest;
@@ -10,12 +23,63 @@ import java.net.InetSocketAddress;
 import static io.netty.handler.codec.http.HttpHeaderValues.CLOSE;
 
 /**
- * Connection strategy implementing standard HTTP 1.0/1.1 behavior.
+ * Default keep-alive strategy implementing standard HTTP 1.0/1.1 connection persistence behavior.
+ * <p>
+ * This implementation follows RFC 7230 section 6.1 for determining connection persistence.
+ * It examines both request and response headers to determine if the connection should be
+ * kept alive for reuse. The strategy considers:
+ * </p>
+ * <ul>
+ *   <li>The {@code Connection} header in both request and response</li>
+ *   <li>HTTP version (1.0 vs 1.1 default behavior)</li>
+ *   <li>Non-standard {@code Proxy-Connection} header for compatibility</li>
+ * </ul>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Create and use the default strategy
+ * KeepAliveStrategy strategy = new DefaultKeepAliveStrategy();
+ *
+ * // In request processing
+ * boolean shouldKeepAlive = strategy.keepAlive(
+ *     remoteAddress,
+ *     ahcRequest,
+ *     nettyRequest,
+ *     nettyResponse
+ * );
+ *
+ * if (shouldKeepAlive) {
+ *     // Connection will be reused - return to pool
+ *     channelPool.offer(channel, partitionKey);
+ * } else {
+ *     // Connection will be closed
+ *     channel.close();
+ * }
+ * }</pre>
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc7230#section-6.1">RFC 7230 Section 6.1</a>
  */
 public class DefaultKeepAliveStrategy implements KeepAliveStrategy {
 
   /**
-   * Implemented in accordance with RFC 7230 section 6.1 https://tools.ietf.org/html/rfc7230#section-6.1
+   * Determines if the connection should be kept alive based on HTTP headers.
+   * <p>
+   * This implementation is in accordance with RFC 7230 section 6.1. The connection
+   * is kept alive only if:
+   * </p>
+   * <ol>
+   *   <li>The response indicates keep-alive support (via {@code Connection} header or HTTP/1.1 default)</li>
+   *   <li>The request indicates keep-alive support</li>
+   *   <li>The non-standard {@code Proxy-Connection} header does not indicate "close"</li>
+   * </ol>
+   *
+   * @param remoteAddress the remote {@link InetSocketAddress} associated with the request
+   * @param ahcRequest the {@link Request} object, as built by AsyncHttpClient
+   * @param request the {@link HttpRequest} sent to Netty
+   * @param response the {@link HttpResponse} received from Netty
+   * @return {@code true} if the connection should be kept alive for reuse,
+   *         {@code false} if it should be closed
+   * @see <a href="https://tools.ietf.org/html/rfc7230#section-6.1">RFC 7230 Section 6.1</a>
    */
   @Override
   public boolean keepAlive(InetSocketAddress remoteAddress, Request ahcRequest, HttpRequest request, HttpResponse response) {

--- a/client/src/main/java/org/asynchttpclient/channel/NoopChannelPool.java
+++ b/client/src/main/java/org/asynchttpclient/channel/NoopChannelPool.java
@@ -19,38 +19,113 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.function.Predicate;
 
+/**
+ * No-operation implementation of {@link ChannelPool} that disables connection pooling.
+ * <p>
+ * This implementation provides a channel pool that never caches channels. All operations
+ * are no-ops or return empty results. This is useful when connection pooling is not desired,
+ * such as in testing scenarios or when each request should use a fresh connection.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Using the no-op channel pool
+ * ChannelPool pool = NoopChannelPool.INSTANCE;
+ *
+ * // Attempting to offer a channel - always returns false
+ * Channel channel = ...;
+ * boolean added = pool.offer(channel, "key"); // returns false
+ *
+ * // Attempting to poll a channel - always returns null
+ * Channel reused = pool.poll("key"); // returns null
+ *
+ * // All operations are safe but have no effect
+ * pool.destroy(); // does nothing
+ * pool.flushPartitions(key -> true); // does nothing
+ * }</pre>
+ */
 public enum NoopChannelPool implements ChannelPool {
 
+  /**
+   * Singleton instance of the no-op channel pool.
+   */
   INSTANCE;
 
+  /**
+   * Always rejects the channel without caching it.
+   *
+   * @param channel the I/O channel to add to the pool
+   * @param partitionKey the key used to partition and retrieve the cached channel
+   * @return always {@code false}, indicating the channel was not added
+   */
   @Override
   public boolean offer(Channel channel, Object partitionKey) {
     return false;
   }
 
+  /**
+   * Always returns {@code null} as no channels are cached.
+   *
+   * @param partitionKey the partition key used when the channel was offered via {@link #offer(Channel, Object)}
+   * @return always {@code null}, indicating no channel is available
+   */
   @Override
   public Channel poll(Object partitionKey) {
     return null;
   }
 
+  /**
+   * Always returns {@code false} as no channels are cached.
+   *
+   * @param channel the channel to remove from all partitions
+   * @return always {@code false}, indicating the channel was not found
+   */
   @Override
   public boolean removeAll(Channel channel) {
     return false;
   }
 
+  /**
+   * Always returns {@code true}, indicating the pool accepts channels.
+   * <p>
+   * Note: Even though this returns {@code true}, {@link #offer(Channel, Object)}
+   * will still return {@code false} as this implementation never caches channels.
+   * </p>
+   *
+   * @return always {@code true}
+   */
   @Override
   public boolean isOpen() {
     return true;
   }
 
+  /**
+   * No-op implementation that does nothing.
+   * <p>
+   * Since no channels are cached, there is nothing to destroy.
+   * </p>
+   */
   @Override
   public void destroy() {
   }
 
+  /**
+   * No-op implementation that does nothing.
+   * <p>
+   * Since no channels are cached, there are no partitions to flush.
+   * </p>
+   *
+   * @param predicate the predicate to evaluate partition keys (ignored)
+   */
   @Override
   public void flushPartitions(Predicate<Object> predicate) {
   }
 
+  /**
+   * Returns an empty map as no channels are cached.
+   *
+   * @return an empty immutable map
+   */
   @Override
   public Map<String, Long> getIdleChannelCountPerHost() {
     return Collections.emptyMap();

--- a/client/src/main/java/org/asynchttpclient/config/AsyncHttpClientConfigDefaults.java
+++ b/client/src/main/java/org/asynchttpclient/config/AsyncHttpClientConfigDefaults.java
@@ -16,6 +16,25 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
+/**
+ * Provides default configuration values for {@link org.asynchttpclient.AsyncHttpClient}.
+ * Configuration values are loaded from property files and system properties, with the following precedence:
+ * <ol>
+ *   <li>System properties (-Dorg.asynchttpclient.propertyName)</li>
+ *   <li>Custom ahc.properties file</li>
+ *   <li>Default ahc-default.properties file</li>
+ * </ol>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Get default values
+ * int defaultConnectTimeout = AsyncHttpClientConfigDefaults.defaultConnectTimeout();
+ * int defaultMaxConnections = AsyncHttpClientConfigDefaults.defaultMaxConnections();
+ *
+ * // Override via system property
+ * System.setProperty("org.asynchttpclient.connectTimeout", "10000");
+ * }</pre>
+ */
 public final class AsyncHttpClientConfigDefaults {
 
   public static final String ASYNC_CLIENT_CONFIG_ROOT = "org.asynchttpclient.";
@@ -90,22 +109,47 @@ public final class AsyncHttpClientConfigDefaults {
   private AsyncHttpClientConfigDefaults() {
   }
 
+  /**
+   * Returns the default thread pool name.
+   *
+   * @return the default thread pool name
+   */
   public static String defaultThreadPoolName() {
     return AsyncHttpClientConfigHelper.getAsyncHttpClientConfig().getString(ASYNC_CLIENT_CONFIG_ROOT + THREAD_POOL_NAME_CONFIG);
   }
 
+  /**
+   * Returns the default maximum number of connections.
+   *
+   * @return the default maximum number of connections
+   */
   public static int defaultMaxConnections() {
     return AsyncHttpClientConfigHelper.getAsyncHttpClientConfig().getInt(ASYNC_CLIENT_CONFIG_ROOT + MAX_CONNECTIONS_CONFIG);
   }
 
+  /**
+   * Returns the default maximum number of connections per host.
+   *
+   * @return the default maximum number of connections per host
+   */
   public static int defaultMaxConnectionsPerHost() {
     return AsyncHttpClientConfigHelper.getAsyncHttpClientConfig().getInt(ASYNC_CLIENT_CONFIG_ROOT + MAX_CONNECTIONS_PER_HOST_CONFIG);
   }
 
+  /**
+   * Returns the default timeout for acquiring a free channel from the pool in milliseconds.
+   *
+   * @return the default acquire free channel timeout in milliseconds
+   */
   public static int defaultAcquireFreeChannelTimeout() {
     return AsyncHttpClientConfigHelper.getAsyncHttpClientConfig().getInt(ASYNC_CLIENT_CONFIG_ROOT + ACQUIRE_FREE_CHANNEL_TIMEOUT);
   }
 
+  /**
+   * Returns the default connection timeout in milliseconds.
+   *
+   * @return the default connection timeout in milliseconds
+   */
   public static int defaultConnectTimeout() {
     return AsyncHttpClientConfigHelper.getAsyncHttpClientConfig().getInt(ASYNC_CLIENT_CONFIG_ROOT + CONNECTION_TIMEOUT_CONFIG);
   }

--- a/client/src/main/java/org/asynchttpclient/config/AsyncHttpClientConfigHelper.java
+++ b/client/src/main/java/org/asynchttpclient/config/AsyncHttpClientConfigHelper.java
@@ -5,10 +5,36 @@ import java.io.InputStream;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * Helper class for loading and managing AsyncHttpClient configuration properties.
+ * Properties are loaded from multiple sources with the following precedence:
+ * <ol>
+ *   <li>System properties</li>
+ *   <li>Custom properties file (ahc.properties)</li>
+ *   <li>Default properties file (ahc-default.properties)</li>
+ * </ol>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Get configuration
+ * AsyncHttpClientConfigHelper.Config config = AsyncHttpClientConfigHelper.getAsyncHttpClientConfig();
+ * String threadPoolName = config.getString("org.asynchttpclient.threadPoolName");
+ *
+ * // Reload properties after system property change
+ * System.setProperty("org.asynchttpclient.maxConnections", "200");
+ * AsyncHttpClientConfigHelper.reloadProperties();
+ * }</pre>
+ */
 public class AsyncHttpClientConfigHelper {
 
   private static volatile Config config;
 
+  /**
+   * Returns the singleton configuration instance.
+   * Creates a new instance if not already initialized.
+   *
+   * @return the configuration instance
+   */
   public static Config getAsyncHttpClientConfig() {
     if (config == null) {
       config = new Config();
@@ -18,14 +44,28 @@ public class AsyncHttpClientConfigHelper {
   }
 
   /**
-   * This method invalidates the property caches. So if a system property has been changed and the effect of this change is to be seen then call reloadProperties() and then
-   * getAsyncHttpClientConfig() to get the new property values.
+   * Reloads all configuration properties from their sources.
+   * This method invalidates the property caches, allowing changes to system properties
+   * or configuration files to take effect. After calling this method, call
+   * {@link #getAsyncHttpClientConfig()} to get the refreshed configuration.
+   *
+   * <p><b>Usage Examples:</b></p>
+   * <pre>{@code
+   * // Change a system property and reload
+   * System.setProperty("org.asynchttpclient.connectTimeout", "5000");
+   * AsyncHttpClientConfigHelper.reloadProperties();
+   * }</pre>
    */
   public static void reloadProperties() {
     if (config != null)
       config.reload();
   }
 
+  /**
+   * Configuration holder that manages property loading and caching.
+   * Properties are loaded from default and custom property files, with system properties
+   * taking highest precedence.
+   */
   public static class Config {
 
     public static final String DEFAULT_AHC_PROPERTIES = "ahc-default.properties";
@@ -35,11 +75,22 @@ public class AsyncHttpClientConfigHelper {
     private final Properties defaultProperties = parsePropertiesFile(DEFAULT_AHC_PROPERTIES, true);
     private volatile Properties customProperties = parsePropertiesFile(CUSTOM_AHC_PROPERTIES, false);
 
+    /**
+     * Reloads custom properties and clears the property cache.
+     */
     public void reload() {
       customProperties = parsePropertiesFile(CUSTOM_AHC_PROPERTIES, false);
       propsCache.clear();
     }
 
+    /**
+     * Parses a properties file from the classpath.
+     *
+     * @param file the name of the properties file
+     * @param required {@code true} if the file must exist, {@code false} if it's optional
+     * @return the loaded properties
+     * @throws IllegalArgumentException if the file is required but not found, or if parsing fails
+     */
     private Properties parsePropertiesFile(String file, boolean required) {
       Properties props = new Properties();
 
@@ -57,6 +108,13 @@ public class AsyncHttpClientConfigHelper {
       return props;
     }
 
+    /**
+     * Returns a string property value.
+     * Checks system properties first, then custom properties, then default properties.
+     *
+     * @param key the property key
+     * @return the property value, or {@code null} if not found
+     */
     public String getString(String key) {
       return propsCache.computeIfAbsent(key, k -> {
         String value = System.getProperty(k);
@@ -68,6 +126,13 @@ public class AsyncHttpClientConfigHelper {
       });
     }
 
+    /**
+     * Returns a string array property value.
+     * The property value should be a comma-separated list.
+     *
+     * @param key the property key
+     * @return an array of trimmed string values, or {@code null} if the property is empty
+     */
     public String[] getStringArray(String key) {
       String s = getString(key);
       s = s.trim();
@@ -81,10 +146,23 @@ public class AsyncHttpClientConfigHelper {
       return array;
     }
 
+    /**
+     * Returns an integer property value.
+     *
+     * @param key the property key
+     * @return the property value as an integer
+     * @throws NumberFormatException if the property value is not a valid integer
+     */
     public int getInt(String key) {
       return Integer.parseInt(getString(key));
     }
 
+    /**
+     * Returns a boolean property value.
+     *
+     * @param key the property key
+     * @return the property value as a boolean
+     */
     public boolean getBoolean(String key) {
       return Boolean.parseBoolean(getString(key));
     }

--- a/client/src/main/java/org/asynchttpclient/cookie/CookieEvictionTask.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/CookieEvictionTask.java
@@ -8,15 +8,34 @@ import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
 
 /**
- * Evicts expired cookies from the {@linkplain CookieStore} periodically.
- * The default delay is 30 seconds. You may override the default using
- * {@linkplain AsyncHttpClientConfig#expiredCookieEvictionDelay()}.
+ * Periodic task that evicts expired cookies from a {@link CookieStore}.
+ * This task runs at a configurable interval to clean up cookies that have passed
+ * their expiration time, preventing memory leaks from accumulating expired cookies.
+ *
+ * <p>The default eviction delay is 30 seconds. You can override this using
+ * {@link AsyncHttpClientConfig#expiredCookieEvictionDelay()}.</p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Configure custom eviction delay (in milliseconds)
+ * AsyncHttpClient client = Dsl.asyncHttpClient(
+ *     new DefaultAsyncHttpClientConfig.Builder()
+ *         .setExpiredCookieEvictionDelay(60000) // 60 seconds
+ *         .build()
+ * );
+ * }</pre>
  */
 public class CookieEvictionTask implements TimerTask {
 
     private final long evictDelayInMs;
     private final CookieStore cookieStore;
 
+    /**
+     * Constructs a new cookie eviction task.
+     *
+     * @param evictDelayInMs the delay in milliseconds between eviction runs
+     * @param cookieStore the cookie store to evict expired cookies from
+     */
     public CookieEvictionTask(long evictDelayInMs, CookieStore cookieStore) {
         this.evictDelayInMs = evictDelayInMs;
         this.cookieStore = cookieStore;

--- a/client/src/main/java/org/asynchttpclient/cookie/CookieStore.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/CookieStore.java
@@ -23,14 +23,43 @@ import java.util.List;
 import java.util.function.Predicate;
 
 /**
- * This interface represents an abstract store for {@link Cookie} objects.
+ * Interface representing a storage mechanism for {@link Cookie} objects.
+ * The cookie store automatically manages cookie lifecycle including expiration,
+ * domain matching, path matching, and secure cookie handling according to RFC 6265.
  *
- * <p>{@link CookieManager} will call {@code CookieStore.add} to save cookies
- * for every incoming HTTP response, and call {@code CookieStore.get} to
- * retrieve cookie for every outgoing HTTP request. A CookieStore
- * is responsible for removing HttpCookie instances which have expired.
+ * <p>The {@link org.asynchttpclient.AsyncHttpClient} calls {@link #add(Uri, Cookie)}
+ * to save cookies for every incoming HTTP response, and calls {@link #get(Uri)} to
+ * retrieve matching cookies for every outgoing HTTP request.</p>
+ *
+ * <p>Implementations are responsible for:</p>
+ * <ul>
+ *   <li>Storing and retrieving cookies efficiently</li>
+ *   <li>Removing expired cookies periodically</li>
+ *   <li>Matching cookies by domain and path</li>
+ *   <li>Handling secure and host-only cookies</li>
+ *   <li>Thread-safety for concurrent access</li>
+ * </ul>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Use the default thread-safe cookie store
+ * AsyncHttpClient client = Dsl.asyncHttpClient(
+ *     new DefaultAsyncHttpClientConfig.Builder()
+ *         .setCookieStore(new ThreadSafeCookieStore())
+ *         .build()
+ * );
+ *
+ * // Manually add a cookie
+ * CookieStore store = new ThreadSafeCookieStore();
+ * Cookie cookie = new DefaultCookie("session", "abc123");
+ * store.add(Uri.create("http://example.com"), cookie);
+ *
+ * // Retrieve cookies for a URI
+ * List<Cookie> cookies = store.get(Uri.create("http://example.com/path"));
+ * }</pre>
  *
  * @since 2.1
+ * @see ThreadSafeCookieStore
  */
 public interface CookieStore extends Counted {
   /**

--- a/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
@@ -25,6 +25,43 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+/**
+ * Thread-safe implementation of {@link CookieStore} that stores cookies in memory.
+ * This implementation follows RFC 6265 cookie specifications including domain matching,
+ * path matching, secure cookies, and expiration handling.
+ *
+ * <p>Features:</p>
+ * <ul>
+ *   <li>Thread-safe concurrent access using {@link ConcurrentHashMap}</li>
+ *   <li>Automatic expiration checking when retrieving cookies</li>
+ *   <li>Domain and path matching according to RFC 6265</li>
+ *   <li>Support for host-only and persistent cookies</li>
+ *   <li>Efficient lookup by domain and path</li>
+ * </ul>
+ *
+ * <p>This is the default cookie store used by {@link org.asynchttpclient.AsyncHttpClient}
+ * when no custom cookie store is configured.</p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Create and configure with client
+ * CookieStore cookieStore = new ThreadSafeCookieStore();
+ * AsyncHttpClient client = Dsl.asyncHttpClient(
+ *     new DefaultAsyncHttpClientConfig.Builder()
+ *         .setCookieStore(cookieStore)
+ *         .build()
+ * );
+ *
+ * // Cookies are automatically stored from responses
+ * client.prepareGet("http://example.com").execute();
+ *
+ * // Retrieve all cookies
+ * List<Cookie> allCookies = cookieStore.getAll();
+ *
+ * // Clear all cookies
+ * cookieStore.clear();
+ * }</pre>
+ */
 public final class ThreadSafeCookieStore implements CookieStore {
 
   private final Map<String, Map<CookieKey, StoredCookie>> cookieJar = new ConcurrentHashMap<>();

--- a/client/src/main/java/org/asynchttpclient/exception/ChannelClosedException.java
+++ b/client/src/main/java/org/asynchttpclient/exception/ChannelClosedException.java
@@ -16,9 +16,20 @@ import java.io.IOException;
 
 import static org.asynchttpclient.util.ThrowableUtil.unknownStackTrace;
 
+/**
+ * Exception thrown when a channel has been closed unexpectedly.
+ * This exception indicates that the underlying network channel was closed before
+ * the request could be completed or sent.
+ *
+ * <p>This is a singleton exception optimized for performance by using a shared
+ * instance with no stack trace.</p>
+ */
 @SuppressWarnings("serial")
 public final class ChannelClosedException extends IOException {
 
+  /**
+   * Singleton instance of this exception with no stack trace for performance optimization.
+   */
   public static final ChannelClosedException INSTANCE = unknownStackTrace(new ChannelClosedException(), ChannelClosedException.class, "INSTANCE");
 
   private ChannelClosedException() {

--- a/client/src/main/java/org/asynchttpclient/exception/PoolAlreadyClosedException.java
+++ b/client/src/main/java/org/asynchttpclient/exception/PoolAlreadyClosedException.java
@@ -16,9 +16,20 @@ import java.io.IOException;
 
 import static org.asynchttpclient.util.ThrowableUtil.unknownStackTrace;
 
+/**
+ * Exception thrown when attempting to use a connection pool that has already been closed.
+ * This typically occurs when trying to execute a request after the {@link org.asynchttpclient.AsyncHttpClient}
+ * has been closed.
+ *
+ * <p>This is a singleton exception optimized for performance by using a shared
+ * instance with no stack trace.</p>
+ */
 @SuppressWarnings("serial")
 public class PoolAlreadyClosedException extends IOException {
 
+  /**
+   * Singleton instance of this exception with no stack trace for performance optimization.
+   */
   public static final PoolAlreadyClosedException INSTANCE = unknownStackTrace(new PoolAlreadyClosedException(), PoolAlreadyClosedException.class, "INSTANCE");
 
   private PoolAlreadyClosedException() {

--- a/client/src/main/java/org/asynchttpclient/exception/RemotelyClosedException.java
+++ b/client/src/main/java/org/asynchttpclient/exception/RemotelyClosedException.java
@@ -16,9 +16,20 @@ import java.io.IOException;
 
 import static org.asynchttpclient.util.ThrowableUtil.unknownStackTrace;
 
+/**
+ * Exception thrown when the remote server closes the connection unexpectedly.
+ * This occurs when the server terminates the connection before the request
+ * has been fully processed or the response has been completely received.
+ *
+ * <p>This is a singleton exception optimized for performance by using a shared
+ * instance with no stack trace.</p>
+ */
 @SuppressWarnings("serial")
 public final class RemotelyClosedException extends IOException {
 
+  /**
+   * Singleton instance of this exception with no stack trace for performance optimization.
+   */
   public static final RemotelyClosedException INSTANCE = unknownStackTrace(new RemotelyClosedException(), RemotelyClosedException.class, "INSTANCE");
 
   private RemotelyClosedException() {

--- a/client/src/main/java/org/asynchttpclient/exception/TooManyConnectionsException.java
+++ b/client/src/main/java/org/asynchttpclient/exception/TooManyConnectionsException.java
@@ -14,9 +14,26 @@ package org.asynchttpclient.exception;
 
 import java.io.IOException;
 
+/**
+ * Exception thrown when the maximum number of total connections has been reached.
+ * This occurs when the client attempts to open a new connection but has already
+ * reached the configured {@code maxConnections} limit.
+ *
+ * <p>To resolve this, either:</p>
+ * <ul>
+ *   <li>Increase the {@code maxConnections} configuration value</li>
+ *   <li>Ensure connections are being properly closed and returned to the pool</li>
+ *   <li>Reduce the number of concurrent requests</li>
+ * </ul>
+ */
 @SuppressWarnings("serial")
 public class TooManyConnectionsException extends IOException {
 
+  /**
+   * Constructs a new exception with the maximum number of connections.
+   *
+   * @param max the maximum number of connections that was exceeded
+   */
   public TooManyConnectionsException(int max) {
     super("Too many connections: " + max);
   }

--- a/client/src/main/java/org/asynchttpclient/exception/TooManyConnectionsPerHostException.java
+++ b/client/src/main/java/org/asynchttpclient/exception/TooManyConnectionsPerHostException.java
@@ -14,9 +14,26 @@ package org.asynchttpclient.exception;
 
 import java.io.IOException;
 
+/**
+ * Exception thrown when the maximum number of connections per host has been reached.
+ * This occurs when the client attempts to open a new connection to a specific host
+ * but has already reached the configured {@code maxConnectionsPerHost} limit for that host.
+ *
+ * <p>To resolve this, either:</p>
+ * <ul>
+ *   <li>Increase the {@code maxConnectionsPerHost} configuration value</li>
+ *   <li>Ensure connections are being properly closed and returned to the pool</li>
+ *   <li>Reduce the number of concurrent requests to this specific host</li>
+ * </ul>
+ */
 @SuppressWarnings("serial")
 public class TooManyConnectionsPerHostException extends IOException {
 
+  /**
+   * Constructs a new exception with the maximum number of connections per host.
+   *
+   * @param max the maximum number of connections per host that was exceeded
+   */
   public TooManyConnectionsPerHostException(int max) {
     super("Too many connections: " + max);
   }

--- a/client/src/main/java/org/asynchttpclient/filter/FilterException.java
+++ b/client/src/main/java/org/asynchttpclient/filter/FilterException.java
@@ -13,16 +13,51 @@
 package org.asynchttpclient.filter;
 
 /**
- * An exception that can be thrown by an {@link org.asynchttpclient.AsyncHandler} to interrupt invocation of
- * the {@link RequestFilter} and {@link ResponseFilter}. It also interrupt the request and response processing.
+ * Exception that can be thrown by filters to interrupt filter chain processing
+ * and abort the current request or response handling.
+ *
+ * <p>When a filter throws this exception:</p>
+ * <ul>
+ *   <li>The filter chain execution is immediately stopped</li>
+ *   <li>No subsequent filters in the chain are invoked</li>
+ *   <li>The request or response processing is terminated</li>
+ *   <li>The exception is propagated to the {@link org.asynchttpclient.AsyncHandler}</li>
+ * </ul>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Abort request if authentication token is missing
+ * public <T> FilterContext<T> filter(FilterContext<T> ctx) throws FilterException {
+ *     if (ctx.getRequest().getHeaders().get("Authorization") == null) {
+ *         throw new FilterException("Missing authentication token");
+ *     }
+ *     return ctx;
+ * }
+ *
+ * // Abort on too many retries
+ * if (retryCount > maxRetries) {
+ *     throw new FilterException("Maximum retry count exceeded", originalException);
+ * }
+ * }</pre>
  */
 @SuppressWarnings("serial")
 public class FilterException extends Exception {
 
+  /**
+   * Constructs a new filter exception with the specified detail message.
+   *
+   * @param message the detail message
+   */
   public FilterException(final String message) {
     super(message);
   }
 
+  /**
+   * Constructs a new filter exception with the specified detail message and cause.
+   *
+   * @param message the detail message
+   * @param cause the cause of this exception
+   */
   public FilterException(final String message, final Throwable cause) {
     super(message, cause);
   }

--- a/client/src/main/java/org/asynchttpclient/filter/RequestFilter.java
+++ b/client/src/main/java/org/asynchttpclient/filter/RequestFilter.java
@@ -13,19 +13,55 @@
 package org.asynchttpclient.filter;
 
 /**
- * A Filter interface that gets invoked before making an actual request.
+ * Filter interface for preprocessing requests before they are sent to the remote server.
+ * Request filters are executed in the order they are added to the client configuration.
+ *
+ * <p>Request filters can be used to:</p>
+ * <ul>
+ *   <li>Add, modify, or remove request headers</li>
+ *   <li>Modify request parameters or body</li>
+ *   <li>Implement custom authentication schemes</li>
+ *   <li>Log or audit requests</li>
+ *   <li>Wrap or replace the {@link org.asynchttpclient.AsyncHandler}</li>
+ *   <li>Abort requests by throwing {@link FilterException}</li>
+ * </ul>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Add an authentication header to all requests
+ * public class AuthFilter implements RequestFilter {
+ *     @Override
+ *     public <T> FilterContext<T> filter(FilterContext<T> ctx) throws FilterException {
+ *         Request originalRequest = ctx.getRequest();
+ *         Request newRequest = new RequestBuilder(originalRequest)
+ *             .addHeader("Authorization", "Bearer " + getToken())
+ *             .build();
+ *         return new FilterContext.FilterContextBuilder<>(ctx)
+ *             .request(newRequest)
+ *             .build();
+ *     }
+ * }
+ *
+ * // Register the filter
+ * AsyncHttpClient client = Dsl.asyncHttpClient(
+ *     new DefaultAsyncHttpClientConfig.Builder()
+ *         .addRequestFilter(new AuthFilter())
+ *         .build()
+ * );
+ * }</pre>
  */
 public interface RequestFilter {
 
   /**
-   * An {@link org.asynchttpclient.AsyncHttpClient} will invoke {@link RequestFilter#filter} and will use the
-   * returned {@link FilterContext#getRequest()} and {@link FilterContext#getAsyncHandler()} to continue the request
-   * processing.
+   * Processes the request before it is sent to the remote server.
+   * The {@link org.asynchttpclient.AsyncHttpClient} will use the returned {@link FilterContext}
+   * to obtain the (potentially modified) {@link FilterContext#getRequest()} and
+   * {@link FilterContext#getAsyncHandler()} for continuing the request processing.
    *
-   * @param ctx a {@link FilterContext}
+   * @param ctx the filter context containing the request and handler
    * @param <T> the handler result type
-   * @return {@link FilterContext}. The {@link FilterContext} instance may not the same as the original one.
-   * @throws FilterException to interrupt the filter processing.
+   * @return a {@link FilterContext}, which may be the same as or different from the input context
+   * @throws FilterException to abort the request and stop filter chain processing
    */
   <T> FilterContext<T> filter(FilterContext<T> ctx) throws FilterException;
 }

--- a/client/src/main/java/org/asynchttpclient/filter/ThrottleRequestFilter.java
+++ b/client/src/main/java/org/asynchttpclient/filter/ThrottleRequestFilter.java
@@ -19,22 +19,64 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 /**
- * A {@link org.asynchttpclient.filter.RequestFilter} throttles requests and block when the number of permits is reached,
- * waiting for the response to arrives before executing the next request.
+ * A {@link RequestFilter} that throttles concurrent requests using a semaphore-based mechanism.
+ * This filter blocks new requests when the maximum number of concurrent requests is reached,
+ * waiting for responses to complete before allowing new requests to proceed.
+ *
+ * <p>The filter automatically releases permits when requests complete (either successfully or with an error),
+ * using the {@link ReleasePermitOnComplete} wrapper.</p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Limit to 10 concurrent requests, wait indefinitely for a slot
+ * ThrottleRequestFilter throttle = new ThrottleRequestFilter(10);
+ *
+ * // Limit to 5 concurrent requests, wait max 5 seconds for a slot
+ * ThrottleRequestFilter throttle = new ThrottleRequestFilter(5, 5000);
+ *
+ * // Limit to 20 concurrent requests with fair semaphore scheduling
+ * ThrottleRequestFilter throttle = new ThrottleRequestFilter(20, Integer.MAX_VALUE, true);
+ *
+ * // Register with client
+ * AsyncHttpClient client = Dsl.asyncHttpClient(
+ *     new DefaultAsyncHttpClientConfig.Builder()
+ *         .addRequestFilter(throttle)
+ *         .build()
+ * );
+ * }</pre>
  */
 public class ThrottleRequestFilter implements RequestFilter {
   private static final Logger logger = LoggerFactory.getLogger(ThrottleRequestFilter.class);
   private final Semaphore available;
   private final int maxWait;
 
+  /**
+   * Constructs a throttle filter with the specified maximum concurrent requests.
+   * Requests will wait indefinitely for a permit to become available.
+   *
+   * @param maxConnections the maximum number of concurrent requests
+   */
   public ThrottleRequestFilter(int maxConnections) {
     this(maxConnections, Integer.MAX_VALUE);
   }
 
+  /**
+   * Constructs a throttle filter with the specified maximum concurrent requests and wait timeout.
+   *
+   * @param maxConnections the maximum number of concurrent requests
+   * @param maxWait the maximum time in milliseconds to wait for a permit
+   */
   public ThrottleRequestFilter(int maxConnections, int maxWait) {
     this(maxConnections, maxWait, false);
   }
 
+  /**
+   * Constructs a throttle filter with full configuration options.
+   *
+   * @param maxConnections the maximum number of concurrent requests
+   * @param maxWait the maximum time in milliseconds to wait for a permit
+   * @param fair {@code true} to use fair semaphore scheduling (FIFO), {@code false} for non-fair
+   */
   public ThrottleRequestFilter(int maxConnections, int maxWait, boolean fair) {
     this.maxWait = maxWait;
     available = new Semaphore(maxConnections, fair);

--- a/client/src/main/java/org/asynchttpclient/handler/MaxRedirectException.java
+++ b/client/src/main/java/org/asynchttpclient/handler/MaxRedirectException.java
@@ -14,11 +14,43 @@
 package org.asynchttpclient.handler;
 
 /**
- * Thrown when the {@link org.asynchttpclient.DefaultAsyncHttpClientConfig#getMaxRedirects()} has been reached.
+ * Exception thrown when the maximum number of redirects has been exceeded.
+ * <p>
+ * This exception is thrown when a request follows more HTTP redirects than the limit
+ * configured via {@link org.asynchttpclient.DefaultAsyncHttpClientConfig#getMaxRedirects()}.
+ * The default maximum is typically 5 redirects, but can be configured per client.
+ * <p>
+ * This prevents infinite redirect loops and excessive redirect chains that could
+ * indicate a misconfigured server or a malicious redirect attack.
+ *
+ * <p><b>Example:</b></p>
+ * <pre>{@code
+ * AsyncHttpClient client = new DefaultAsyncHttpClient(
+ *     new DefaultAsyncHttpClientConfig.Builder()
+ *         .setMaxRedirects(3)
+ *         .build()
+ * );
+ *
+ * try {
+ *     client.prepareGet("http://example.com/redirect-loop").execute().get();
+ * } catch (ExecutionException e) {
+ *     if (e.getCause() instanceof MaxRedirectException) {
+ *         // Handle too many redirects
+ *     }
+ * }
+ * }</pre>
  */
 public class MaxRedirectException extends Exception {
   private static final long serialVersionUID = 1L;
 
+  /**
+   * Creates a new MaxRedirectException with the specified message.
+   * <p>
+   * The exception is created with suppression and stack trace writing disabled
+   * for performance reasons, as this is typically a well-understood control flow exception.
+   *
+   * @param msg the detail message explaining why the maximum redirect limit was exceeded
+   */
   public MaxRedirectException(String msg) {
     super(msg, null, true, false);
   }

--- a/client/src/main/java/org/asynchttpclient/handler/StreamedAsyncHandler.java
+++ b/client/src/main/java/org/asynchttpclient/handler/StreamedAsyncHandler.java
@@ -17,15 +17,69 @@ import org.asynchttpclient.HttpResponseBodyPart;
 import org.reactivestreams.Publisher;
 
 /**
- * AsyncHandler that uses reactive streams to handle the request.
+ * An {@link AsyncHandler} that uses reactive streams to handle HTTP response bodies.
+ * <p>
+ * This interface extends {@link AsyncHandler} to provide streaming capabilities through
+ * the Reactive Streams API. Instead of receiving body parts one at a time through
+ * {@link AsyncHandler#onBodyPartReceived}, implementations receive a {@link Publisher}
+ * that produces body parts, enabling backpressure-aware consumption of the response body.
+ * <p>
+ * The {@link #onStream} method is invoked once when the response body begins streaming.
+ * It may not be called if the response has no body.
+ *
+ * <p><b>Usage Example:</b></p>
+ * <pre>{@code
+ * StreamedAsyncHandler<Response> handler = new StreamedAsyncHandler<Response>() {
+ *     @Override
+ *     public State onStream(Publisher<HttpResponseBodyPart> publisher) {
+ *         publisher.subscribe(new Subscriber<HttpResponseBodyPart>() {
+ *             private Subscription subscription;
+ *
+ *             @Override
+ *             public void onSubscribe(Subscription s) {
+ *                 this.subscription = s;
+ *                 s.request(1); // Request first item
+ *             }
+ *
+ *             @Override
+ *             public void onNext(HttpResponseBodyPart bodyPart) {
+ *                 // Process body part
+ *                 subscription.request(1); // Request next item
+ *             }
+ *
+ *             @Override
+ *             public void onError(Throwable t) {
+ *                 // Handle error
+ *             }
+ *
+ *             @Override
+ *             public void onComplete() {
+ *                 // Body streaming complete
+ *             }
+ *         });
+ *         return State.CONTINUE;
+ *     }
+ *
+ *     // Implement other AsyncHandler methods...
+ * };
+ * }</pre>
+ *
+ * @param <T> the response type
  */
 public interface StreamedAsyncHandler<T> extends AsyncHandler<T> {
 
   /**
-   * Called when the body is received. May not be called if there's no body.
+   * Invoked when the response body begins streaming.
+   * <p>
+   * This method provides a {@link Publisher} of {@link HttpResponseBodyPart} objects
+   * that can be consumed using the Reactive Streams API. The publisher will emit body
+   * parts as they arrive from the server, allowing for backpressure-aware processing.
+   * <p>
+   * This method may not be called if the response has no body (e.g., HEAD requests
+   * or 204 No Content responses).
    *
-   * @param publisher The publisher of response body parts.
-   * @return Whether to continue or abort.
+   * @param publisher the publisher that will emit response body parts
+   * @return {@link State#CONTINUE} to proceed with processing, or {@link State#ABORT} to cancel the request
    */
   State onStream(Publisher<HttpResponseBodyPart> publisher);
 }

--- a/client/src/main/java/org/asynchttpclient/handler/TransferCompletionHandler.java
+++ b/client/src/main/java/org/asynchttpclient/handler/TransferCompletionHandler.java
@@ -22,36 +22,61 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
- * A {@link org.asynchttpclient.AsyncHandler} that can be used to notify a set of {@link TransferListener}
- * <br>
- * <blockquote>
- * <pre>
- * AsyncHttpClient client = new AsyncHttpClient();
- * TransferCompletionHandler tl = new TransferCompletionHandler();
- * tl.addTransferListener(new TransferListener() {
+ * An {@link org.asynchttpclient.AsyncHandler} that notifies registered {@link TransferListener}s
+ * of various transfer events during request and response processing.
+ * <p>
+ * This handler extends {@link AsyncCompletionHandlerBase} and provides a mechanism to track
+ * the progress of HTTP requests and responses by notifying listeners at key points:
+ * <ul>
+ *   <li>Request headers sent</li>
+ *   <li>Response headers received</li>
+ *   <li>Bytes sent (upload progress)</li>
+ *   <li>Bytes received (download progress)</li>
+ *   <li>Request/response completion</li>
+ *   <li>Exceptions</li>
+ * </ul>
+ * <p>
+ * By default, this handler does not accumulate response bytes in memory. To access the
+ * response body via {@link org.asynchttpclient.Response#getResponseBody()}, construct
+ * the handler with {@code accumulateResponseBytes = true}.
  *
- * public void onRequestHeadersSent(HttpHeaders headers) {
- * }
+ * <p><b>Usage Example:</b></p>
+ * <pre>{@code
+ * TransferCompletionHandler handler = new TransferCompletionHandler();
+ * handler.addTransferListener(new TransferListener() {
+ *     @Override
+ *     public void onRequestHeadersSent(HttpHeaders headers) {
+ *         System.out.println("Request headers sent");
+ *     }
  *
- * public void onResponseHeadersReceived(HttpHeaders headers) {
- * }
+ *     @Override
+ *     public void onResponseHeadersReceived(HttpHeaders headers) {
+ *         System.out.println("Response headers received");
+ *     }
  *
- * public void onBytesReceived(ByteBuffer buffer) {
- * }
+ *     @Override
+ *     public void onBytesReceived(byte[] bytes) {
+ *         System.out.println("Received " + bytes.length + " bytes");
+ *     }
  *
- * public void onBytesSent(long amount, long current, long total) {
- * }
+ *     @Override
+ *     public void onBytesSent(long amount, long current, long total) {
+ *         System.out.println("Sent " + current + " of " + total + " bytes");
+ *     }
  *
- * public void onRequestResponseCompleted() {
- * }
+ *     @Override
+ *     public void onRequestResponseCompleted() {
+ *         System.out.println("Transfer completed");
+ *     }
  *
- * public void onThrowable(Throwable t) {
- * }
+ *     @Override
+ *     public void onThrowable(Throwable t) {
+ *         System.err.println("Error: " + t.getMessage());
+ *     }
  * });
  *
- * Response response = httpClient.prepareGet("http://...").execute(tl).get();
- * </pre>
- * </blockquote>
+ * Response response = client.prepareGet("http://example.com").execute(handler).get();
+ * }</pre>
  */
 public class TransferCompletionHandler extends AsyncCompletionHandlerBase {
   private final static Logger logger = LoggerFactory.getLogger(TransferCompletionHandler.class);
@@ -60,49 +85,108 @@ public class TransferCompletionHandler extends AsyncCompletionHandlerBase {
   private HttpHeaders headers;
 
   /**
-   * Create a TransferCompletionHandler that will not accumulate bytes. The resulting {@link org.asynchttpclient.Response#getResponseBody()},
-   * {@link org.asynchttpclient.Response#getResponseBodyAsStream()} will throw an IllegalStateException if called.
+   * Creates a TransferCompletionHandler that does not accumulate response bytes.
+   * <p>
+   * When using this constructor, the response body is not stored in memory.
+   * Attempting to call {@link org.asynchttpclient.Response#getResponseBody()} or
+   * {@link org.asynchttpclient.Response#getResponseBodyAsStream()} will throw an
+   * {@link IllegalStateException}.
+   * <p>
+   * This is useful when you only need to track transfer progress through listeners
+   * and don't need to access the response body through the Response object.
    */
   public TransferCompletionHandler() {
     this(false);
   }
 
   /**
-   * Create a TransferCompletionHandler that can or cannot accumulate bytes and make it available when {@link org.asynchttpclient.Response#getResponseBody()} get called. The
-   * default is false.
+   * Creates a TransferCompletionHandler with optional response byte accumulation.
+   * <p>
+   * When {@code accumulateResponseBytes} is {@code true}, the response body is stored
+   * in memory and can be accessed via {@link org.asynchttpclient.Response#getResponseBody()}.
+   * When {@code false}, response body methods will throw an {@link IllegalStateException}.
    *
-   * @param accumulateResponseBytes true to accumulates bytes in memory.
+   * @param accumulateResponseBytes {@code true} to accumulate response bytes in memory,
+   *                                {@code false} to skip accumulation
    */
   public TransferCompletionHandler(boolean accumulateResponseBytes) {
     this.accumulateResponseBytes = accumulateResponseBytes;
   }
 
+  /**
+   * Adds a listener to be notified of transfer events.
+   * <p>
+   * Multiple listeners can be added. All registered listeners will be notified
+   * of transfer events in the order they were added.
+   *
+   * @param t the listener to add
+   * @return this handler for method chaining
+   */
   public TransferCompletionHandler addTransferListener(TransferListener t) {
     listeners.offer(t);
     return this;
   }
 
+  /**
+   * Removes a previously registered listener.
+   * <p>
+   * If the listener was added multiple times, only the first occurrence is removed.
+   *
+   * @param t the listener to remove
+   * @return this handler for method chaining
+   */
   public TransferCompletionHandler removeTransferListener(TransferListener t) {
     listeners.remove(t);
     return this;
   }
 
+  /**
+   * Sets the request headers that will be sent to listeners when {@link #onHeadersWritten()} is called.
+   * <p>
+   * This method should be called before the request is executed to ensure listeners
+   * are notified with the correct headers.
+   *
+   * @param headers the request headers to be sent to listeners
+   */
   public void headers(HttpHeaders headers) {
     this.headers = headers;
   }
 
+  /**
+   * Processes response headers and notifies all registered listeners.
+   *
+   * @param headers the HTTP response headers received from the server
+   * @return the state returned by the superclass method
+   * @throws Exception if an error occurs during processing
+   */
   @Override
   public State onHeadersReceived(final HttpHeaders headers) throws Exception {
     fireOnHeaderReceived(headers);
     return super.onHeadersReceived(headers);
   }
 
+  /**
+   * Processes trailing response headers and notifies all registered listeners.
+   *
+   * @param headers the trailing HTTP response headers received from the server
+   * @return the state returned by the superclass method
+   * @throws Exception if an error occurs during processing
+   */
   @Override
   public State onTrailingHeadersReceived(HttpHeaders headers) throws Exception {
     fireOnHeaderReceived(headers);
     return super.onHeadersReceived(headers);
   }
 
+  /**
+   * Processes a response body chunk and notifies all registered listeners.
+   * <p>
+   * If byte accumulation is enabled, delegates to the superclass to store the bytes.
+   *
+   * @param content the chunk of response body received from the server
+   * @return {@link State#CONTINUE} to proceed with processing
+   * @throws Exception if an error occurs during processing
+   */
   @Override
   public State onBodyPartReceived(final HttpResponseBodyPart content) throws Exception {
     State s = State.CONTINUE;
@@ -113,12 +197,24 @@ public class TransferCompletionHandler extends AsyncCompletionHandlerBase {
     return s;
   }
 
+  /**
+   * Completes the request and notifies all registered listeners.
+   *
+   * @param response the complete response received from the server
+   * @return the response object
+   * @throws Exception if an error occurs during completion
+   */
   @Override
   public Response onCompleted(Response response) throws Exception {
     fireOnEnd();
     return response;
   }
 
+  /**
+   * Invoked when request headers have been written, notifies all registered listeners.
+   *
+   * @return {@link State#CONTINUE} to proceed with the request
+   */
   @Override
   public State onHeadersWritten() {
     if (headers != null) {
@@ -127,12 +223,25 @@ public class TransferCompletionHandler extends AsyncCompletionHandlerBase {
     return State.CONTINUE;
   }
 
+  /**
+   * Invoked during request body upload to report progress, notifies all registered listeners.
+   *
+   * @param amount the number of bytes written in the current write operation
+   * @param current the cumulative number of bytes written so far
+   * @param total the total number of bytes to be written
+   * @return {@link State#CONTINUE} to proceed with the upload
+   */
   @Override
   public State onContentWriteProgress(long amount, long current, long total) {
     fireOnBytesSent(amount, current, total);
     return State.CONTINUE;
   }
 
+  /**
+   * Handles exceptions that occur during request processing, notifies all registered listeners.
+   *
+   * @param t the exception that occurred
+   */
   @Override
   public void onThrowable(Throwable t) {
     fireOnThrowable(t);

--- a/client/src/main/java/org/asynchttpclient/handler/TransferListener.java
+++ b/client/src/main/java/org/asynchttpclient/handler/TransferListener.java
@@ -15,49 +15,120 @@ package org.asynchttpclient.handler;
 import io.netty.handler.codec.http.HttpHeaders;
 
 /**
- * A simple interface an application can implements in order to received byte transfer information.
+ * A listener interface for receiving notifications about HTTP request and response transfer events.
+ * <p>
+ * Implementations of this interface can be registered with a {@link TransferCompletionHandler}
+ * to track the progress of HTTP requests and responses, including header transmission,
+ * byte transfer progress, completion, and error handling.
+ * <p>
+ * This interface is particularly useful for:
+ * <ul>
+ *   <li>Monitoring upload and download progress</li>
+ *   <li>Implementing custom logging or metrics collection</li>
+ *   <li>Building progress bars or status indicators</li>
+ *   <li>Debugging network communication</li>
+ * </ul>
+ *
+ * <p><b>Usage Example:</b></p>
+ * <pre>{@code
+ * TransferListener listener = new TransferListener() {
+ *     private long totalBytesReceived = 0;
+ *
+ *     @Override
+ *     public void onRequestHeadersSent(HttpHeaders headers) {
+ *         System.out.println("Sent headers: " + headers.size());
+ *     }
+ *
+ *     @Override
+ *     public void onResponseHeadersReceived(HttpHeaders headers) {
+ *         System.out.println("Received headers: " + headers.size());
+ *     }
+ *
+ *     @Override
+ *     public void onBytesReceived(byte[] bytes) {
+ *         totalBytesReceived += bytes.length;
+ *         System.out.println("Downloaded: " + totalBytesReceived + " bytes");
+ *     }
+ *
+ *     @Override
+ *     public void onBytesSent(long amount, long current, long total) {
+ *         int percent = (int) ((current * 100) / total);
+ *         System.out.println("Upload: " + percent + "%");
+ *     }
+ *
+ *     @Override
+ *     public void onRequestResponseCompleted() {
+ *         System.out.println("Transfer complete");
+ *     }
+ *
+ *     @Override
+ *     public void onThrowable(Throwable t) {
+ *         System.err.println("Error: " + t.getMessage());
+ *     }
+ * };
+ * }</pre>
  */
 public interface TransferListener {
 
   /**
-   * Invoked when the request bytes are starting to get send.
+   * Invoked when the request headers begin to be sent to the server.
+   * <p>
+   * This is called after the connection is established but before the request body
+   * (if any) is transmitted.
    *
-   * @param headers the headers
+   * @param headers the HTTP request headers being sent
    */
   void onRequestHeadersSent(HttpHeaders headers);
 
   /**
-   * Invoked when the response bytes are starting to get received.
+   * Invoked when the response headers are received from the server.
+   * <p>
+   * This is called after the server responds with headers but before the response
+   * body (if any) is received.
    *
-   * @param headers the headers
+   * @param headers the HTTP response headers received
    */
   void onResponseHeadersReceived(HttpHeaders headers);
 
   /**
-   * Invoked every time response's chunk are received.
+   * Invoked each time a chunk of the response body is received.
+   * <p>
+   * This method may be called multiple times for a single response as data arrives
+   * in chunks from the server. The frequency depends on network conditions and
+   * the size of the response.
    *
-   * @param bytes a {@link byte[]}
+   * @param bytes the chunk of response body bytes received
    */
   void onBytesReceived(byte[] bytes);
 
   /**
-   * Invoked every time request's chunk are sent.
+   * Invoked periodically during the request body upload to report progress.
+   * <p>
+   * This method is called multiple times as the request body is sent to the server,
+   * allowing tracking of upload progress. It is only invoked for requests that have
+   * a body (POST, PUT, etc.) and when the body requires multiple write operations.
    *
-   * @param amount  The amount of bytes to transfer
-   * @param current The amount of bytes transferred
-   * @param total   The total number of bytes transferred
+   * @param amount the number of bytes written in the current write operation
+   * @param current the cumulative number of bytes written so far
+   * @param total the total number of bytes to be written
    */
   void onBytesSent(long amount, long current, long total);
 
   /**
-   * Invoked when the response bytes are been fully received.
+   * Invoked when the request and response transfer has been fully completed.
+   * <p>
+   * This is called after all request bytes have been sent and all response bytes
+   * have been received, indicating successful completion of the HTTP transaction.
    */
   void onRequestResponseCompleted();
 
   /**
-   * Invoked when there is an unexpected issue.
+   * Invoked when an error or exception occurs during the request or response processing.
+   * <p>
+   * This method is called for any unexpected issues that occur during the HTTP
+   * transaction, including network errors, timeouts, or protocol violations.
    *
-   * @param t a {@link Throwable}
+   * @param t the exception or error that occurred
    */
   void onThrowable(Throwable t);
 }

--- a/client/src/main/java/org/asynchttpclient/handler/resumable/ResumableListener.java
+++ b/client/src/main/java/org/asynchttpclient/handler/resumable/ResumableListener.java
@@ -16,27 +16,84 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /**
- * A listener class that can be used to digest the bytes from an {@link ResumableAsyncHandler}
+ * A listener interface for processing response body bytes in a resumable download.
+ * <p>
+ * Implementations of this interface are used by {@link ResumableAsyncHandler} to
+ * receive and store response body bytes. The listener is responsible for:
+ * <ul>
+ *   <li>Writing received bytes to their final destination (e.g., a file)</li>
+ *   <li>Tracking the current download position</li>
+ *   <li>Providing the length of previously downloaded bytes for resume operations</li>
+ * </ul>
+ * <p>
+ * The most common implementation is {@link ResumableRandomAccessFileListener}, which
+ * writes bytes to a file using {@link java.io.RandomAccessFile} for seek support.
+ *
+ * <p><b>Usage Example:</b></p>
+ * <pre>{@code
+ * // Custom implementation example
+ * public class CustomResumableListener implements ResumableListener {
+ *     private final OutputStream output;
+ *     private long bytesWritten = 0;
+ *
+ *     public CustomResumableListener(OutputStream output) {
+ *         this.output = output;
+ *     }
+ *
+ *     @Override
+ *     public void onBytesReceived(ByteBuffer buffer) throws IOException {
+ *         byte[] bytes = new byte[buffer.remaining()];
+ *         buffer.get(bytes);
+ *         output.write(bytes);
+ *         bytesWritten += bytes.length;
+ *     }
+ *
+ *     @Override
+ *     public void onAllBytesReceived() {
+ *         try {
+ *             output.close();
+ *         } catch (IOException e) {
+ *             // Handle exception
+ *         }
+ *     }
+ *
+ *     @Override
+ *     public long length() {
+ *         return bytesWritten;
+ *     }
+ * }
+ * }</pre>
  */
 public interface ResumableListener {
 
   /**
-   * Invoked when some bytes are available to digest.
+   * Invoked when a chunk of response body bytes is available.
+   * <p>
+   * Implementations should write the bytes to their destination (e.g., file, stream)
+   * and update their internal state to track the download progress. This method
+   * may be called multiple times for a single response as data arrives in chunks.
    *
-   * @param byteBuffer the current bytes
-   * @throws IOException exception while writing the byteBuffer
+   * @param byteBuffer the ByteBuffer containing the response body chunk
+   * @throws IOException if an I/O error occurs while processing the bytes
    */
   void onBytesReceived(ByteBuffer byteBuffer) throws IOException;
 
   /**
-   * Invoked when all the bytes has been successfully transferred.
+   * Invoked when all response body bytes have been successfully received.
+   * <p>
+   * Implementations should perform cleanup operations such as closing files
+   * or streams. This method is called once at the end of a successful download.
    */
   void onAllBytesReceived();
 
   /**
-   * Return the length of previously downloaded bytes.
+   * Returns the number of bytes that have been previously downloaded.
+   * <p>
+   * This value is used to determine the starting position when resuming an
+   * interrupted download. It should return the actual number of bytes successfully
+   * written to the destination.
    *
-   * @return the length of previously downloaded bytes
+   * @return the number of bytes previously downloaded, or 0 if starting fresh
    */
   long length();
 }

--- a/client/src/main/java/org/asynchttpclient/netty/EagerResponseBodyPart.java
+++ b/client/src/main/java/org/asynchttpclient/netty/EagerResponseBodyPart.java
@@ -20,13 +20,27 @@ import java.nio.ByteBuffer;
 import static org.asynchttpclient.netty.util.ByteBufUtils.byteBuf2Bytes;
 
 /**
- * A callback class used when an HTTP response body is received.
- * Bytes are eagerly fetched from the ByteBuf
+ * Response body part that eagerly copies bytes from the Netty ByteBuf.
+ * <p>
+ * This implementation immediately extracts bytes from the ByteBuf upon construction,
+ * allowing the original buffer to be released quickly. This is the default strategy
+ * and is suitable for most use cases where response bodies are small to medium sized.
+ * </p>
+ * <p>
+ * The eager strategy trades memory (for the byte copy) for simplified lifecycle management
+ * and avoids the need to manually manage ByteBuf reference counts.
+ * </p>
  */
 public class EagerResponseBodyPart extends HttpResponseBodyPart {
 
   private final byte[] bytes;
 
+  /**
+   * Constructs an eager response body part.
+   *
+   * @param buf the Netty ByteBuf containing the response body chunk
+   * @param last whether this is the final body part
+   */
   public EagerResponseBodyPart(ByteBuf buf, boolean last) {
     super(last);
     bytes = byteBuf2Bytes(buf);

--- a/client/src/main/java/org/asynchttpclient/netty/NettyResponse.java
+++ b/client/src/main/java/org/asynchttpclient/netty/NettyResponse.java
@@ -39,7 +39,13 @@ import static org.asynchttpclient.util.MiscUtils.isNonEmpty;
 import static org.asynchttpclient.util.MiscUtils.withDefault;
 
 /**
- * Wrapper around the {@link org.asynchttpclient.Response} API.
+ * Netty-based implementation of the {@link Response} interface.
+ * <p>
+ * This class aggregates the HTTP response status, headers, and body parts collected
+ * during the request-response cycle. It provides convenient methods for accessing
+ * response data in various formats (bytes, String, ByteBuffer, InputStream) and
+ * handles cookie parsing from Set-Cookie headers.
+ * </p>
  */
 public class NettyResponse implements Response {
 
@@ -48,6 +54,13 @@ public class NettyResponse implements Response {
   private final HttpResponseStatus status;
   private List<Cookie> cookies;
 
+  /**
+   * Constructs a new NettyResponse.
+   *
+   * @param status the HTTP response status
+   * @param headers the HTTP response headers
+   * @param bodyParts the list of body parts received
+   */
   public NettyResponse(HttpResponseStatus status,
                        HttpHeaders headers,
                        List<HttpResponseBodyPart> bodyParts) {

--- a/client/src/main/java/org/asynchttpclient/netty/NettyResponseStatus.java
+++ b/client/src/main/java/org/asynchttpclient/netty/NettyResponseStatus.java
@@ -21,7 +21,12 @@ import org.asynchttpclient.uri.Uri;
 import java.net.SocketAddress;
 
 /**
- * A class that represent the HTTP response' status line (code + text)
+ * Netty-based implementation of HTTP response status information.
+ * <p>
+ * This class wraps a Netty {@link HttpResponse} and extracts status code, status text,
+ * protocol version, and socket address information. It provides access to the complete
+ * HTTP status line and connection details.
+ * </p>
  */
 public class NettyResponseStatus extends HttpResponseStatus {
 
@@ -29,6 +34,13 @@ public class NettyResponseStatus extends HttpResponseStatus {
   private final SocketAddress remoteAddress;
   private final SocketAddress localAddress;
 
+  /**
+   * Constructs a new NettyResponseStatus.
+   *
+   * @param uri the request URI
+   * @param response the Netty HTTP response
+   * @param channel the channel the response was received on (may be null)
+   */
   public NettyResponseStatus(Uri uri, HttpResponse response, Channel channel) {
     super(uri);
     this.response = response;

--- a/client/src/main/java/org/asynchttpclient/netty/channel/ChannelState.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/ChannelState.java
@@ -13,6 +13,34 @@
  */
 package org.asynchttpclient.netty.channel;
 
+/**
+ * Represents the lifecycle state of a Netty channel in the connection pool.
+ * <p>
+ * Channels transition through various states from creation to closure, with
+ * pooling and reconnection states in between. This enum tracks these states
+ * for connection management and debugging purposes.
+ * </p>
+ */
 public enum ChannelState {
-  NEW, POOLED, RECONNECTED, CLOSED,
+  /**
+   * Indicates a newly created channel that has not been used yet.
+   */
+  NEW,
+
+  /**
+   * Indicates a channel that has been returned to the connection pool
+   * and is available for reuse.
+   */
+  POOLED,
+
+  /**
+   * Indicates a channel that was taken from the pool and reconnected
+   * for a new request.
+   */
+  RECONNECTED,
+
+  /**
+   * Indicates a channel that has been closed and is no longer usable.
+   */
+  CLOSED,
 }

--- a/client/src/main/java/org/asynchttpclient/netty/channel/Channels.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/Channels.java
@@ -20,6 +20,14 @@ import org.asynchttpclient.netty.DiscardEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Utility class for managing Netty channel attributes and lifecycle operations.
+ * <p>
+ * This class provides helper methods for attaching state to channels, checking
+ * channel activity, and performing safe channel operations. It uses Netty's
+ * attribute system to store per-channel state information.
+ * </p>
+ */
 public class Channels {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Channels.class);
@@ -27,31 +35,95 @@ public class Channels {
   private static final AttributeKey<Object> DEFAULT_ATTRIBUTE = AttributeKey.valueOf("default");
   private static final AttributeKey<Active> ACTIVE_TOKEN_ATTRIBUTE = AttributeKey.valueOf("activeToken");
 
+  /**
+   * Retrieves the attribute attached to the channel.
+   * <p>
+   * The attribute typically contains state information such as a {@link org.asynchttpclient.netty.NettyResponseFuture},
+   * {@link org.asynchttpclient.netty.handler.StreamedResponsePublisher}, or {@link org.asynchttpclient.netty.DiscardEvent}.
+   * </p>
+   *
+   * @param channel the channel to query
+   * @return the attribute object, or null if no attribute is set
+   */
   public static Object getAttribute(Channel channel) {
     Attribute<Object> attr = channel.attr(DEFAULT_ATTRIBUTE);
     return attr != null ? attr.get() : null;
   }
 
+  /**
+   * Sets an attribute on the channel.
+   * <p>
+   * This method attaches state information to the channel for use by handlers
+   * in the pipeline. Common attributes include response futures and callbacks.
+   * </p>
+   *
+   * @param channel the channel to modify
+   * @param o the attribute object to attach
+   */
   public static void setAttribute(Channel channel, Object o) {
     channel.attr(DEFAULT_ATTRIBUTE).set(o);
   }
 
+  /**
+   * Marks the channel for discard by setting the DISCARD attribute.
+   * <p>
+   * When a channel is marked for discard, handlers will ignore incoming
+   * messages and the channel will be closed rather than returned to the pool.
+   * </p>
+   *
+   * @param channel the channel to mark for discard
+   */
   public static void setDiscard(Channel channel) {
     setAttribute(channel, DiscardEvent.DISCARD);
   }
 
+  /**
+   * Checks if a channel is active and usable.
+   *
+   * @param channel the channel to check
+   * @return true if the channel is non-null and active
+   */
   public static boolean isChannelActive(Channel channel) {
     return channel != null && channel.isActive();
   }
 
+  /**
+   * Sets an active token on the channel.
+   * <p>
+   * This token is used to track channel activation state and prevent
+   * duplicate connection attempts or race conditions.
+   * </p>
+   *
+   * @param channel the channel to mark as active
+   */
   public static void setActiveToken(Channel channel) {
     channel.attr(ACTIVE_TOKEN_ATTRIBUTE).set(Active.INSTANCE);
   }
 
+  /**
+   * Checks and removes the active token from the channel atomically.
+   * <p>
+   * This method returns true if the token was present (indicating the channel
+   * was properly activated) and removes it in a single atomic operation.
+   * </p>
+   *
+   * @param channel the channel to check
+   * @return true if the active token was present and has been removed
+   */
   public static boolean isActiveTokenSet(Channel channel) {
     return channel != null && channel.attr(ACTIVE_TOKEN_ATTRIBUTE).getAndSet(null) != null;
   }
 
+  /**
+   * Closes a channel while suppressing any exceptions.
+   * <p>
+   * This method attempts to close the channel if it is active, logging
+   * any errors that occur during closure. It is safe to call on null
+   * or already-closed channels.
+   * </p>
+   *
+   * @param channel the channel to close (may be null)
+   */
   public static void silentlyCloseChannel(Channel channel) {
     try {
       if (channel != null && channel.isActive())

--- a/client/src/main/java/org/asynchttpclient/netty/channel/ConnectionSemaphore.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/ConnectionSemaphore.java
@@ -16,12 +16,37 @@ package org.asynchttpclient.netty.channel;
 import java.io.IOException;
 
 /**
- * Connections limiter.
+ * Semaphore for limiting concurrent connections.
+ * <p>
+ * This interface provides a mechanism to control the maximum number of concurrent
+ * connections that can be established, either globally or per-host. Implementations
+ * enforce connection limits to prevent resource exhaustion.
+ * </p>
  */
 public interface ConnectionSemaphore {
 
+    /**
+     * Acquires a lock to allow a new channel connection.
+     * <p>
+     * This method blocks or throws an exception if the connection limit has been reached.
+     * The lock must be released by calling {@link #releaseChannelLock(Object)} when the
+     * connection is no longer needed.
+     * </p>
+     *
+     * @param partitionKey the key identifying the connection partition (e.g., host)
+     * @throws IOException if the lock cannot be acquired due to connection limits
+     */
     void acquireChannelLock(Object partitionKey) throws IOException;
 
+    /**
+     * Releases a previously acquired channel lock.
+     * <p>
+     * This method should be called when a connection is closed or returned to the pool,
+     * allowing other pending requests to proceed.
+     * </p>
+     *
+     * @param partitionKey the key identifying the connection partition (e.g., host)
+     */
     void releaseChannelLock(Object partitionKey);
 
 }

--- a/client/src/main/java/org/asynchttpclient/netty/channel/ConnectionSemaphoreFactory.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/ConnectionSemaphoreFactory.java
@@ -15,8 +15,25 @@ package org.asynchttpclient.netty.channel;
 
 import org.asynchttpclient.AsyncHttpClientConfig;
 
+/**
+ * Factory for creating ConnectionSemaphore instances.
+ * <p>
+ * This factory creates connection limiters based on the client configuration,
+ * allowing different semaphore strategies (per-host, global, or no limits).
+ * </p>
+ */
 public interface ConnectionSemaphoreFactory {
 
+    /**
+     * Creates a new ConnectionSemaphore based on the provided configuration.
+     * <p>
+     * The returned semaphore enforces connection limits according to the
+     * configuration settings such as maxConnections and maxConnectionsPerHost.
+     * </p>
+     *
+     * @param config the async HTTP client configuration
+     * @return a new ConnectionSemaphore instance
+     */
     ConnectionSemaphore newConnectionSemaphore(AsyncHttpClientConfig config);
 
 }

--- a/client/src/main/java/org/asynchttpclient/netty/channel/DefaultChannelPool.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/DefaultChannelPool.java
@@ -38,7 +38,19 @@ import static org.asynchttpclient.util.Assertions.assertNotNull;
 import static org.asynchttpclient.util.DateUtils.unpreciseMillisTime;
 
 /**
- * A simple implementation of {@link ChannelPool} based on a {@link java.util.concurrent.ConcurrentHashMap}
+ * Default implementation of {@link ChannelPool} based on a {@link java.util.concurrent.ConcurrentHashMap}.
+ * <p>
+ * This pool manages idle connections organized by partition keys (typically host:port),
+ * supporting configurable connection TTL and idle timeouts. It uses a timer-based cleaner
+ * to remove expired or remotely-closed connections.
+ * </p>
+ * <p>
+ * Supports two lease strategies:
+ * <ul>
+ *   <li>LIFO (Last-In-First-Out) - reuses most recently returned connections (default)</li>
+ *   <li>FIFO (First-In-First-Out) - reuses oldest connections first</li>
+ * </ul>
+ * </p>
  */
 public final class DefaultChannelPool implements ChannelPool {
 
@@ -55,6 +67,12 @@ public final class DefaultChannelPool implements ChannelPool {
   private final long cleanerPeriod;
   private final PoolLeaseStrategy poolLeaseStrategy;
 
+  /**
+   * Constructs a pool using configuration settings.
+   *
+   * @param config the client configuration
+   * @param hashedWheelTimer the timer for scheduling cleanup tasks
+   */
   public DefaultChannelPool(AsyncHttpClientConfig config, Timer hashedWheelTimer) {
     this(config.getPooledConnectionIdleTimeout(),
             config.getConnectionTtl(),

--- a/client/src/main/java/org/asynchttpclient/netty/channel/NettyChannelConnector.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/NettyChannelConnector.java
@@ -26,6 +26,14 @@ import java.util.List;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
+/**
+ * Manages connection attempts to multiple resolved addresses with automatic failover.
+ * <p>
+ * This class iterates through a list of resolved IP addresses, attempting to connect
+ * to each in sequence until one succeeds. It notifies the AsyncHandler of connection
+ * attempts and outcomes, supporting transparent failover for multi-homed hosts.
+ * </p>
+ */
 public class NettyChannelConnector {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(NettyChannelConnector.class);
@@ -39,6 +47,14 @@ public class NettyChannelConnector {
   private final AsyncHttpClientState clientState;
   private volatile int i = 0;
 
+  /**
+   * Constructs a new NettyChannelConnector.
+   *
+   * @param localAddress the local address to bind to, or null for automatic
+   * @param remoteAddresses the list of resolved remote addresses to try
+   * @param asyncHandler the async handler for connection notifications
+   * @param clientState the client state for shutdown checks
+   */
   public NettyChannelConnector(InetAddress localAddress,
                                List<InetSocketAddress> remoteAddresses,
                                AsyncHandler<?> asyncHandler,
@@ -54,6 +70,17 @@ public class NettyChannelConnector {
     return i < remoteAddresses.size();
   }
 
+  /**
+   * Initiates a connection attempt to the current remote address.
+   * <p>
+   * This method notifies the async handler of the connection attempt and
+   * initiates the asynchronous connect operation. On failure, it automatically
+   * tries the next address if available.
+   * </p>
+   *
+   * @param bootstrap the Netty bootstrap to use for connecting
+   * @param connectListener the listener for connection outcome
+   */
   public void connect(final Bootstrap bootstrap, final NettyConnectListener<?> connectListener) {
     final InetSocketAddress remoteAddress = remoteAddresses.get(i);
 

--- a/client/src/main/java/org/asynchttpclient/netty/channel/TransportFactory.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/TransportFactory.java
@@ -19,8 +19,26 @@ import io.netty.channel.EventLoopGroup;
 
 import java.util.concurrent.ThreadFactory;
 
+/**
+ * Factory for creating transport-specific channel and event loop group instances.
+ * <p>
+ * This interface abstracts the creation of Netty transport components, allowing
+ * support for multiple transport implementations (NIO, Epoll, KQueue). Each implementation
+ * provides optimized channel and event loop classes for their respective platform.
+ * </p>
+ *
+ * @param <C> the channel type (e.g., NioSocketChannel, EpollSocketChannel)
+ * @param <L> the event loop group type (e.g., NioEventLoopGroup, EpollEventLoopGroup)
+ */
 public interface TransportFactory<C extends Channel, L extends EventLoopGroup> extends ChannelFactory<C> {
 
+  /**
+   * Creates a new event loop group for this transport.
+   *
+   * @param ioThreadsCount the number of I/O threads to create
+   * @param threadFactory the factory for creating threads
+   * @return a new event loop group instance
+   */
   L newEventLoopGroup(int ioThreadsCount, ThreadFactory threadFactory);
 
 }

--- a/client/src/main/java/org/asynchttpclient/netty/handler/HttpHandler.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/HttpHandler.java
@@ -32,9 +32,37 @@ import org.asynchttpclient.netty.request.NettyRequestSender;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
+/**
+ * HTTP protocol handler for processing HTTP request-response cycles.
+ * <p>
+ * This handler manages HTTP response processing including status lines, headers,
+ * body chunks, and trailer headers. It supports both buffered and streaming response
+ * handling through the AsyncHandler and StreamedAsyncHandler interfaces.
+ * </p>
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // The HttpHandler is automatically installed in the pipeline
+ * AsyncHttpClient client = new DefaultAsyncHttpClient();
+ * client.prepareGet("http://example.com")
+ *     .execute(new AsyncCompletionHandler<Response>() {
+ *         @Override
+ *         public Response onCompleted(Response response) {
+ *             // HttpHandler processed the complete response
+ *             return response;
+ *         }
+ *     });
+ * }</pre>
+ */
 @Sharable
 public final class HttpHandler extends AsyncHttpClientHandler {
 
+  /**
+   * Constructs a new HttpHandler.
+   *
+   * @param config the async HTTP client configuration
+   * @param channelManager the channel manager for managing channel lifecycle
+   * @param requestSender the request sender for sending HTTP requests
+   */
   public HttpHandler(AsyncHttpClientConfig config, ChannelManager channelManager, NettyRequestSender requestSender) {
     super(config, channelManager, requestSender);
   }
@@ -114,6 +142,23 @@ public final class HttpHandler extends AsyncHttpClientHandler {
     }
   }
 
+  /**
+   * Processes HTTP protocol messages including responses and body chunks.
+   * <p>
+   * This method handles:
+   * <ul>
+   *   <li>HttpResponse - status line and headers</li>
+   *   <li>HttpContent - response body chunks and trailer headers</li>
+   *   <li>DecoderResult errors from the HTTP codec</li>
+   * </ul>
+   * It also applies IO exception filters and retry logic when appropriate.
+   * </p>
+   *
+   * @param channel the channel the message was read from
+   * @param future the response future associated with the request
+   * @param e the message to handle (HttpResponse or HttpContent)
+   * @throws Exception if an error occurs during message handling
+   */
   @Override
   public void handleRead(final Channel channel, final NettyResponseFuture<?> future, final Object e) throws Exception {
 
@@ -165,10 +210,29 @@ public final class HttpHandler extends AsyncHttpClientHandler {
     }
   }
 
+  /**
+   * Handles exceptions for HTTP protocol operations.
+   * <p>
+   * This method provides no additional exception handling beyond the base class,
+   * as HTTP-specific error handling is performed in {@link #handleRead}.
+   * </p>
+   *
+   * @param future the response future associated with the request
+   * @param error the exception that occurred
+   */
   @Override
   public void handleException(NettyResponseFuture<?> future, Throwable error) {
   }
 
+  /**
+   * Handles channel inactivation for HTTP protocol operations.
+   * <p>
+   * This method provides no additional handling beyond the base class,
+   * as HTTP channel lifecycle management is performed in the base handler.
+   * </p>
+   *
+   * @param future the response future associated with the request
+   */
   @Override
   public void handleChannelInactive(NettyResponseFuture<?> future) {
   }

--- a/client/src/main/java/org/asynchttpclient/netty/handler/WebSocketHandler.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/WebSocketHandler.java
@@ -34,9 +34,24 @@ import static io.netty.handler.codec.http.HttpHeaderNames.*;
 import static io.netty.handler.codec.http.HttpResponseStatus.SWITCHING_PROTOCOLS;
 import static org.asynchttpclient.ws.WebSocketUtils.getAcceptKey;
 
+/**
+ * WebSocket protocol handler for managing WebSocket connections and frame processing.
+ * <p>
+ * This handler manages the WebSocket handshake upgrade process, validates the upgrade
+ * response, and processes WebSocket frames. It implements the WebSocket protocol as
+ * specified in RFC 6455.
+ * </p>
+ */
 @Sharable
 public final class WebSocketHandler extends AsyncHttpClientHandler {
 
+  /**
+   * Constructs a new WebSocketHandler.
+   *
+   * @param config the async HTTP client configuration
+   * @param channelManager the channel manager for managing channel lifecycle
+   * @param requestSender the request sender for sending HTTP requests
+   */
   public WebSocketHandler(AsyncHttpClientConfig config,
                           ChannelManager channelManager,
                           NettyRequestSender requestSender) {
@@ -95,6 +110,22 @@ public final class WebSocketHandler extends AsyncHttpClientHandler {
     }
   }
 
+  /**
+   * Processes WebSocket protocol messages including handshake responses and frames.
+   * <p>
+   * This method handles:
+   * <ul>
+   *   <li>HTTP upgrade responses for WebSocket handshake validation</li>
+   *   <li>WebSocket frames for established connections</li>
+   *   <li>Final handshake cleanup with LastHttpContent</li>
+   * </ul>
+   * </p>
+   *
+   * @param channel the channel the message was read from
+   * @param future the response future associated with the WebSocket upgrade request
+   * @param e the message to handle (HttpResponse, WebSocketFrame, or LastHttpContent)
+   * @throws Exception if an error occurs during message handling
+   */
   @Override
   public void handleRead(Channel channel, NettyResponseFuture<?> future, Object e) throws Exception {
 
@@ -137,6 +168,16 @@ public final class WebSocketHandler extends AsyncHttpClientHandler {
     }
   }
 
+  /**
+   * Handles exceptions during WebSocket operations by notifying the WebSocket listener.
+   * <p>
+   * This method propagates the exception to the WebSocket's error handler and
+   * sends a close frame to gracefully terminate the connection.
+   * </p>
+   *
+   * @param future the response future associated with the WebSocket
+   * @param e the exception that occurred
+   */
   @Override
   public void handleException(NettyResponseFuture<?> future, Throwable e) {
     logger.warn("onError", e);
@@ -152,6 +193,16 @@ public final class WebSocketHandler extends AsyncHttpClientHandler {
     }
   }
 
+  /**
+   * Handles WebSocket connection closure when the channel becomes inactive.
+   * <p>
+   * This method is called when the connection is closed without receiving a proper
+   * WebSocket close frame. It notifies the WebSocket listener with status code 1006
+   * (abnormal closure) as per RFC 6455.
+   * </p>
+   *
+   * @param future the response future associated with the WebSocket
+   */
   @Override
   public void handleChannelInactive(NettyResponseFuture<?> future) {
     logger.trace("Connection was closed abnormally (that is, with no close frame being received).");

--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequest.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequest.java
@@ -16,20 +16,43 @@ package org.asynchttpclient.netty.request;
 import io.netty.handler.codec.http.HttpRequest;
 import org.asynchttpclient.netty.request.body.NettyBody;
 
+/**
+ * Represents a complete Netty HTTP request with optional body.
+ * <p>
+ * This class wraps a Netty {@link HttpRequest} and its associated {@link NettyBody},
+ * providing a unified representation of the request to be written to the channel.
+ * </p>
+ */
 public final class NettyRequest {
 
   private final HttpRequest httpRequest;
   private final NettyBody body;
 
+  /**
+   * Constructs a new NettyRequest.
+   *
+   * @param httpRequest the Netty HTTP request
+   * @param body the request body, or null for requests without a body
+   */
   NettyRequest(HttpRequest httpRequest, NettyBody body) {
     this.httpRequest = httpRequest;
     this.body = body;
   }
 
+  /**
+   * Returns the Netty HTTP request.
+   *
+   * @return the HTTP request containing headers and metadata
+   */
   public HttpRequest getHttpRequest() {
     return httpRequest;
   }
 
+  /**
+   * Returns the request body.
+   *
+   * @return the body to be written, or null if no body
+   */
   public NettyBody getBody() {
     return body;
   }

--- a/client/src/main/java/org/asynchttpclient/ntlm/NtlmEngineException.java
+++ b/client/src/main/java/org/asynchttpclient/ntlm/NtlmEngineException.java
@@ -29,13 +29,18 @@ package org.asynchttpclient.ntlm;
 
 /**
  * Signals NTLM protocol failure.
+ * <p>
+ * This exception is thrown when an error occurs during NTLM authentication processing,
+ * such as when message decoding fails, required cryptographic algorithms are unavailable,
+ * or the authentication challenge is malformed.
+ * </p>
  */
 class NtlmEngineException extends RuntimeException {
 
   private static final long serialVersionUID = 6027981323731768824L;
 
   /**
-   * Creates a new NTLMEngineException with the specified message.
+   * Creates a new NtlmEngineException with the specified message.
    *
    * @param message the exception detail message
    */
@@ -44,11 +49,11 @@ class NtlmEngineException extends RuntimeException {
   }
 
   /**
-   * Creates a new NTLMEngineException with the specified detail message and cause.
+   * Creates a new NtlmEngineException with the specified detail message and cause.
    *
    * @param message the exception detail message
-   * @param cause   the <tt>Throwable</tt> that caused this exception, or <tt>null</tt>
-   *                if the cause is unavailable, unknown, or not a <tt>Throwable</tt>
+   * @param cause the {@code Throwable} that caused this exception, or {@code null}
+   *              if the cause is unavailable, unknown, or not a {@code Throwable}
    */
   NtlmEngineException(String message, Throwable cause) {
     super(message, cause);

--- a/client/src/main/java/org/asynchttpclient/oauth/ConsumerKey.java
+++ b/client/src/main/java/org/asynchttpclient/oauth/ConsumerKey.java
@@ -17,26 +17,64 @@ import org.asynchttpclient.util.Utf8UrlEncoder;
 
 /**
  * Value class for OAuth consumer keys.
+ * <p>
+ * Represents the consumer credentials used in OAuth 1.0 authentication, consisting of a key and a secret.
+ * The key is automatically percent-encoded for use in OAuth signatures.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * ConsumerKey consumerKey = new ConsumerKey("my-consumer-key", "my-consumer-secret");
+ * String key = consumerKey.getKey();
+ * String encodedKey = consumerKey.getPercentEncodedKey();
+ * }</pre>
  */
 public class ConsumerKey {
   private final String key;
   private final String secret;
   private final String percentEncodedKey;
 
+  /**
+   * Creates a new consumer key with the specified key and secret.
+   * <p>
+   * The key is automatically percent-encoded using UTF-8 URL encoding for use in OAuth signatures.
+   * </p>
+   *
+   * @param key the consumer key (public identifier)
+   * @param secret the consumer secret (confidential part)
+   */
   public ConsumerKey(String key, String secret) {
     this.key = key;
     this.secret = secret;
     this.percentEncodedKey = Utf8UrlEncoder.percentEncodeQueryElement(key);
   }
 
+  /**
+   * Returns the consumer key (public identifier).
+   *
+   * @return the consumer key
+   */
   public String getKey() {
     return key;
   }
 
+  /**
+   * Returns the consumer secret (confidential part).
+   *
+   * @return the consumer secret
+   */
   public String getSecret() {
     return secret;
   }
 
+  /**
+   * Returns the percent-encoded consumer key.
+   * <p>
+   * This is the URL-encoded version of the key, ready for use in OAuth signature calculations.
+   * </p>
+   *
+   * @return the percent-encoded consumer key
+   */
   public String getPercentEncodedKey() {
     return percentEncodedKey;
   }

--- a/client/src/main/java/org/asynchttpclient/oauth/OAuthSignatureCalculatorInstance.java
+++ b/client/src/main/java/org/asynchttpclient/oauth/OAuthSignatureCalculatorInstance.java
@@ -35,8 +35,14 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 /**
  * Non thread-safe {@link SignatureCalculator} for OAuth1.
  * <p>
- * Supports most common signature inclusion and calculation methods: HMAC-SHA1 for calculation, and Header inclusion as inclusion method. Nonce generation uses simple random
- * numbers with base64 encoding.
+ * Supports most common signature inclusion and calculation methods: HMAC-SHA1 for calculation,
+ * and Header inclusion as inclusion method. Nonce generation uses simple random numbers with
+ * base64 encoding.
+ * </p>
+ * <p>
+ * This class is not thread-safe and should be used through the thread-local instance pool
+ * provided by {@link OAuthSignatureCalculator}.
+ * </p>
  */
 public class OAuthSignatureCalculatorInstance {
 
@@ -58,10 +64,34 @@ public class OAuthSignatureCalculatorInstance {
   private final byte[] nonceBuffer = new byte[16];
   private final Parameters parameters = new Parameters();
 
+  /**
+   * Creates a new OAuth signature calculator instance.
+   * <p>
+   * Initializes the HMAC-SHA1 MAC instance used for signature generation.
+   * </p>
+   *
+   * @throws NoSuchAlgorithmException if HMAC-SHA1 algorithm is not available
+   */
   public OAuthSignatureCalculatorInstance() throws NoSuchAlgorithmException {
     mac = Mac.getInstance(HMAC_SHA1_ALGORITHM);
   }
 
+  /**
+   * Computes the OAuth authorization header for the given request.
+   * <p>
+   * This method generates a nonce and timestamp, then computes the OAuth signature
+   * and constructs the complete Authorization header value.
+   * </p>
+   *
+   * @param consumerAuth the consumer key credentials
+   * @param userAuth the request/access token credentials
+   * @param uri the request URI
+   * @param method the HTTP method (e.g., GET, POST)
+   * @param formParams the form parameters (can be null)
+   * @param queryParams the query parameters (can be null)
+   * @return the OAuth Authorization header value
+   * @throws InvalidKeyException if the consumer or user secrets are invalid
+   */
   public String computeAuthorizationHeader(ConsumerKey consumerAuth,
                                            RequestToken userAuth,
                                            Uri uri,

--- a/client/src/main/java/org/asynchttpclient/oauth/Parameter.java
+++ b/client/src/main/java/org/asynchttpclient/oauth/Parameter.java
@@ -14,28 +14,63 @@
 package org.asynchttpclient.oauth;
 
 /**
- * Helper class for sorting query and form parameters that we need
+ * Helper class for sorting query and form parameters used in OAuth signature calculation.
+ * <p>
+ * This class represents a key-value pair that can be sorted according to OAuth specifications.
+ * Parameters are first sorted by key, then by value if keys are equal.
+ * </p>
  */
 final class Parameter implements Comparable<Parameter> {
 
   final String key, value;
 
+  /**
+   * Creates a new parameter with the specified key and value.
+   *
+   * @param key the parameter key
+   * @param value the parameter value
+   */
   public Parameter(String key, String value) {
     this.key = key;
     this.value = value;
   }
 
+  /**
+   * Compares this parameter to another for sorting purposes.
+   * <p>
+   * Parameters are compared first by key, then by value if keys are equal.
+   * This ordering is required for OAuth signature calculation.
+   * </p>
+   *
+   * @param other the parameter to compare to
+   * @return a negative integer, zero, or a positive integer as this parameter
+   *         is less than, equal to, or greater than the specified parameter
+   */
   @Override
   public int compareTo(Parameter other) {
     int keyDiff = key.compareTo(other.key);
     return keyDiff == 0 ? value.compareTo(other.value) : keyDiff;
   }
 
+  /**
+   * Returns a string representation of this parameter in the form "key=value".
+   *
+   * @return a string representation of this parameter
+   */
   @Override
   public String toString() {
     return key + "=" + value;
   }
 
+  /**
+   * Indicates whether some other object is equal to this parameter.
+   * <p>
+   * Two parameters are considered equal if both their keys and values are equal.
+   * </p>
+   *
+   * @param o the reference object with which to compare
+   * @return {@code true} if this parameter is equal to the argument; {@code false} otherwise
+   */
   @Override
   public boolean equals(Object o) {
     if (this == o)
@@ -47,6 +82,11 @@ final class Parameter implements Comparable<Parameter> {
     return key.equals(parameter.key) && value.equals(parameter.value);
   }
 
+  /**
+   * Returns a hash code value for this parameter.
+   *
+   * @return a hash code value for this parameter
+   */
   @Override
   public int hashCode() {
     int result = key.hashCode();

--- a/client/src/main/java/org/asynchttpclient/oauth/Parameters.java
+++ b/client/src/main/java/org/asynchttpclient/oauth/Parameters.java
@@ -19,19 +19,50 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Collection of OAuth parameters used for signature calculation.
+ * <p>
+ * This class maintains a list of parameters that can be sorted and concatenated
+ * according to OAuth 1.0 specifications. Parameters should be added in their
+ * percent-encoded form.
+ * </p>
+ */
 final class Parameters {
 
   private List<Parameter> parameters = new ArrayList<>();
 
+  /**
+   * Adds a parameter to the collection.
+   *
+   * @param key the parameter key (should be percent-encoded)
+   * @param value the parameter value (should be percent-encoded)
+   * @return this Parameters instance for method chaining
+   */
   public Parameters add(String key, String value) {
     parameters.add(new Parameter(key, value));
     return this;
   }
 
+  /**
+   * Clears all parameters from the collection.
+   * <p>
+   * This method allows the Parameters instance to be reused for multiple signature calculations.
+   * </p>
+   */
   public void reset() {
     parameters.clear();
   }
 
+  /**
+   * Sorts the parameters and concatenates them into a query string.
+   * <p>
+   * Parameters are sorted according to OAuth specifications (first by key, then by value),
+   * then concatenated with '&' separators. The result is used in OAuth signature base string
+   * construction.
+   * </p>
+   *
+   * @return the sorted and concatenated parameter string
+   */
   String sortAndConcat() {
     // then sort them (AFTER encoding, important)
     Collections.sort(parameters);

--- a/client/src/main/java/org/asynchttpclient/oauth/RequestToken.java
+++ b/client/src/main/java/org/asynchttpclient/oauth/RequestToken.java
@@ -16,29 +16,66 @@ package org.asynchttpclient.oauth;
 import org.asynchttpclient.util.Utf8UrlEncoder;
 
 /**
- * Value class used for OAuth tokens (request secret, access secret);
- * simple container with two parts, public id part ("key") and
- * confidential ("secret") part.
+ * Value class used for OAuth tokens (request token or access token).
+ * <p>
+ * This is a simple container with two parts: a public identifier ("key") and a
+ * confidential ("secret") part. The key is automatically percent-encoded for use
+ * in OAuth signatures.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * RequestToken requestToken = new RequestToken("request-key", "request-secret");
+ * String key = requestToken.getKey();
+ * String encodedKey = requestToken.getPercentEncodedKey();
+ * }</pre>
  */
 public class RequestToken {
   private final String key;
   private final String secret;
   private final String percentEncodedKey;
 
+  /**
+   * Creates a new request token with the specified key and secret.
+   * <p>
+   * The key is automatically percent-encoded using UTF-8 URL encoding for use in OAuth signatures.
+   * </p>
+   *
+   * @param key the token key (public identifier)
+   * @param token the token secret (confidential part)
+   */
   public RequestToken(String key, String token) {
     this.key = key;
     this.secret = token;
     this.percentEncodedKey = Utf8UrlEncoder.percentEncodeQueryElement(key);
   }
 
+  /**
+   * Returns the token key (public identifier).
+   *
+   * @return the token key
+   */
   public String getKey() {
     return key;
   }
 
+  /**
+   * Returns the token secret (confidential part).
+   *
+   * @return the token secret
+   */
   public String getSecret() {
     return secret;
   }
 
+  /**
+   * Returns the percent-encoded token key.
+   * <p>
+   * This is the URL-encoded version of the key, ready for use in OAuth signature calculations.
+   * </p>
+   *
+   * @return the percent-encoded token key
+   */
   public String getPercentEncodedKey() {
     return percentEncodedKey;
   }

--- a/client/src/main/java/org/asynchttpclient/proxy/ProxyServer.java
+++ b/client/src/main/java/org/asynchttpclient/proxy/ProxyServer.java
@@ -26,7 +26,33 @@ import static org.asynchttpclient.util.Assertions.assertNotNull;
 import static org.asynchttpclient.util.MiscUtils.isNonEmpty;
 
 /**
- * Represents a proxy server.
+ * Represents a proxy server configuration.
+ * <p>
+ * This class encapsulates all the information needed to connect through a proxy server,
+ * including the host, port, authentication realm, and patterns for hosts that should
+ * bypass the proxy. Both HTTP and SOCKS proxy types are supported.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Simple HTTP proxy
+ * ProxyServer proxy = new ProxyServer.Builder("proxy.example.com", 8080)
+ *     .build();
+ *
+ * // Proxy with authentication
+ * Realm realm = new Realm.Builder("username", "password")
+ *     .setScheme(Realm.AuthScheme.BASIC)
+ *     .build();
+ * ProxyServer proxy = new ProxyServer.Builder("proxy.example.com", 8080)
+ *     .setRealm(realm)
+ *     .build();
+ *
+ * // Proxy with non-proxy hosts
+ * ProxyServer proxy = new ProxyServer.Builder("proxy.example.com", 8080)
+ *     .setNonProxyHost("*.internal.com")
+ *     .setNonProxyHost("localhost")
+ *     .build();
+ * }</pre>
  */
 public class ProxyServer {
 
@@ -37,6 +63,16 @@ public class ProxyServer {
   private final List<String> nonProxyHosts;
   private final ProxyType proxyType;
 
+  /**
+   * Creates a new proxy server with the specified configuration.
+   *
+   * @param host the proxy server hostname
+   * @param port the proxy server port for non-SSL connections
+   * @param securedPort the proxy server port for SSL connections
+   * @param realm the authentication realm (can be null)
+   * @param nonProxyHosts list of host patterns that should bypass the proxy (can be null)
+   * @param proxyType the type of proxy (HTTP or SOCKS)
+   */
   public ProxyServer(String host, int port, int securedPort, Realm realm, List<String> nonProxyHosts,
                      ProxyType proxyType) {
     this.host = host;
@@ -47,26 +83,56 @@ public class ProxyServer {
     this.proxyType = proxyType;
   }
 
+  /**
+   * Returns the proxy server hostname.
+   *
+   * @return the proxy server hostname
+   */
   public String getHost() {
     return host;
   }
 
+  /**
+   * Returns the proxy server port for non-SSL connections.
+   *
+   * @return the proxy server port
+   */
   public int getPort() {
     return port;
   }
 
+  /**
+   * Returns the proxy server port for SSL connections.
+   *
+   * @return the secured proxy server port
+   */
   public int getSecuredPort() {
     return securedPort;
   }
 
+  /**
+   * Returns the list of host patterns that should bypass the proxy.
+   *
+   * @return the non-proxy hosts list (never null, may be empty)
+   */
   public List<String> getNonProxyHosts() {
     return nonProxyHosts;
   }
 
+  /**
+   * Returns the authentication realm for the proxy server.
+   *
+   * @return the authentication realm, or null if no authentication is configured
+   */
   public Realm getRealm() {
     return realm;
   }
 
+  /**
+   * Returns the type of proxy (HTTP or SOCKS).
+   *
+   * @return the proxy type
+   */
   public ProxyType getProxyType() {
     return proxyType;
   }
@@ -110,6 +176,9 @@ public class ProxyServer {
     return nonProxyHost.equalsIgnoreCase(targetHost);
   }
 
+  /**
+   * Builder for creating ProxyServer instances.
+   */
   public static class Builder {
 
     private String host;
@@ -119,27 +188,68 @@ public class ProxyServer {
     private List<String> nonProxyHosts;
     private ProxyType proxyType;
 
+    /**
+     * Creates a new proxy server builder with the specified host and port.
+     * <p>
+     * The secured port is initially set to the same value as the port.
+     * </p>
+     *
+     * @param host the proxy server hostname
+     * @param port the proxy server port
+     */
     public Builder(String host, int port) {
       this.host = host;
       this.port = port;
       this.securedPort = port;
     }
 
+    /**
+     * Sets the proxy server port for SSL connections.
+     *
+     * @param securedPort the secured port number
+     * @return this builder for method chaining
+     */
     public Builder setSecuredPort(int securedPort) {
       this.securedPort = securedPort;
       return this;
     }
 
+    /**
+     * Sets the authentication realm for the proxy server.
+     *
+     * @param realm the authentication realm
+     * @return this builder for method chaining
+     */
     public Builder setRealm(Realm realm) {
       this.realm = realm;
       return this;
     }
 
+    /**
+     * Sets the authentication realm using a realm builder.
+     *
+     * @param realm the realm builder
+     * @return this builder for method chaining
+     */
     public Builder setRealm(Realm.Builder realm) {
       this.realm = realm.build();
       return this;
     }
 
+    /**
+     * Adds a single host pattern that should bypass the proxy.
+     * <p>
+     * Patterns can use wildcards (*) as prefixes or suffixes. For example:
+     * </p>
+     * <ul>
+     *   <li>*.example.com - matches any subdomain of example.com</li>
+     *   <li>192.168.* - matches any IP starting with 192.168.</li>
+     *   <li>localhost - exact match</li>
+     * </ul>
+     *
+     * @param nonProxyHost the host pattern to bypass the proxy
+     * @return this builder for method chaining
+     */
     public Builder setNonProxyHost(String nonProxyHost) {
       if (nonProxyHosts == null)
         nonProxyHosts = new ArrayList<>(1);
@@ -147,16 +257,37 @@ public class ProxyServer {
       return this;
     }
 
+    /**
+     * Sets the list of host patterns that should bypass the proxy.
+     *
+     * @param nonProxyHosts the list of host patterns
+     * @return this builder for method chaining
+     */
     public Builder setNonProxyHosts(List<String> nonProxyHosts) {
       this.nonProxyHosts = nonProxyHosts;
       return this;
     }
 
+    /**
+     * Sets the proxy type (HTTP or SOCKS).
+     *
+     * @param proxyType the proxy type
+     * @return this builder for method chaining
+     */
     public Builder setProxyType(ProxyType proxyType) {
       this.proxyType = proxyType;
       return this;
     }
 
+    /**
+     * Builds a new ProxyServer instance with the configured settings.
+     * <p>
+     * If no proxy type is set, defaults to HTTP. If no non-proxy hosts are set,
+     * uses an empty list.
+     * </p>
+     *
+     * @return a new ProxyServer instance
+     */
     public ProxyServer build() {
       List<String> nonProxyHosts = this.nonProxyHosts != null ? Collections.unmodifiableList(this.nonProxyHosts)
               : Collections.emptyList();

--- a/client/src/main/java/org/asynchttpclient/proxy/ProxyServerSelector.java
+++ b/client/src/main/java/org/asynchttpclient/proxy/ProxyServerSelector.java
@@ -3,20 +3,54 @@ package org.asynchttpclient.proxy;
 import org.asynchttpclient.uri.Uri;
 
 /**
- * Selector for a proxy server
+ * Selector for choosing a proxy server based on the target URI.
+ * <p>
+ * This interface allows for flexible proxy selection strategies, such as selecting
+ * different proxies based on the protocol, host, or other URI attributes. It can
+ * also be used to implement proxy auto-configuration (PAC) or other dynamic proxy
+ * selection mechanisms.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Always use the same proxy
+ * ProxyServer proxy = new ProxyServer.Builder("proxy.example.com", 8080).build();
+ * ProxyServerSelector selector = uri -> proxy;
+ *
+ * // Select proxy based on URI
+ * ProxyServerSelector selector = uri -> {
+ *     if (uri.isSecured()) {
+ *         return secureProxy;
+ *     } else {
+ *         return standardProxy;
+ *     }
+ * };
+ *
+ * // No proxy
+ * ProxyServerSelector selector = ProxyServerSelector.NO_PROXY_SELECTOR;
+ * }</pre>
  */
 public interface ProxyServerSelector {
 
   /**
    * A selector that always selects no proxy.
+   * <p>
+   * Use this selector when you want to bypass proxy configuration and connect
+   * directly to all destinations.
+   * </p>
    */
   ProxyServerSelector NO_PROXY_SELECTOR = uri -> null;
 
   /**
-   * Select a proxy server to use for the given URI.
+   * Selects a proxy server to use for the given URI.
+   * <p>
+   * Implementations can inspect the URI's protocol, host, port, or any other
+   * attributes to determine which proxy to use, or whether to bypass the proxy
+   * entirely.
+   * </p>
    *
-   * @param uri The URI to select a proxy server for.
-   * @return The proxy server to use, if any.  May return null.
+   * @param uri the URI to select a proxy server for
+   * @return the proxy server to use, or null to connect directly without a proxy
    */
   ProxyServer select(Uri uri);
 }

--- a/client/src/main/java/org/asynchttpclient/proxy/ProxyType.java
+++ b/client/src/main/java/org/asynchttpclient/proxy/ProxyType.java
@@ -13,19 +13,69 @@
  */
 package org.asynchttpclient.proxy;
 
+/**
+ * Enumeration of supported proxy server types.
+ * <p>
+ * This enum defines the types of proxy protocols that can be used for routing
+ * HTTP requests through a proxy server. Each type has different characteristics
+ * and capabilities.
+ * </p>
+ */
 public enum ProxyType {
-  HTTP(true), SOCKS_V4(false), SOCKS_V5(false);
+  /**
+   * HTTP proxy type.
+   * <p>
+   * HTTP proxies operate at the application layer (Layer 7) and understand HTTP protocol.
+   * They can cache responses, modify headers, and provide content filtering.
+   * This is the most common proxy type for web traffic.
+   * </p>
+   */
+  HTTP(true),
+
+  /**
+   * SOCKS version 4 proxy type.
+   * <p>
+   * SOCKS v4 is a circuit-level proxy that operates at the session layer (Layer 5).
+   * It supports TCP connections but does not support authentication or UDP.
+   * </p>
+   */
+  SOCKS_V4(false),
+
+  /**
+   * SOCKS version 5 proxy type.
+   * <p>
+   * SOCKS v5 is an enhanced version of SOCKS that supports authentication,
+   * UDP traffic, and IPv6. It provides more features than SOCKS v4 while
+   * still operating at the session layer.
+   * </p>
+   */
+  SOCKS_V5(false);
 
   private final boolean http;
 
+  /**
+   * Creates a proxy type with the specified HTTP flag.
+   *
+   * @param http true if this is an HTTP proxy type, false for SOCKS
+   */
   ProxyType(boolean http) {
     this.http = http;
   }
 
+  /**
+   * Checks whether this is an HTTP proxy type.
+   *
+   * @return true if this is an HTTP proxy, false otherwise
+   */
   public boolean isHttp() {
     return http;
   }
 
+  /**
+   * Checks whether this is a SOCKS proxy type.
+   *
+   * @return true if this is a SOCKS proxy (v4 or v5), false otherwise
+   */
   public boolean isSocks() {
     return !isHttp();
   }

--- a/client/src/main/java/org/asynchttpclient/request/body/Body.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/Body.java
@@ -19,40 +19,81 @@ import java.io.Closeable;
 import java.io.IOException;
 
 /**
- * A request body.
+ * Represents a request body that can be transferred to a target buffer.
+ * <p>
+ * This interface provides methods to retrieve the content length and transfer
+ * body content in chunks to a ByteBuf. Implementations should be closeable to
+ * release any resources held by the body.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * Body body = bodyGenerator.createBody();
+ * try {
+ *     long length = body.getContentLength();
+ *     ByteBuf buffer = Unpooled.buffer();
+ *     BodyState state = body.transferTo(buffer);
+ *     while (state == BodyState.CONTINUE) {
+ *         // Process buffer content
+ *         state = body.transferTo(buffer);
+ *     }
+ * } finally {
+ *     body.close();
+ * }
+ * }</pre>
  */
 public interface Body extends Closeable {
 
   /**
-   * Gets the length of the body.
+   * Gets the content length of the body.
    *
-   * @return The length of the body in bytes, or negative if unknown.
+   * @return the length of the body in bytes, or a negative value if the length is unknown
    */
   long getContentLength();
 
   /**
-   * Reads the next chunk of bytes from the body.
+   * Transfers the next chunk of bytes from the body to the target buffer.
+   * <p>
+   * This method reads available bytes from the body and writes them to the provided
+   * target buffer. The transfer continues until the buffer is full or no more data
+   * is immediately available.
+   * </p>
    *
-   * @param target The buffer to store the chunk in, must not be {@code null}.
-   * @return The state.
-   * @throws IOException If the chunk could not be read.
+   * @param target the buffer to store the chunk in, must not be {@code null}
+   * @return the current state of the body transfer indicating whether to continue,
+   *         suspend, or stop reading
+   * @throws IOException if the chunk could not be read due to an I/O error
    */
   BodyState transferTo(ByteBuf target) throws IOException;
 
+  /**
+   * Represents the state of a body transfer operation.
+   * <p>
+   * This enum is used to control the flow of data transfer from a body to a target buffer,
+   * indicating whether more data is available, the operation should pause, or the transfer
+   * is complete.
+   * </p>
+   */
   enum BodyState {
 
     /**
-     * There's something to read
+     * More data is available and the transfer should continue.
+     * This state indicates that the body has successfully written data to the buffer
+     * and additional data may be available for reading.
      */
     CONTINUE,
 
     /**
-     * There's nothing to read and input has to suspend
+     * No data is currently available and the transfer should be suspended.
+     * This state indicates that the transfer should pause temporarily and may be
+     * resumed later when more data becomes available.
      */
     SUSPEND,
 
     /**
-     * There's nothing to read and input has to stop
+     * No more data is available and the transfer should stop.
+     * This state indicates that the body has been completely transferred and
+     * no further reading is necessary.
      */
     STOP
   }

--- a/client/src/main/java/org/asynchttpclient/request/body/RandomAccessBody.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/RandomAccessBody.java
@@ -17,16 +17,39 @@ import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
 
 /**
- * A request body which supports random access to its contents.
+ * A request body that supports random access to its contents via channel-based transfer.
+ * <p>
+ * This interface extends {@link Body} to provide an additional transfer method using
+ * {@link WritableByteChannel}, which enables efficient zero-copy transfer for certain
+ * types of bodies (e.g., file-based bodies). This is particularly useful for HTTP
+ * connections where zero-copy optimizations can be applied.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * RandomAccessBody body = new FileBodyGenerator(new File("data.bin")).createBody();
+ * try (FileChannel channel = FileChannel.open(outputPath, StandardOpenOption.WRITE)) {
+ *     long transferred = body.transferTo(channel);
+ *     System.out.println("Transferred " + transferred + " bytes");
+ * } finally {
+ *     body.close();
+ * }
+ * }</pre>
  */
 public interface RandomAccessBody extends Body {
 
   /**
-   * Transfers the specified chunk of bytes from this body to the specified channel.
+   * Transfers bytes from this body to the specified writable channel.
+   * <p>
+   * This method performs an efficient transfer of body content to the target channel,
+   * potentially using zero-copy optimizations when supported by the underlying
+   * implementation. The transfer is typically more efficient than buffer-based
+   * transfers for file-based bodies.
+   * </p>
    *
-   * @param target The destination channel to transfer the body chunk to, must not be {@code null}.
-   * @return The non-negative number of bytes actually transferred.
-   * @throws IOException If the body chunk could not be transferred.
+   * @param target the destination channel to transfer the body chunk to, must not be {@code null}
+   * @return the non-negative number of bytes actually transferred
+   * @throws IOException if the body chunk could not be transferred due to an I/O error
    */
   long transferTo(WritableByteChannel target) throws IOException;
 }

--- a/client/src/main/java/org/asynchttpclient/request/body/generator/BodyChunk.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/generator/BodyChunk.java
@@ -15,10 +15,34 @@ package org.asynchttpclient.request.body.generator;
 
 import io.netty.buffer.ByteBuf;
 
+/**
+ * Represents a chunk of body data for feedable body generators.
+ * <p>
+ * A body chunk contains a buffer with the actual data and a flag indicating
+ * whether this is the last chunk in the sequence. This class is used by
+ * {@link FeedableBodyGenerator} implementations to queue and transfer body
+ * data incrementally.
+ * </p>
+ */
 public final class BodyChunk {
+  /**
+   * Indicates whether this is the last chunk in the body.
+   * When {@code true}, no more chunks will follow.
+   */
   public final boolean last;
+
+  /**
+   * The buffer containing the chunk data.
+   * This buffer holds the actual bytes to be transferred.
+   */
   public final ByteBuf buffer;
 
+  /**
+   * Constructs a new body chunk.
+   *
+   * @param buffer the buffer containing the chunk data
+   * @param last   {@code true} if this is the last chunk, {@code false} otherwise
+   */
   BodyChunk(ByteBuf buffer, boolean last) {
     this.buffer = buffer;
     this.last = last;

--- a/client/src/main/java/org/asynchttpclient/request/body/generator/BodyGenerator.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/generator/BodyGenerator.java
@@ -16,16 +16,36 @@ package org.asynchttpclient.request.body.generator;
 import org.asynchttpclient.request.body.Body;
 
 /**
- * Creates a request body.
+ * A factory for creating request bodies.
+ * <p>
+ * Implementations of this interface are responsible for creating {@link Body} instances
+ * that provide the actual data to be sent in HTTP requests. The generator pattern allows
+ * for creating multiple body instances with the same content, which is necessary for
+ * scenarios like authentication challenges and redirects where the request needs to be resent.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Create a body generator from a byte array
+ * BodyGenerator generator = new ByteArrayBodyGenerator("Hello World".getBytes());
+ * Body body = generator.createBody();
+ *
+ * // Create a body generator from a file
+ * BodyGenerator fileGenerator = new FileBodyGenerator(new File("data.txt"));
+ * Body fileBody = fileGenerator.createBody();
+ * }</pre>
  */
 public interface BodyGenerator {
 
   /**
-   * Creates a new instance of the request body to be read. While each invocation of this method is supposed to create
-   * a fresh instance of the body, the actual contents of all these body instances is the same. For example, the body
-   * needs to be resend after an authentication challenge of a redirect.
+   * Creates a new instance of the request body to be read.
+   * <p>
+   * Each invocation of this method creates a fresh instance of the body, but the actual
+   * contents of all these body instances is the same. This is necessary for scenarios where
+   * the body needs to be resent, such as after an authentication challenge or redirect.
+   * </p>
    *
-   * @return The request body, never {@code null}.
+   * @return the request body, never {@code null}
    */
   Body createBody();
 }

--- a/client/src/main/java/org/asynchttpclient/request/body/generator/BoundedQueueFeedableBodyGenerator.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/generator/BoundedQueueFeedableBodyGenerator.java
@@ -16,12 +16,57 @@ package org.asynchttpclient.request.body.generator;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
+/**
+ * A feedable body generator backed by a bounded blocking queue.
+ * <p>
+ * This implementation uses an {@link ArrayBlockingQueue} with a fixed capacity to store
+ * body chunks. When the queue reaches its capacity, attempts to feed additional chunks
+ * will fail (return {@code false}) until space becomes available. This provides backpressure
+ * to prevent unbounded memory consumption.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Create a bounded feedable body generator with capacity of 100 chunks
+ * BoundedQueueFeedableBodyGenerator generator = new BoundedQueueFeedableBodyGenerator(100);
+ * generator.setListener(new FeedListener() {
+ *     public void onContentAdded() {
+ *         System.out.println("Content added to queue");
+ *     }
+ *     public void onError(Throwable t) {
+ *         System.err.println("Error: " + t.getMessage());
+ *     }
+ * });
+ *
+ * // Feed data
+ * ByteBuf buffer = Unpooled.wrappedBuffer("data".getBytes());
+ * boolean accepted = generator.feed(buffer, false);
+ * if (!accepted) {
+ *     System.out.println("Queue is full");
+ * }
+ * }</pre>
+ */
 public final class BoundedQueueFeedableBodyGenerator extends QueueBasedFeedableBodyGenerator<BlockingQueue<BodyChunk>> {
 
+  /**
+   * Constructs a bounded queue feedable body generator with the specified capacity.
+   *
+   * @param capacity the maximum number of chunks that can be queued
+   */
   public BoundedQueueFeedableBodyGenerator(int capacity) {
     super(new ArrayBlockingQueue<>(capacity, true));
   }
 
+  /**
+   * Attempts to add a chunk to the queue.
+   * <p>
+   * If the queue is full, this method returns {@code false} immediately without blocking.
+   * </p>
+   *
+   * @param chunk the body chunk to add to the queue
+   * @return {@code true} if the chunk was added, {@code false} if the queue is full
+   * @throws InterruptedException if interrupted while attempting to add the chunk
+   */
   @Override
   protected boolean offer(BodyChunk chunk) throws InterruptedException {
     return queue.offer(chunk);

--- a/client/src/main/java/org/asynchttpclient/request/body/generator/FeedListener.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/generator/FeedListener.java
@@ -13,8 +13,50 @@
  */
 package org.asynchttpclient.request.body.generator;
 
+/**
+ * A listener interface for receiving notifications from feedable body generators.
+ * <p>
+ * Implementations of this interface can be registered with {@link FeedableBodyGenerator}
+ * instances to be notified when content is added to the generator or when errors occur.
+ * This allows for reactive processing of body data as it becomes available.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * FeedableBodyGenerator generator = new UnboundedQueueFeedableBodyGenerator();
+ * generator.setListener(new FeedListener() {
+ *     @Override
+ *     public void onContentAdded() {
+ *         System.out.println("New content is available");
+ *         // Resume request processing
+ *     }
+ *
+ *     @Override
+ *     public void onError(Throwable t) {
+ *         System.err.println("Error feeding content: " + t.getMessage());
+ *         // Handle error
+ *     }
+ * });
+ * }</pre>
+ */
 public interface FeedListener {
+  /**
+   * Called when new content has been added to the feedable body generator.
+   * <p>
+   * This notification indicates that data is available for transfer and any
+   * suspended operations may be resumed.
+   * </p>
+   */
   void onContentAdded();
 
+  /**
+   * Called when an error occurs while feeding content to the generator.
+   * <p>
+   * This notification allows the listener to handle errors that occur during
+   * the content feeding process.
+   * </p>
+   *
+   * @param t the error that occurred, never {@code null}
+   */
   void onError(Throwable t);
 }

--- a/client/src/main/java/org/asynchttpclient/request/body/generator/FeedableBodyGenerator.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/generator/FeedableBodyGenerator.java
@@ -16,12 +16,69 @@ package org.asynchttpclient.request.body.generator;
 import io.netty.buffer.ByteBuf;
 
 /**
- * {@link BodyGenerator} which may return just part of the payload at the time handler is requesting it.
- * If it happens, client becomes responsible for providing the rest of the chunks.
+ * A {@link BodyGenerator} that supports incremental feeding of body content.
+ * <p>
+ * Unlike regular body generators where all content is available upfront, feedable
+ * body generators allow content to be provided incrementally over time. This is useful
+ * for scenarios where the full request body is not immediately available, such as
+ * streaming uploads or reactive data sources.
+ * </p>
+ * <p>
+ * When the body generator returns only part of the payload, the client becomes
+ * responsible for feeding the remaining chunks through the {@link #feed} method.
+ * A {@link FeedListener} can be registered to receive notifications when content
+ * is added or errors occur.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Create a feedable body generator
+ * FeedableBodyGenerator generator = new UnboundedQueueFeedableBodyGenerator();
+ *
+ * // Set up a listener for notifications
+ * generator.setListener(new FeedListener() {
+ *     public void onContentAdded() {
+ *         System.out.println("Content available");
+ *     }
+ *     public void onError(Throwable t) {
+ *         System.err.println("Error: " + t);
+ *     }
+ * });
+ *
+ * // Feed data incrementally
+ * ByteBuf chunk1 = Unpooled.wrappedBuffer("Hello ".getBytes());
+ * generator.feed(chunk1, false);
+ *
+ * ByteBuf chunk2 = Unpooled.wrappedBuffer("World!".getBytes());
+ * generator.feed(chunk2, true); // Mark as last chunk
+ * }</pre>
  */
 public interface FeedableBodyGenerator extends BodyGenerator {
 
+  /**
+   * Feeds a chunk of data to the body generator.
+   * <p>
+   * This method adds a chunk of body content to the generator. The chunk is queued
+   * for transfer to the target. If this is the last chunk, the {@code isLast} parameter
+   * should be {@code true} to signal completion.
+   * </p>
+   *
+   * @param buffer the buffer containing the chunk data to feed
+   * @param isLast {@code true} if this is the last chunk, {@code false} otherwise
+   * @return {@code true} if the chunk was accepted, {@code false} if it could not be queued
+   *         (e.g., queue is full in bounded implementations)
+   * @throws Exception if an error occurs while feeding the chunk
+   */
   boolean feed(ByteBuf buffer, boolean isLast) throws Exception;
 
+  /**
+   * Sets the listener to be notified of feed events.
+   * <p>
+   * The listener will be called when content is successfully added to the generator
+   * or when errors occur during the feeding process.
+   * </p>
+   *
+   * @param listener the listener to notify, or {@code null} to remove the current listener
+   */
   void setListener(FeedListener listener);
 }

--- a/client/src/main/java/org/asynchttpclient/request/body/generator/FileBodyGenerator.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/generator/FileBodyGenerator.java
@@ -20,6 +20,32 @@ import static org.asynchttpclient.util.Assertions.assertNotNull;
 
 /**
  * Creates a request body from the contents of a file.
+ * <p>
+ * This body generator supports reading the entire file or a specific region within
+ * the file. It implements {@link BodyGenerator} and returns a {@link RandomAccessBody}
+ * to enable efficient zero-copy file transfers using Netty's file region support.
+ * </p>
+ * <p>
+ * Note: The {@link #createBody()} method is not actually invoked during request
+ * processing. Instead, Netty directly sends the file using its optimized file
+ * transfer mechanisms.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Create a body generator for an entire file
+ * File file = new File("upload.dat");
+ * BodyGenerator generator = new FileBodyGenerator(file);
+ *
+ * // Create a body generator for a specific region of a file
+ * BodyGenerator regionGenerator = new FileBodyGenerator(file, 1024, 2048);
+ *
+ * // Use with AsyncHttpClient
+ * AsyncHttpClient client = asyncHttpClient();
+ * client.preparePost("http://example.com/upload")
+ *     .setBody(generator)
+ *     .execute();
+ * }</pre>
  */
 public final class FileBodyGenerator implements BodyGenerator {
 
@@ -27,33 +53,68 @@ public final class FileBodyGenerator implements BodyGenerator {
   private final long regionSeek;
   private final long regionLength;
 
+  /**
+   * Constructs a file body generator for the entire file.
+   *
+   * @param file the file to read from
+   */
   public FileBodyGenerator(File file) {
     this(file, 0L, file.length());
   }
 
+  /**
+   * Constructs a file body generator for a specific region of the file.
+   *
+   * @param file         the file to read from
+   * @param regionSeek   the offset in bytes from the start of the file
+   * @param regionLength the number of bytes to read from the file
+   */
   public FileBodyGenerator(File file, long regionSeek, long regionLength) {
     this.file = assertNotNull(file, "file");
     this.regionLength = regionLength;
     this.regionSeek = regionSeek;
   }
 
+  /**
+   * Gets the file that this generator reads from.
+   *
+   * @return the file
+   */
   public File getFile() {
     return file;
   }
 
+  /**
+   * Gets the length of the region to read from the file.
+   *
+   * @return the region length in bytes
+   */
   public long getRegionLength() {
     return regionLength;
   }
 
+  /**
+   * Gets the offset within the file where reading should start.
+   *
+   * @return the region seek offset in bytes
+   */
   public long getRegionSeek() {
     return regionSeek;
   }
 
   /**
-   * {@inheritDoc}
+   * Creates a body instance.
+   * <p>
+   * Note: This method is not actually used during request processing. Netty directly
+   * sends the file using its optimized file transfer mechanisms, so calling this
+   * method will throw an exception.
+   * </p>
+   *
+   * @return never returns normally
+   * @throws UnsupportedOperationException always thrown as this method is not used
    */
   @Override
   public RandomAccessBody createBody() {
-    throw new UnsupportedOperationException("FileBodyGenerator.createBody isn't used, Netty direclt sends the file");
+    throw new UnsupportedOperationException("FileBodyGenerator.createBody isn't used, Netty directly sends the file");
   }
 }

--- a/client/src/main/java/org/asynchttpclient/request/body/generator/PushBody.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/generator/PushBody.java
@@ -18,20 +18,60 @@ import org.asynchttpclient.request.body.Body;
 
 import java.util.Queue;
 
+/**
+ * A body implementation that reads from a queue of chunks.
+ * <p>
+ * This class is used by {@link QueueBasedFeedableBodyGenerator} implementations to provide
+ * a body that pulls data from a queue as it becomes available. The body maintains state
+ * to track whether more data is expected, the transfer should be suspended, or the
+ * body is complete.
+ * </p>
+ * <p>
+ * The content length is unknown (-1) since data is fed incrementally to the queue.
+ * The body continues reading chunks from the queue until it receives a chunk marked
+ * as the last chunk.
+ * </p>
+ */
 public final class PushBody implements Body {
 
   private final Queue<BodyChunk> queue;
   private BodyState state = BodyState.CONTINUE;
 
+  /**
+   * Constructs a push body that reads from the specified queue.
+   *
+   * @param queue the queue containing body chunks
+   */
   public PushBody(Queue<BodyChunk> queue) {
     this.queue = queue;
   }
 
+  /**
+   * Returns the content length of this body.
+   * <p>
+   * Since the content is fed incrementally, the total length is not known in advance.
+   * </p>
+   *
+   * @return -1 indicating unknown length
+   */
   @Override
   public long getContentLength() {
     return -1;
   }
 
+  /**
+   * Transfers available chunks from the queue to the target buffer.
+   * <p>
+   * This method reads chunks from the queue and writes them to the target buffer
+   * until the buffer is full, no more chunks are available, or the last chunk
+   * has been processed.
+   * </p>
+   *
+   * @param target the buffer to write chunks to
+   * @return the current body state: {@link BodyState#CONTINUE} if more data may be available,
+   *         {@link BodyState#SUSPEND} if the queue is empty and more data is expected,
+   *         or {@link BodyState#STOP} if the last chunk has been processed
+   */
   @Override
   public BodyState transferTo(final ByteBuf target) {
     switch (state) {

--- a/client/src/main/java/org/asynchttpclient/request/body/generator/QueueBasedFeedableBodyGenerator.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/generator/QueueBasedFeedableBodyGenerator.java
@@ -18,22 +18,70 @@ import org.asynchttpclient.request.body.Body;
 
 import java.util.Queue;
 
+/**
+ * An abstract base class for feedable body generators backed by a queue.
+ * <p>
+ * This class provides a common implementation for feedable body generators that use
+ * a queue to store {@link BodyChunk}s. Subclasses must implement the {@link #offer(BodyChunk)}
+ * method to define how chunks are added to their specific queue implementation (bounded
+ * or unbounded).
+ * </p>
+ * <p>
+ * The generator creates {@link PushBody} instances that read from the queue as data
+ * becomes available. When chunks are successfully added, registered {@link FeedListener}s
+ * are notified.
+ * </p>
+ */
 public abstract class QueueBasedFeedableBodyGenerator<T extends Queue<BodyChunk>> implements FeedableBodyGenerator {
 
   protected final T queue;
   private FeedListener listener;
 
+  /**
+   * Constructs a queue-based feedable body generator.
+   *
+   * @param queue the queue to use for storing body chunks
+   */
   public QueueBasedFeedableBodyGenerator(T queue) {
     this.queue = queue;
   }
 
+  /**
+   * Creates a new body instance that reads from the queue.
+   *
+   * @return a new {@link PushBody} instance backed by the queue
+   */
   @Override
   public Body createBody() {
     return new PushBody(queue);
   }
 
+  /**
+   * Attempts to add a chunk to the queue.
+   * <p>
+   * Subclasses must implement this method to define the specific queuing behavior,
+   * such as blocking until space is available or returning immediately if the queue
+   * is full.
+   * </p>
+   *
+   * @param chunk the body chunk to add to the queue
+   * @return {@code true} if the chunk was successfully added, {@code false} otherwise
+   * @throws Exception if an error occurs while adding the chunk
+   */
   protected abstract boolean offer(BodyChunk chunk) throws Exception;
 
+  /**
+   * Feeds a chunk of data to the body generator.
+   * <p>
+   * This method wraps the buffer in a {@link BodyChunk}, attempts to add it to the queue,
+   * and notifies the listener if the chunk was successfully added.
+   * </p>
+   *
+   * @param buffer the buffer containing the chunk data
+   * @param isLast {@code true} if this is the last chunk, {@code false} otherwise
+   * @return {@code true} if the chunk was accepted, {@code false} otherwise
+   * @throws Exception if an error occurs while feeding the chunk
+   */
   @Override
   public boolean feed(final ByteBuf buffer, final boolean isLast) throws Exception {
     boolean offered = offer(new BodyChunk(buffer, isLast));
@@ -43,6 +91,11 @@ public abstract class QueueBasedFeedableBodyGenerator<T extends Queue<BodyChunk>
     return offered;
   }
 
+  /**
+   * Sets the listener to be notified when content is added.
+   *
+   * @param listener the listener to notify, or {@code null} to remove the current listener
+   */
   @Override
   public void setListener(FeedListener listener) {
     this.listener = listener;

--- a/client/src/main/java/org/asynchttpclient/request/body/generator/UnboundedQueueFeedableBodyGenerator.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/generator/UnboundedQueueFeedableBodyGenerator.java
@@ -15,12 +15,61 @@ package org.asynchttpclient.request.body.generator;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+/**
+ * A feedable body generator backed by an unbounded concurrent queue.
+ * <p>
+ * This implementation uses a {@link ConcurrentLinkedQueue} to store body chunks.
+ * Unlike {@link BoundedQueueFeedableBodyGenerator}, this generator will always accept
+ * new chunks regardless of queue size, which means it does not provide backpressure.
+ * This can lead to unbounded memory consumption if chunks are fed faster than they
+ * can be transferred.
+ * </p>
+ * <p>
+ * Use this generator when you need a simple feedable body without backpressure concerns,
+ * or when the data source naturally limits the rate of chunk production.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Create an unbounded feedable body generator
+ * UnboundedQueueFeedableBodyGenerator generator = new UnboundedQueueFeedableBodyGenerator();
+ *
+ * // Set up listener for notifications
+ * generator.setListener(new FeedListener() {
+ *     public void onContentAdded() {
+ *         System.out.println("Content available");
+ *     }
+ *     public void onError(Throwable t) {
+ *         System.err.println("Error: " + t.getMessage());
+ *     }
+ * });
+ *
+ * // Feed data - always succeeds
+ * ByteBuf buffer1 = Unpooled.wrappedBuffer("chunk1".getBytes());
+ * generator.feed(buffer1, false);
+ *
+ * ByteBuf buffer2 = Unpooled.wrappedBuffer("chunk2".getBytes());
+ * generator.feed(buffer2, true);
+ * }</pre>
+ */
 public final class UnboundedQueueFeedableBodyGenerator extends QueueBasedFeedableBodyGenerator<ConcurrentLinkedQueue<BodyChunk>> {
 
+  /**
+   * Constructs an unbounded queue feedable body generator.
+   */
   public UnboundedQueueFeedableBodyGenerator() {
     super(new ConcurrentLinkedQueue<>());
   }
 
+  /**
+   * Adds a chunk to the unbounded queue.
+   * <p>
+   * This method always succeeds and returns {@code true}, as the queue has no capacity limit.
+   * </p>
+   *
+   * @param chunk the body chunk to add to the queue
+   * @return {@code true} always, as the chunk is always added
+   */
   @Override
   protected boolean offer(BodyChunk chunk) {
     return queue.offer(chunk);

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/ByteArrayPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/ByteArrayPart.java
@@ -16,35 +16,122 @@ import java.nio.charset.Charset;
 
 import static org.asynchttpclient.util.Assertions.assertNotNull;
 
+/**
+ * A multipart part representing binary data from a byte array.
+ * <p>
+ * This class is used for in-memory binary data in multipart/form-data requests.
+ * It provides a convenient way to upload binary content without requiring file I/O.
+ * The content type is automatically determined from the file name if not explicitly
+ * specified.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Simple byte array part with auto-detected content type
+ * byte[] imageData = Files.readAllBytes(Paths.get("image.png"));
+ * Part imagePart = new ByteArrayPart("image", imageData);
+ *
+ * // Byte array part with explicit content type
+ * byte[] jsonData = "{\"key\":\"value\"}".getBytes(StandardCharsets.UTF_8);
+ * Part jsonPart = new ByteArrayPart("data", jsonData, "application/json");
+ *
+ * // Byte array part with file name for content type detection
+ * Part filePart = new ByteArrayPart("document", pdfBytes,
+ *     null, null, "document.pdf");
+ *
+ * // Use in a multipart request
+ * AsyncHttpClient client = asyncHttpClient();
+ * client.preparePost("http://example.com/upload")
+ *     .addBodyPart(imagePart)
+ *     .addBodyPart(jsonPart)
+ *     .execute();
+ * }</pre>
+ */
 public class ByteArrayPart extends FileLikePart {
 
   private final byte[] bytes;
 
+  /**
+   * Constructs a byte array part with name and data.
+   *
+   * @param name  the name of the form field
+   * @param bytes the binary data
+   */
   public ByteArrayPart(String name, byte[] bytes) {
     this(name, bytes, null);
   }
 
+  /**
+   * Constructs a byte array part with name, data, and content type.
+   *
+   * @param name        the name of the form field
+   * @param bytes       the binary data
+   * @param contentType the content type, or {@code null} to auto-detect
+   */
   public ByteArrayPart(String name, byte[] bytes, String contentType) {
     this(name, bytes, contentType, null);
   }
 
+  /**
+   * Constructs a byte array part with name, data, content type, and charset.
+   *
+   * @param name        the name of the form field
+   * @param bytes       the binary data
+   * @param contentType the content type, or {@code null} to auto-detect
+   * @param charset     the character encoding, or {@code null} for default
+   */
   public ByteArrayPart(String name, byte[] bytes, String contentType, Charset charset) {
     this(name, bytes, contentType, charset, null);
   }
 
+  /**
+   * Constructs a byte array part with name, data, content type, charset, and file name.
+   *
+   * @param name        the name of the form field
+   * @param bytes       the binary data
+   * @param contentType the content type, or {@code null} to auto-detect from fileName
+   * @param charset     the character encoding, or {@code null} for default
+   * @param fileName    the file name for content type detection and disposition header
+   */
   public ByteArrayPart(String name, byte[] bytes, String contentType, Charset charset, String fileName) {
     this(name, bytes, contentType, charset, fileName, null);
   }
 
+  /**
+   * Constructs a byte array part with name, data, content type, charset, file name, and content ID.
+   *
+   * @param name        the name of the form field
+   * @param bytes       the binary data
+   * @param contentType the content type, or {@code null} to auto-detect from fileName
+   * @param charset     the character encoding, or {@code null} for default
+   * @param fileName    the file name for content type detection and disposition header
+   * @param contentId   the content ID, or {@code null} if not needed
+   */
   public ByteArrayPart(String name, byte[] bytes, String contentType, Charset charset, String fileName, String contentId) {
     this(name, bytes, contentType, charset, fileName, contentId, null);
   }
 
+  /**
+   * Constructs a byte array part with all optional parameters.
+   *
+   * @param name             the name of the form field
+   * @param bytes            the binary data
+   * @param contentType      the content type, or {@code null} to auto-detect from fileName
+   * @param charset          the character encoding, or {@code null} for default
+   * @param fileName         the file name for content type detection and disposition header
+   * @param contentId        the content ID, or {@code null} if not needed
+   * @param transferEncoding the transfer encoding, or {@code null} for default
+   */
   public ByteArrayPart(String name, byte[] bytes, String contentType, Charset charset, String fileName, String contentId, String transferEncoding) {
     super(name, contentType, charset, fileName, contentId, transferEncoding);
     this.bytes = assertNotNull(bytes, "bytes");
   }
 
+  /**
+   * Returns the binary data of this part.
+   *
+   * @return the byte array containing the data
+   */
   public byte[] getBytes() {
     return bytes;
   }

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/FileLikePart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/FileLikePart.java
@@ -20,7 +20,17 @@ import java.nio.charset.Charset;
 import static org.asynchttpclient.util.MiscUtils.withDefault;
 
 /**
- * This class is an adaptation of the Apache HttpClient implementation
+ * Abstract base class for file-like multipart parts.
+ * <p>
+ * This class provides common functionality for parts that represent file-like content,
+ * including file uploads ({@link FilePart}), byte arrays ({@link ByteArrayPart}), and
+ * input streams ({@link InputStreamPart}). It handles automatic content type detection
+ * based on file name extensions using a MIME types mapping.
+ * </p>
+ * <p>
+ * This class is an adaptation of the Apache HttpClient implementation and includes
+ * a built-in MIME types file (ahc-mime.types) for content type detection.
+ * </p>
  */
 public abstract class FileLikePart extends PartBase {
 
@@ -35,19 +45,23 @@ public abstract class FileLikePart extends PartBase {
   }
 
   /**
-   * Default content encoding of file attachments.
+   * The file name associated with this part.
    */
   private String fileName;
 
   /**
-   * FilePart Constructor.
+   * Constructs a file-like part with the specified parameters.
+   * <p>
+   * If no content type is provided, it will be automatically determined from the
+   * file name extension using the built-in MIME types mapping.
+   * </p>
    *
-   * @param name              the name for this part
-   * @param contentType       the content type for this part, if <code>null</code> try to figure out from the fileName mime type
-   * @param charset           the charset encoding for this part
-   * @param fileName          the fileName
-   * @param contentId         the content id
-   * @param transferEncoding the transfer encoding
+   * @param name             the name of the form field
+   * @param contentType      the content type, or {@code null} to auto-detect from fileName
+   * @param charset          the character encoding, or {@code null} for default
+   * @param fileName         the file name for content type detection and disposition header
+   * @param contentId        the content ID, or {@code null} if not needed
+   * @param transferEncoding the transfer encoding, or {@code null} for default
    */
   public FileLikePart(String name, String contentType, Charset charset, String fileName, String contentId, String transferEncoding) {
     super(name,
@@ -58,14 +72,35 @@ public abstract class FileLikePart extends PartBase {
     this.fileName = fileName;
   }
 
+  /**
+   * Computes the content type based on the provided type or file name.
+   * <p>
+   * If a content type is explicitly provided, it is used. Otherwise, the content type
+   * is determined from the file name extension using the MIME types mapping.
+   * </p>
+   *
+   * @param contentType the explicit content type, or {@code null}
+   * @param fileName    the file name for type detection, or {@code null}
+   * @return the computed content type
+   */
   private static String computeContentType(String contentType, String fileName) {
     return contentType != null ? contentType : MIME_TYPES_FILE_TYPE_MAP.getContentType(withDefault(fileName, ""));
   }
 
+  /**
+   * Returns the file name associated with this part.
+   *
+   * @return the file name, or {@code null} if not set
+   */
   public String getFileName() {
     return fileName;
   }
 
+  /**
+   * Returns a string representation of this part including the file name.
+   *
+   * @return a string representation of this part
+   */
   @Override
   public String toString() {
     return super.toString() + " filename=" + fileName;

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/FilePart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/FilePart.java
@@ -17,30 +17,119 @@ import java.nio.charset.Charset;
 
 import static org.asynchttpclient.util.Assertions.assertNotNull;
 
+/**
+ * A multipart part representing a file upload.
+ * <p>
+ * This class is used for file uploads in multipart/form-data requests. The file must
+ * be a regular file (not a directory) and must be readable. The content type is
+ * automatically determined from the file name if not explicitly specified. If no file
+ * name is provided, the actual file name is used.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Simple file upload
+ * File document = new File("/path/to/document.pdf");
+ * Part filePart = new FilePart("document", document);
+ *
+ * // File upload with explicit content type
+ * File image = new File("/path/to/photo.jpg");
+ * Part imagePart = new FilePart("photo", image, "image/jpeg");
+ *
+ * // File upload with custom file name in request
+ * File data = new File("/path/to/data.bin");
+ * Part dataPart = new FilePart("data", data, "application/octet-stream",
+ *     null, "custom-name.bin");
+ *
+ * // Use in a multipart request
+ * AsyncHttpClient client = asyncHttpClient();
+ * client.preparePost("http://example.com/upload")
+ *     .addBodyPart(filePart)
+ *     .addBodyPart(imagePart)
+ *     .execute();
+ * }</pre>
+ */
 public class FilePart extends FileLikePart {
 
   private final File file;
 
+  /**
+   * Constructs a file part with name and file.
+   *
+   * @param name the name of the form field
+   * @param file the file to upload
+   * @throws IllegalArgumentException if the file is not a regular file or is not readable
+   */
   public FilePart(String name, File file) {
     this(name, file, null);
   }
 
+  /**
+   * Constructs a file part with name, file, and content type.
+   *
+   * @param name        the name of the form field
+   * @param file        the file to upload
+   * @param contentType the content type, or {@code null} to auto-detect from file name
+   * @throws IllegalArgumentException if the file is not a regular file or is not readable
+   */
   public FilePart(String name, File file, String contentType) {
     this(name, file, contentType, null);
   }
 
+  /**
+   * Constructs a file part with name, file, content type, and charset.
+   *
+   * @param name        the name of the form field
+   * @param file        the file to upload
+   * @param contentType the content type, or {@code null} to auto-detect from file name
+   * @param charset     the character encoding, or {@code null} for default
+   * @throws IllegalArgumentException if the file is not a regular file or is not readable
+   */
   public FilePart(String name, File file, String contentType, Charset charset) {
     this(name, file, contentType, charset, null);
   }
 
+  /**
+   * Constructs a file part with name, file, content type, charset, and custom file name.
+   *
+   * @param name        the name of the form field
+   * @param file        the file to upload
+   * @param contentType the content type, or {@code null} to auto-detect from fileName
+   * @param charset     the character encoding, or {@code null} for default
+   * @param fileName    the file name to use in the request, or {@code null} to use actual file name
+   * @throws IllegalArgumentException if the file is not a regular file or is not readable
+   */
   public FilePart(String name, File file, String contentType, Charset charset, String fileName) {
     this(name, file, contentType, charset, fileName, null);
   }
 
+  /**
+   * Constructs a file part with name, file, content type, charset, file name, and content ID.
+   *
+   * @param name        the name of the form field
+   * @param file        the file to upload
+   * @param contentType the content type, or {@code null} to auto-detect from fileName
+   * @param charset     the character encoding, or {@code null} for default
+   * @param fileName    the file name to use in the request, or {@code null} to use actual file name
+   * @param contentId   the content ID, or {@code null} if not needed
+   * @throws IllegalArgumentException if the file is not a regular file or is not readable
+   */
   public FilePart(String name, File file, String contentType, Charset charset, String fileName, String contentId) {
     this(name, file, contentType, charset, fileName, contentId, null);
   }
 
+  /**
+   * Constructs a file part with all optional parameters.
+   *
+   * @param name             the name of the form field
+   * @param file             the file to upload
+   * @param contentType      the content type, or {@code null} to auto-detect from fileName
+   * @param charset          the character encoding, or {@code null} for default
+   * @param fileName         the file name to use in the request, or {@code null} to use actual file name
+   * @param contentId        the content ID, or {@code null} if not needed
+   * @param transferEncoding the transfer encoding, or {@code null} for default
+   * @throws IllegalArgumentException if the file is not a regular file or is not readable
+   */
   public FilePart(String name, File file, String contentType, Charset charset, String fileName, String contentId, String transferEncoding) {
     super(name,
             contentType,
@@ -55,6 +144,11 @@ public class FilePart extends FileLikePart {
     this.file = file;
   }
 
+  /**
+   * Returns the file being uploaded.
+   *
+   * @return the file
+   */
   public File getFile() {
     return file;
   }

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/InputStreamPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/InputStreamPart.java
@@ -18,32 +18,122 @@ import java.nio.charset.Charset;
 
 import static org.asynchttpclient.util.Assertions.assertNotNull;
 
+/**
+ * A multipart part representing data from an input stream.
+ * <p>
+ * This class is used for streaming data uploads in multipart/form-data requests.
+ * It allows uploading data from an {@link InputStream} without loading the entire
+ * content into memory. The content length can be specified if known, or -1 if unknown.
+ * The content type is automatically determined from the file name if not explicitly
+ * specified.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Stream upload with known length
+ * InputStream stream = new FileInputStream("data.bin");
+ * long length = new File("data.bin").length();
+ * Part streamPart = new InputStreamPart("file", stream, "data.bin", length);
+ *
+ * // Stream upload with unknown length
+ * InputStream urlStream = new URL("http://example.com/data").openStream();
+ * Part urlPart = new InputStreamPart("download", urlStream, "download.dat", -1);
+ *
+ * // Stream upload with explicit content type
+ * InputStream jsonStream = new ByteArrayInputStream(jsonBytes);
+ * Part jsonPart = new InputStreamPart("json", jsonStream, "data.json",
+ *     jsonBytes.length, "application/json");
+ *
+ * // Use in a multipart request
+ * AsyncHttpClient client = asyncHttpClient();
+ * client.preparePost("http://example.com/upload")
+ *     .addBodyPart(streamPart)
+ *     .execute();
+ * }</pre>
+ */
 public class InputStreamPart extends FileLikePart {
 
   private final InputStream inputStream;
   private final long contentLength;
 
+  /**
+   * Constructs an input stream part with name, stream, and file name.
+   *
+   * @param name        the name of the form field
+   * @param inputStream the input stream to read from
+   * @param fileName    the file name for content type detection and disposition header
+   */
   public InputStreamPart(String name, InputStream inputStream, String fileName) {
     this(name, inputStream, fileName, -1);
   }
 
+  /**
+   * Constructs an input stream part with name, stream, file name, and content length.
+   *
+   * @param name          the name of the form field
+   * @param inputStream   the input stream to read from
+   * @param fileName      the file name for content type detection and disposition header
+   * @param contentLength the total number of bytes to read, or -1 if unknown
+   */
   public InputStreamPart(String name, InputStream inputStream, String fileName, long contentLength) {
     this(name, inputStream, fileName, contentLength, null);
   }
 
+  /**
+   * Constructs an input stream part with name, stream, file name, content length, and content type.
+   *
+   * @param name          the name of the form field
+   * @param inputStream   the input stream to read from
+   * @param fileName      the file name for content type detection and disposition header
+   * @param contentLength the total number of bytes to read, or -1 if unknown
+   * @param contentType   the content type, or {@code null} to auto-detect from fileName
+   */
   public InputStreamPart(String name, InputStream inputStream, String fileName, long contentLength, String contentType) {
     this(name, inputStream, fileName, contentLength, contentType, null);
   }
 
+  /**
+   * Constructs an input stream part with name, stream, file name, content length, content type, and charset.
+   *
+   * @param name          the name of the form field
+   * @param inputStream   the input stream to read from
+   * @param fileName      the file name for content type detection and disposition header
+   * @param contentLength the total number of bytes to read, or -1 if unknown
+   * @param contentType   the content type, or {@code null} to auto-detect from fileName
+   * @param charset       the character encoding, or {@code null} for default
+   */
   public InputStreamPart(String name, InputStream inputStream, String fileName, long contentLength, String contentType, Charset charset) {
     this(name, inputStream, fileName, contentLength, contentType, charset, null);
   }
 
+  /**
+   * Constructs an input stream part with name, stream, file name, content length, content type, charset, and content ID.
+   *
+   * @param name          the name of the form field
+   * @param inputStream   the input stream to read from
+   * @param fileName      the file name for content type detection and disposition header
+   * @param contentLength the total number of bytes to read, or -1 if unknown
+   * @param contentType   the content type, or {@code null} to auto-detect from fileName
+   * @param charset       the character encoding, or {@code null} for default
+   * @param contentId     the content ID, or {@code null} if not needed
+   */
   public InputStreamPart(String name, InputStream inputStream, String fileName, long contentLength, String contentType, Charset charset,
                          String contentId) {
     this(name, inputStream, fileName, contentLength, contentType, charset, contentId, null);
   }
 
+  /**
+   * Constructs an input stream part with all optional parameters.
+   *
+   * @param name             the name of the form field
+   * @param inputStream      the input stream to read from
+   * @param fileName         the file name for content type detection and disposition header
+   * @param contentLength    the total number of bytes to read, or -1 if unknown
+   * @param contentType      the content type, or {@code null} to auto-detect from fileName
+   * @param charset          the character encoding, or {@code null} for default
+   * @param contentId        the content ID, or {@code null} if not needed
+   * @param transferEncoding the transfer encoding, or {@code null} for default
+   */
   public InputStreamPart(String name, InputStream inputStream, String fileName, long contentLength, String contentType, Charset charset,
                          String contentId, String transferEncoding) {
     super(name,
@@ -56,10 +146,20 @@ public class InputStreamPart extends FileLikePart {
     this.contentLength = contentLength;
   }
 
+  /**
+   * Returns the input stream that provides the part's data.
+   *
+   * @return the input stream
+   */
   public InputStream getInputStream() {
     return inputStream;
   }
 
+  /**
+   * Returns the content length of this part.
+   *
+   * @return the content length in bytes, or -1 if unknown
+   */
   public long getContentLength() {
     return contentLength;
   }

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/MultipartBody.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/MultipartBody.java
@@ -29,6 +29,20 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.asynchttpclient.util.Assertions.assertNotNull;
 import static org.asynchttpclient.util.MiscUtils.closeSilently;
 
+/**
+ * A body implementation for multipart/form-data requests.
+ * <p>
+ * This class implements {@link RandomAccessBody} to provide both buffer-based and
+ * channel-based transfer of multipart data. It manages a list of {@link MultipartPart}s
+ * and transfers them sequentially, handling proper encoding according to the
+ * multipart/form-data specification.
+ * </p>
+ * <p>
+ * The body computes the total content length if all parts have known lengths, or
+ * returns -1 for chunked transfer encoding if any part has unknown length. Transfer
+ * operations are stateful and track the current part being transferred.
+ * </p>
+ */
 public class MultipartBody implements RandomAccessBody {
 
   private final static Logger LOGGER = LoggerFactory.getLogger(MultipartBody.class);
@@ -41,6 +55,13 @@ public class MultipartBody implements RandomAccessBody {
   private boolean done = false;
   private AtomicBoolean closed = new AtomicBoolean();
 
+  /**
+   * Constructs a multipart body with the specified parts, content type, and boundary.
+   *
+   * @param parts       the list of multipart parts to include
+   * @param contentType the Content-Type header value (typically includes the boundary)
+   * @param boundary    the multipart boundary bytes
+   */
   public MultipartBody(List<MultipartPart<? extends Part>> parts, String contentType, byte[] boundary) {
     this.boundary = boundary;
     this.contentType = contentType;

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/MultipartUtils.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/MultipartUtils.java
@@ -26,14 +26,29 @@ import static org.asynchttpclient.util.Assertions.assertNotNull;
 import static org.asynchttpclient.util.HttpUtils.*;
 import static org.asynchttpclient.util.MiscUtils.isNonEmpty;
 
+/**
+ * Utility class for creating multipart request bodies.
+ * <p>
+ * This class provides static methods for constructing {@link MultipartBody} instances
+ * from a list of {@link Part}s. It handles boundary generation, Content-Type header
+ * construction, and conversion of parts to their multipart representation.
+ * </p>
+ */
 public class MultipartUtils {
 
   /**
-   * Creates a new multipart entity containing the given parts.
+   * Creates a new multipart body containing the specified parts.
+   * <p>
+   * This method generates a multipart boundary, constructs the appropriate Content-Type
+   * header, and creates a {@link MultipartBody} that encodes all the parts according to
+   * the multipart/form-data specification. If a Content-Type header with a boundary is
+   * already present in the request headers, that boundary is used; otherwise, a new
+   * boundary is generated.
+   * </p>
    *
-   * @param parts          the parts to include.
-   * @param requestHeaders the request headers
-   * @return a MultipartBody
+   * @param parts          the parts to include in the multipart body
+   * @param requestHeaders the request headers, used to check for existing boundary
+   * @return a new multipart body containing the specified parts
    */
   public static MultipartBody newMultipartBody(List<Part> parts, HttpHeaders requestHeaders) {
     assertNotNull(parts, "parts");
@@ -63,6 +78,20 @@ public class MultipartUtils {
     return new MultipartBody(multipartParts, contentType, boundary);
   }
 
+  /**
+   * Generates multipart part representations from a list of parts.
+   * <p>
+   * This method converts high-level {@link Part} objects into their corresponding
+   * {@link MultipartPart} implementations that handle the actual encoding and transfer
+   * of data. Each part type (FilePart, ByteArrayPart, etc.) is mapped to its specific
+   * multipart implementation. A message end part is automatically appended to properly
+   * terminate the multipart message.
+   * </p>
+   *
+   * @param parts    the list of parts to convert
+   * @param boundary the multipart boundary bytes
+   * @return a list of multipart part implementations, including a terminating message end part
+   */
   public static List<MultipartPart<? extends Part>> generateMultipartParts(List<Part> parts, byte[] boundary) {
     List<MultipartPart<? extends Part>> multipartParts = new ArrayList<>(parts.size());
     for (Part part : parts) {

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/Part.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/Part.java
@@ -17,53 +17,113 @@ import org.asynchttpclient.Param;
 import java.nio.charset.Charset;
 import java.util.List;
 
+/**
+ * Represents a part in a multipart HTTP request.
+ * <p>
+ * A part is a component of a multipart/form-data request, which allows combining
+ * multiple pieces of data (text fields, files, etc.) in a single HTTP request body.
+ * Each part has a name, optional content type, charset, transfer encoding, and other
+ * metadata that controls how it is encoded in the request.
+ * </p>
+ * <p>
+ * Common implementations include {@link StringPart} for text fields, {@link FilePart}
+ * for file uploads, {@link ByteArrayPart} for in-memory binary data, and
+ * {@link InputStreamPart} for streaming data.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Create different types of parts
+ * Part textField = new StringPart("username", "john_doe");
+ * Part fileUpload = new FilePart("avatar", new File("photo.jpg"), "image/jpeg");
+ * Part binaryData = new ByteArrayPart("data", bytes, "application/octet-stream");
+ *
+ * // Use parts in a multipart request
+ * List<Part> parts = Arrays.asList(textField, fileUpload, binaryData);
+ * AsyncHttpClient client = asyncHttpClient();
+ * client.preparePost("http://example.com/upload")
+ *     .setBodyParts(parts)
+ *     .execute();
+ * }</pre>
+ */
 public interface Part {
 
   /**
-   * Return the name of this part.
+   * Returns the name of this part.
+   * <p>
+   * The name is used in the Content-Disposition header and corresponds to the
+   * form field name in HTML form submissions.
+   * </p>
    *
-   * @return The name.
+   * @return the part name, or {@code null} if no name is set
    */
   String getName();
 
   /**
    * Returns the content type of this part.
+   * <p>
+   * The content type specifies the MIME type of the part's content and is included
+   * in the Content-Type header. If {@code null}, the Content-Type header may be
+   * omitted or a default type may be used.
+   * </p>
    *
-   * @return the content type, or <code>null</code> to exclude the content
-   * type header
+   * @return the content type, or {@code null} to exclude the Content-Type header
    */
   String getContentType();
 
   /**
-   * Return the character encoding of this part.
+   * Returns the character encoding of this part.
+   * <p>
+   * The charset is appended to the Content-Type header and specifies how text
+   * content should be decoded. This is primarily used for text-based parts.
+   * </p>
    *
-   * @return the character encoding, or <code>null</code> to exclude the
-   * character encoding header
+   * @return the character encoding, or {@code null} to exclude the charset parameter
    */
   Charset getCharset();
 
   /**
-   * Return the transfer encoding of this part.
+   * Returns the transfer encoding of this part.
+   * <p>
+   * The transfer encoding specifies how the part's content is encoded for transmission
+   * and is included in the Content-Transfer-Encoding header.
+   * </p>
    *
-   * @return the transfer encoding, or <code>null</code> to exclude the
-   * transfer encoding header
+   * @return the transfer encoding, or {@code null} to exclude the Content-Transfer-Encoding header
    */
   String getTransferEncoding();
 
   /**
-   * Return the content ID of this part.
+   * Returns the content ID of this part.
+   * <p>
+   * The content ID provides a unique identifier for the part and is included
+   * in the Content-ID header. This is useful for referencing parts within
+   * multipart messages.
+   * </p>
    *
-   * @return the content ID, or <code>null</code> to exclude the content ID
-   * header
+   * @return the content ID, or {@code null} to exclude the Content-ID header
    */
   String getContentId();
 
   /**
-   * Gets the disposition-type to be used in Content-Disposition header
+   * Returns the disposition type to be used in the Content-Disposition header.
+   * <p>
+   * The disposition type is typically "form-data" for multipart/form-data requests.
+   * Other values like "attachment" may be used in different contexts.
+   * </p>
    *
-   * @return the disposition-type
+   * @return the disposition type, or {@code null} to use the default
    */
   String getDispositionType();
 
+  /**
+   * Returns the list of custom headers for this part.
+   * <p>
+   * Custom headers allow adding arbitrary HTTP headers to the part beyond the
+   * standard Content-Disposition, Content-Type, and other predefined headers.
+   * </p>
+   *
+   * @return the list of custom headers, or {@code null} if no custom headers are set
+   */
   List<Param> getCustomHeaders();
 }

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/PartBase.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/PartBase.java
@@ -18,20 +18,29 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Abstract base class implementing common functionality for multipart parts.
+ * <p>
+ * This class provides the core implementation of the {@link Part} interface,
+ * managing common metadata such as name, content type, charset, transfer encoding,
+ * disposition type, and custom headers. Concrete implementations extend this class
+ * to provide specific content handling.
+ * </p>
+ */
 public abstract class PartBase implements Part {
 
   /**
-   * The name of the form field, part of the Content-Disposition header
+   * The name of the form field, used in the Content-Disposition header.
    */
   private final String name;
 
   /**
-   * The main part of the Content-Type header
+   * The MIME type of the part's content, used in the Content-Type header.
    */
   private final String contentType;
 
   /**
-   * The charset (part of Content-Type header)
+   * The character encoding, appended to the Content-Type header.
    */
   private final Charset charset;
 
@@ -41,28 +50,28 @@ public abstract class PartBase implements Part {
   private final String transferEncoding;
 
   /**
-   * The Content-Id
+   * The Content-ID header value, used to uniquely identify the part.
    */
   private final String contentId;
 
   /**
-   * The disposition type (part of Content-Disposition)
+   * The disposition type used in the Content-Disposition header (e.g., "form-data").
    */
   private String dispositionType;
 
   /**
-   * Additional part headers
+   * Additional custom headers to be included with this part.
    */
   private List<Param> customHeaders;
 
   /**
-   * Constructor.
+   * Constructs a part base with the specified metadata.
    *
-   * @param name             The name of the part, or <code>null</code>
-   * @param contentType      The content type, or <code>null</code>
-   * @param charset          The character encoding, or <code>null</code>
-   * @param contentId        The content id, or <code>null</code>
-   * @param transferEncoding The transfer encoding, or <code>null</code>
+   * @param name             the name of the form field, or {@code null}
+   * @param contentType      the content type, or {@code null}
+   * @param charset          the character encoding, or {@code null}
+   * @param contentId        the content ID, or {@code null}
+   * @param transferEncoding the transfer encoding, or {@code null}
    */
   public PartBase(String name, String contentType, Charset charset, String contentId, String transferEncoding) {
     this.name = name;
@@ -102,6 +111,11 @@ public abstract class PartBase implements Part {
     return dispositionType;
   }
 
+  /**
+   * Sets the disposition type for this part.
+   *
+   * @param dispositionType the disposition type (e.g., "form-data", "attachment")
+   */
   public void setDispositionType(String dispositionType) {
     this.dispositionType = dispositionType;
   }
@@ -111,10 +125,24 @@ public abstract class PartBase implements Part {
     return customHeaders;
   }
 
+  /**
+   * Sets the custom headers for this part.
+   *
+   * @param customHeaders the list of custom headers, or {@code null} to clear
+   */
   public void setCustomHeaders(List<Param> customHeaders) {
     this.customHeaders = customHeaders;
   }
 
+  /**
+   * Adds a custom header to this part.
+   * <p>
+   * If no custom headers have been set yet, a new list is created.
+   * </p>
+   *
+   * @param name  the header name
+   * @param value the header value
+   */
   public void addCustomHeader(String name, String value) {
     if (customHeaders == null) {
       customHeaders = new ArrayList<>(2);
@@ -122,6 +150,11 @@ public abstract class PartBase implements Part {
     customHeaders.add(new Param(name, value));
   }
 
+  /**
+   * Returns a string representation of this part.
+   *
+   * @return a string containing the part's metadata
+   */
   public String toString() {
     return getClass().getSimpleName() +
             " name=" + getName() +

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/StringPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/StringPart.java
@@ -18,34 +18,103 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.asynchttpclient.util.Assertions.assertNotNull;
 import static org.asynchttpclient.util.MiscUtils.withDefault;
 
+/**
+ * A multipart part representing a string value (text field).
+ * <p>
+ * This class is used for text-based form fields in multipart/form-data requests.
+ * String parts default to UTF-8 encoding if no charset is specified. The string
+ * value must not contain NUL characters (U+0000) as per RFC 2048 section 2.8.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Simple text field
+ * Part username = new StringPart("username", "john_doe");
+ *
+ * // Text field with explicit content type
+ * Part description = new StringPart("description", "User profile", "text/plain");
+ *
+ * // Text field with custom charset
+ * Part comment = new StringPart("comment", "Comment text",
+ *     "text/plain", StandardCharsets.ISO_8859_1);
+ *
+ * // Use in a multipart request
+ * AsyncHttpClient client = asyncHttpClient();
+ * client.preparePost("http://example.com/form")
+ *     .addBodyPart(username)
+ *     .addBodyPart(description)
+ *     .execute();
+ * }</pre>
+ */
 public class StringPart extends PartBase {
 
   /**
-   * Default charset of string parameters
+   * Default charset for string parameters (UTF-8).
    */
   private static final Charset DEFAULT_CHARSET = UTF_8;
 
   /**
-   * Contents of this StringPart.
+   * The string value of this part.
    */
   private final String value;
 
+  /**
+   * Constructs a string part with the specified name and value.
+   *
+   * @param name  the name of the form field
+   * @param value the string value
+   */
   public StringPart(String name, String value) {
     this(name, value, null);
   }
 
+  /**
+   * Constructs a string part with name, value, and content type.
+   *
+   * @param name        the name of the form field
+   * @param value       the string value
+   * @param contentType the content type, or {@code null} for default
+   */
   public StringPart(String name, String value, String contentType) {
     this(name, value, contentType, null);
   }
 
+  /**
+   * Constructs a string part with name, value, content type, and charset.
+   *
+   * @param name        the name of the form field
+   * @param value       the string value
+   * @param contentType the content type, or {@code null} for default
+   * @param charset     the character encoding, or {@code null} for UTF-8
+   */
   public StringPart(String name, String value, String contentType, Charset charset) {
     this(name, value, contentType, charset, null);
   }
 
+  /**
+   * Constructs a string part with name, value, content type, charset, and content ID.
+   *
+   * @param name        the name of the form field
+   * @param value       the string value
+   * @param contentType the content type, or {@code null} for default
+   * @param charset     the character encoding, or {@code null} for UTF-8
+   * @param contentId   the content ID, or {@code null} if not needed
+   */
   public StringPart(String name, String value, String contentType, Charset charset, String contentId) {
     this(name, value, contentType, charset, contentId, null);
   }
 
+  /**
+   * Constructs a string part with all optional parameters.
+   *
+   * @param name             the name of the form field
+   * @param value            the string value
+   * @param contentType      the content type, or {@code null} for default
+   * @param charset          the character encoding, or {@code null} for UTF-8
+   * @param contentId        the content ID, or {@code null} if not needed
+   * @param transferEncoding the transfer encoding, or {@code null} for default
+   * @throws IllegalArgumentException if the value contains NUL characters
+   */
   public StringPart(String name, String value, String contentType, Charset charset, String contentId, String transferEncoding) {
     super(name, contentType, charsetOrDefault(charset), contentId, transferEncoding);
     assertNotNull(value, "value");
@@ -61,6 +130,11 @@ public class StringPart extends PartBase {
     return withDefault(charset, DEFAULT_CHARSET);
   }
 
+  /**
+   * Returns the string value of this part.
+   *
+   * @return the string value
+   */
   public String getValue() {
     return value;
   }

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/part/ByteArrayMultipartPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/part/ByteArrayMultipartPart.java
@@ -20,10 +20,23 @@ import org.asynchttpclient.request.body.multipart.ByteArrayPart;
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
 
+/**
+ * Multipart part implementation for {@link ByteArrayPart}.
+ * <p>
+ * This class handles encoding and transfer of in-memory byte array data as a multipart
+ * part. The byte array is wrapped in a ByteBuf for efficient transfer operations.
+ * </p>
+ */
 public class ByteArrayMultipartPart extends FileLikeMultipartPart<ByteArrayPart> {
 
   private final ByteBuf contentBuffer;
 
+  /**
+   * Constructs a byte array multipart part.
+   *
+   * @param part     the byte array part containing the data and metadata
+   * @param boundary the multipart boundary bytes
+   */
   public ByteArrayMultipartPart(ByteArrayPart part, byte[] boundary) {
     super(part, boundary);
     contentBuffer = Unpooled.wrappedBuffer(part.getBytes());

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/part/FileLikeMultipartPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/part/FileLikeMultipartPart.java
@@ -4,13 +4,33 @@ import org.asynchttpclient.request.body.multipart.FileLikePart;
 
 import static java.nio.charset.StandardCharsets.*;
 
+/**
+ * Abstract base class for multipart parts representing file-like content.
+ * <p>
+ * This class extends {@link MultipartPart} to provide common functionality for parts
+ * that have file names, such as file uploads, byte arrays, and input streams. It adds
+ * the filename parameter to the Content-Disposition header when present.
+ * </p>
+ * <p>
+ * Concrete implementations include {@link FileMultipartPart}, {@link ByteArrayMultipartPart},
+ * and {@link InputStreamMultipartPart}.
+ * </p>
+ *
+ * @param <T> the type of FileLikePart this multipart part represents
+ */
 public abstract class FileLikeMultipartPart<T extends FileLikePart> extends MultipartPart<T> {
 
   /**
-   * Attachment's file name as a byte array
+   * The filename parameter prefix for the Content-Disposition header.
    */
   private static final byte[] FILE_NAME_BYTES = "; filename=".getBytes(US_ASCII);
 
+  /**
+   * Constructs a file-like multipart part.
+   *
+   * @param part     the file-like part containing metadata
+   * @param boundary the multipart boundary bytes
+   */
   FileLikeMultipartPart(T part, byte[] boundary) {
     super(part, boundary);
   }

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/part/FileMultipartPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/part/FileMultipartPart.java
@@ -23,12 +23,28 @@ import java.nio.channels.WritableByteChannel;
 
 import static org.asynchttpclient.util.MiscUtils.closeSilently;
 
+/**
+ * Multipart part implementation for {@link FilePart}.
+ * <p>
+ * This class handles encoding and transfer of file uploads as multipart parts. It uses
+ * {@link FileChannel} for efficient file reading and supports both buffer-based and
+ * channel-based transfer operations. The file is validated for existence and readability
+ * during construction.
+ * </p>
+ */
 public class FileMultipartPart extends FileLikeMultipartPart<FilePart> {
 
   private final long length;
   private FileChannel channel;
   private long position = 0L;
 
+  /**
+   * Constructs a file multipart part.
+   *
+   * @param part     the file part containing the file and metadata
+   * @param boundary the multipart boundary bytes
+   * @throws IllegalArgumentException if the file doesn't exist or can't be read
+   */
   public FileMultipartPart(FilePart part, byte[] boundary) {
     super(part, boundary);
     File file = part.getFile();

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/part/InputStreamMultipartPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/part/InputStreamMultipartPart.java
@@ -26,12 +26,26 @@ import java.nio.channels.WritableByteChannel;
 
 import static org.asynchttpclient.util.MiscUtils.closeSilently;
 
+/**
+ * Multipart part implementation for {@link InputStreamPart}.
+ * <p>
+ * This class handles encoding and transfer of streaming data as multipart parts. It wraps
+ * the input stream in a {@link ReadableByteChannel} for efficient transfer operations and
+ * tracks the position for content length validation when known.
+ * </p>
+ */
 public class InputStreamMultipartPart extends FileLikeMultipartPart<InputStreamPart> {
 
   private long position = 0L;
   private ByteBuffer buffer;
   private ReadableByteChannel channel;
 
+  /**
+   * Constructs an input stream multipart part.
+   *
+   * @param part     the input stream part containing the stream and metadata
+   * @param boundary the multipart boundary bytes
+   */
   public InputStreamMultipartPart(InputStreamPart part, byte[] boundary) {
     super(part, boundary);
   }

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/part/MessageEndMultipartPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/part/MessageEndMultipartPart.java
@@ -21,11 +21,25 @@ import org.asynchttpclient.request.body.multipart.FileLikePart;
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
 
+/**
+ * Special multipart part that represents the end of a multipart message.
+ * <p>
+ * This class generates the final boundary marker that terminates a multipart/form-data
+ * message. It consists of "--boundary--CRLF" according to the multipart specification.
+ * Unlike regular parts, it has no associated Part object and no separate pre-content,
+ * content, and post-content phases.
+ * </p>
+ */
 public class MessageEndMultipartPart extends MultipartPart<FileLikePart> {
 
   // lazy
   private ByteBuf contentBuffer;
 
+  /**
+   * Constructs a message end multipart part.
+   *
+   * @param boundary the multipart boundary bytes
+   */
   public MessageEndMultipartPart(byte[] boundary) {
     super(null, boundary);
     state = MultipartState.PRE_CONTENT;

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/part/MultipartPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/part/MultipartPart.java
@@ -30,18 +30,34 @@ import java.nio.charset.Charset;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.asynchttpclient.util.MiscUtils.isNonEmpty;
 
+/**
+ * Abstract base class for multipart part implementations that handle encoding and transfer.
+ * <p>
+ * This class provides the core functionality for encoding and transferring multipart parts
+ * according to the multipart/form-data specification (RFC 2388). It manages the three-phase
+ * transfer process: pre-content (boundary and headers), content (actual data), and post-content
+ * (trailing CRLF).
+ * </p>
+ * <p>
+ * Subclasses must implement {@link #getContentLength()}, {@link #transferContentTo(ByteBuf)},
+ * and {@link #transferContentTo(WritableByteChannel)} to provide content-specific transfer logic.
+ * The class handles lazy loading of pre-content and post-content buffers to optimize memory usage.
+ * </p>
+ *
+ * @param <T> the type of Part this multipart part represents
+ */
 public abstract class MultipartPart<T extends PartBase> implements Closeable {
 
   /**
-   * Content disposition as a byte
+   * Quote character as a byte, used in headers.
    */
   static final byte QUOTE_BYTE = '\"';
   /**
-   * Carriage return/linefeed as a byte array
+   * Carriage return/line feed sequence as bytes (CRLF).
    */
   protected static final byte[] CRLF_BYTES = "\r\n".getBytes(US_ASCII);
   /**
-   * Extra characters as a byte array
+   * Boundary delimiter prefix ("--") as bytes.
    */
   protected static final byte[] EXTRA_BYTES = "--".getBytes(US_ASCII);
 

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/part/MultipartState.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/part/MultipartState.java
@@ -13,13 +13,38 @@
  */
 package org.asynchttpclient.request.body.multipart.part;
 
+/**
+ * Represents the state of a multipart part during transfer.
+ * <p>
+ * This enum tracks the progress of transferring a multipart part, which consists of
+ * three phases: pre-content (headers and boundary), content (actual data), and
+ * post-content (trailing boundary). The DONE state indicates the part has been
+ * completely transferred.
+ * </p>
+ */
 public enum MultipartState {
 
+  /**
+   * The part is transferring pre-content data (boundary, headers).
+   * This is the initial state when a part begins transfer.
+   */
   PRE_CONTENT,
 
+  /**
+   * The part is transferring the actual content data.
+   * This state follows PRE_CONTENT once all headers have been written.
+   */
   CONTENT,
 
+  /**
+   * The part is transferring post-content data (trailing CRLF).
+   * This state follows CONTENT once all data has been written.
+   */
   POST_CONTENT,
 
+  /**
+   * The part transfer is complete.
+   * All data for this part has been successfully transferred.
+   */
   DONE
 }

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/part/PartVisitor.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/part/PartVisitor.java
@@ -14,43 +14,107 @@ package org.asynchttpclient.request.body.multipart.part;
 
 import io.netty.buffer.ByteBuf;
 
+/**
+ * Visitor interface for building multipart part headers and boundaries.
+ * <p>
+ * This interface implements the Visitor pattern for constructing multipart part data.
+ * It provides methods for appending bytes and is used by {@link MultipartPart} to
+ * build pre-content and post-content buffers. Two implementations are provided:
+ * {@link CounterPartVisitor} for computing sizes and {@link ByteBufVisitor} for
+ * writing actual data.
+ * </p>
+ */
 public interface PartVisitor {
 
+  /**
+   * Visits a byte array, incorporating it into the part being built.
+   *
+   * @param bytes the byte array to visit
+   */
   void withBytes(byte[] bytes);
 
+  /**
+   * Visits a single byte, incorporating it into the part being built.
+   *
+   * @param b the byte to visit
+   */
   void withByte(byte b);
 
+  /**
+   * A visitor implementation that counts the total number of bytes visited.
+   * <p>
+   * This visitor is used to compute the size of pre-content and post-content sections
+   * before allocating buffers for them.
+   * </p>
+   */
   class CounterPartVisitor implements PartVisitor {
 
     private int count = 0;
 
+    /**
+     * Increments the count by the length of the byte array.
+     *
+     * @param bytes the byte array being visited
+     */
     @Override
     public void withBytes(byte[] bytes) {
       count += bytes.length;
     }
 
+    /**
+     * Increments the count by one.
+     *
+     * @param b the byte being visited
+     */
     @Override
     public void withByte(byte b) {
       count++;
     }
 
+    /**
+     * Returns the total count of bytes visited.
+     *
+     * @return the total byte count
+     */
     public int getCount() {
       return count;
     }
   }
 
+  /**
+   * A visitor implementation that writes bytes to a ByteBuf.
+   * <p>
+   * This visitor is used to actually write the pre-content and post-content data
+   * to allocated buffers that will be transferred.
+   * </p>
+   */
   class ByteBufVisitor implements PartVisitor {
     private final ByteBuf target;
 
+    /**
+     * Constructs a ByteBuf visitor with the specified target buffer.
+     *
+     * @param target the buffer to write bytes to
+     */
     public ByteBufVisitor(ByteBuf target) {
       this.target = target;
     }
 
+    /**
+     * Writes the byte array to the target buffer.
+     *
+     * @param bytes the byte array to write
+     */
     @Override
     public void withBytes(byte[] bytes) {
       target.writeBytes(bytes);
     }
 
+    /**
+     * Writes the single byte to the target buffer.
+     *
+     * @param b the byte to write
+     */
     @Override
     public void withByte(byte b) {
       target.writeByte(b);

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/part/StringMultipartPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/part/StringMultipartPart.java
@@ -20,10 +20,23 @@ import org.asynchttpclient.request.body.multipart.StringPart;
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
 
+/**
+ * Multipart part implementation for {@link StringPart}.
+ * <p>
+ * This class handles encoding and transfer of text field data as multipart parts. The
+ * string value is encoded using the part's charset and wrapped in a ByteBuf for transfer.
+ * </p>
+ */
 public class StringMultipartPart extends MultipartPart<StringPart> {
 
   private final ByteBuf contentBuffer;
 
+  /**
+   * Constructs a string multipart part.
+   *
+   * @param part     the string part containing the text and metadata
+   * @param boundary the multipart boundary bytes
+   */
   public StringMultipartPart(StringPart part, byte[] boundary) {
     super(part, boundary);
     contentBuffer = Unpooled.wrappedBuffer(part.getValue().getBytes(part.getCharset()));

--- a/client/src/main/java/org/asynchttpclient/resolver/RequestHostnameResolver.java
+++ b/client/src/main/java/org/asynchttpclient/resolver/RequestHostnameResolver.java
@@ -27,12 +27,35 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Hostname resolver that coordinates DNS resolution with AsyncHandler callbacks.
+ * <p>
+ * This singleton resolver wraps Netty's NameResolver and provides hooks for
+ * AsyncHandlers to be notified of resolution attempts, successes, and failures.
+ * It converts resolved InetAddresses to InetSocketAddresses with the appropriate port.
+ * </p>
+ */
 public enum RequestHostnameResolver {
 
+  /** Singleton instance */
   INSTANCE;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RequestHostnameResolver.class);
 
+  /**
+   * Resolves a hostname to a list of socket addresses, notifying the handler of progress.
+   * <p>
+   * This method performs asynchronous DNS resolution using the provided name resolver,
+   * and invokes the appropriate callbacks on the async handler for resolution attempts,
+   * successes, and failures.
+   * </p>
+   *
+   * @param nameResolver the Netty name resolver to use for DNS resolution
+   * @param unresolvedAddress the unresolved socket address containing the hostname and port
+   * @param asyncHandler the handler to notify of resolution events
+   * @return a future that will be completed with the list of resolved socket addresses,
+   *         or failed with an exception if resolution fails
+   */
   public Future<List<InetSocketAddress>> resolve(NameResolver<InetAddress> nameResolver, InetSocketAddress unresolvedAddress, AsyncHandler<?> asyncHandler) {
 
     final String hostname = unresolvedAddress.getHostString();

--- a/client/src/main/java/org/asynchttpclient/spnego/NamePasswordCallbackHandler.java
+++ b/client/src/main/java/org/asynchttpclient/spnego/NamePasswordCallbackHandler.java
@@ -11,6 +11,22 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import java.io.IOException;
 import java.lang.reflect.Method;
 
+/**
+ * Callback handler that provides username and password for JAAS authentication.
+ * <p>
+ * This implementation handles standard {@link NameCallback} and {@link PasswordCallback}
+ * callbacks, as well as custom password callbacks through reflection. It is primarily
+ * used for Kerberos/SPNEGO authentication where credentials need to be provided
+ * programmatically.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * CallbackHandler handler = new NamePasswordCallbackHandler("username", "password");
+ * LoginContext loginContext = new LoginContext("MyContext", handler);
+ * loginContext.login();
+ * }</pre>
+ */
 public class NamePasswordCallbackHandler implements CallbackHandler {
   private final Logger log = LoggerFactory.getLogger(getClass());
   private static final String PASSWORD_CALLBACK_NAME = "setObject";
@@ -22,16 +38,46 @@ public class NamePasswordCallbackHandler implements CallbackHandler {
 
   private String passwordCallbackName;
 
+  /**
+   * Creates a new callback handler with the specified username and password.
+   *
+   * @param username the username to provide in callbacks
+   * @param password the password to provide in callbacks
+   */
   public NamePasswordCallbackHandler(String username, String password) {
     this(username, password, null);
   }
 
+  /**
+   * Creates a new callback handler with the specified username, password, and custom
+   * password callback method name.
+   *
+   * @param username the username to provide in callbacks
+   * @param password the password to provide in callbacks
+   * @param passwordCallbackName the name of the method to invoke for custom password callbacks
+   *                            (can be null to use the default "setObject")
+   */
   public NamePasswordCallbackHandler(String username, String password, String passwordCallbackName) {
     this.username = username;
     this.password = password;
     this.passwordCallbackName = passwordCallbackName;
   }
 
+  /**
+   * Handles the specified callbacks by providing username and password information.
+   * <p>
+   * This method supports:
+   * </p>
+   * <ul>
+   *   <li>{@link NameCallback} - provides the username</li>
+   *   <li>{@link PasswordCallback} - provides the password as a character array</li>
+   *   <li>Custom callbacks - invokes password setter methods through reflection</li>
+   * </ul>
+   *
+   * @param callbacks the callbacks to handle
+   * @throws IOException if an I/O error occurs
+   * @throws UnsupportedCallbackException if a callback type is not supported
+   */
   public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
     for (int i = 0; i < callbacks.length; i++) {
       Callback callback = callbacks[i];
@@ -50,16 +96,30 @@ public class NamePasswordCallbackHandler implements CallbackHandler {
     }
   }
 
+  /**
+   * Extension point for subclasses to handle custom callback types.
+   * <p>
+   * This method is called before standard callback handling. Subclasses can override
+   * this method to provide custom callback handling logic.
+   * </p>
+   *
+   * @param callback the callback to handle
+   * @return {@code true} if the callback was handled, {@code false} otherwise
+   */
   protected boolean handleCallback(Callback callback) {
     return false;
   }
 
-  /*
-   * This method is called from the handle(Callback[]) method when the specified callback
-   * did not match any of the known callback classes. It looks for the callback method
-   * having the specified method name with one of the supported parameter types.
-   * If found, it invokes the callback method on the object and returns true.
-   * If not, it returns false.
+  /**
+   * Invokes a password setter method on the callback object through reflection.
+   * <p>
+   * This method is called when the callback doesn't match any of the standard types.
+   * It looks for a method with the configured name (or default "setObject") that accepts
+   * one of the supported parameter types (Object, char[], or String).
+   * </p>
+   *
+   * @param callback the callback on which to invoke the password setter
+   * @return {@code true} if a matching method was found and invoked, {@code false} otherwise
    */
   private boolean invokePasswordCallback(Callback callback) {
     String cbname = passwordCallbackName == null

--- a/client/src/main/java/org/asynchttpclient/spnego/SpnegoEngineException.java
+++ b/client/src/main/java/org/asynchttpclient/spnego/SpnegoEngineException.java
@@ -15,15 +15,31 @@ package org.asynchttpclient.spnego;
 
 /**
  * Signals SPNEGO protocol failure.
+ * <p>
+ * This exception is thrown when an error occurs during SPNEGO authentication processing,
+ * such as when GSS context initialization fails, credentials are invalid or expired,
+ * or login failures occur.
+ * </p>
  */
 public class SpnegoEngineException extends Exception {
 
   private static final long serialVersionUID = -3123799505052881438L;
 
+  /**
+   * Creates a new SpnegoEngineException with the specified message.
+   *
+   * @param message the exception detail message
+   */
   public SpnegoEngineException(String message) {
     super(message);
   }
 
+  /**
+   * Creates a new SpnegoEngineException with the specified detail message and cause.
+   *
+   * @param message the exception detail message
+   * @param cause the {@code Throwable} that caused this exception
+   */
   public SpnegoEngineException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/client/src/main/java/org/asynchttpclient/spnego/SpnegoTokenGenerator.java
+++ b/client/src/main/java/org/asynchttpclient/spnego/SpnegoTokenGenerator.java
@@ -41,14 +41,31 @@ package org.asynchttpclient.spnego;
 import java.io.IOException;
 
 /**
- * Abstract SPNEGO token generator. Implementations should take an Kerberos ticket and transform
- * into a SPNEGO token.
- * <br>
+ * Interface for generating SPNEGO tokens from Kerberos tickets.
+ * <p>
+ * Implementations of this interface transform Kerberos tickets into SPNEGO tokens
+ * by wrapping them in the appropriate DER-encoded SPNEGO structure. This is necessary
+ * for servers that only accept SPNEGO tokens but not raw Kerberos tickets.
+ * </p>
+ * <p>
  * Implementations of this interface are expected to be thread-safe.
+ * </p>
  *
  * @since 4.1
  */
 public interface SpnegoTokenGenerator {
 
+  /**
+   * Generates a SPNEGO DER-encoded object from a Kerberos ticket.
+   * <p>
+   * This method wraps the provided Kerberos ticket in a SPNEGO token structure
+   * according to RFC 4178. The resulting token can be sent to servers that require
+   * SPNEGO authentication.
+   * </p>
+   *
+   * @param kerberosTicket the Kerberos ticket bytes to wrap
+   * @return the SPNEGO DER-encoded token bytes
+   * @throws IOException if an error occurs during token generation
+   */
   byte[] generateSpnegoDERObject(byte[] kerberosTicket) throws IOException;
 }

--- a/client/src/main/java/org/asynchttpclient/uri/Uri.java
+++ b/client/src/main/java/org/asynchttpclient/uri/Uri.java
@@ -22,11 +22,40 @@ import static org.asynchttpclient.util.Assertions.assertNotEmpty;
 import static org.asynchttpclient.util.MiscUtils.isEmpty;
 import static org.asynchttpclient.util.MiscUtils.isNonEmpty;
 
+/**
+ * Immutable URI representation optimized for HTTP client operations.
+ * <p>
+ * This class provides a high-performance URI implementation that parses and validates
+ * URI components according to RFC 3986. It supports HTTP, HTTPS, WS (WebSocket), and
+ * WSS (secure WebSocket) schemes.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Parse a URI from string
+ * Uri uri = Uri.create("https://example.com:8443/path?query=value");
+ *
+ * // Access components
+ * String scheme = uri.getScheme();     // "https"
+ * String host = uri.getHost();         // "example.com"
+ * int port = uri.getPort();            // 8443
+ * String path = uri.getPath();         // "/path"
+ * String query = uri.getQuery();       // "query=value"
+ *
+ * // Create with context (relative URL resolution)
+ * Uri base = Uri.create("https://example.com/foo/bar");
+ * Uri relative = Uri.create(base, "../baz");  // resolves to https://example.com/foo/baz
+ * }</pre>
+ */
 public class Uri {
 
+  /** HTTP scheme constant */
   public static final String HTTP = "http";
+  /** HTTPS scheme constant */
   public static final String HTTPS = "https";
+  /** WebSocket scheme constant */
   public static final String WS = "ws";
+  /** Secure WebSocket scheme constant */
   public static final String WSS = "wss";
   private final String scheme;
   private final String userInfo;

--- a/client/src/main/java/org/asynchttpclient/util/Assertions.java
+++ b/client/src/main/java/org/asynchttpclient/util/Assertions.java
@@ -13,11 +13,37 @@
  */
 package org.asynchttpclient.util;
 
+/**
+ * Utility class for performing common assertion checks on method parameters.
+ * <p>
+ * This class provides convenience methods to validate that parameters meet certain requirements
+ * such as being non-null or non-empty. These methods throw appropriate exceptions when assertions fail.
+ * </p>
+ */
 public final class Assertions {
 
   private Assertions() {
   }
 
+  /**
+   * Asserts that the specified value is not null.
+   * <p>
+   * This method validates that the provided value is not null and returns the value if valid.
+   * If the value is null, a {@link NullPointerException} is thrown with the parameter name.
+   * </p>
+   *
+   * <p><b>Usage Examples:</b></p>
+   * <pre>{@code
+   * String userName = assertNotNull(getUserName(), "userName");
+   * Request request = assertNotNull(buildRequest(), "request");
+   * }</pre>
+   *
+   * @param <T>   the type of the value being checked
+   * @param value the value to check for null
+   * @param name  the name of the parameter (used in error message)
+   * @return the non-null value
+   * @throws NullPointerException if the value is null
+   */
   public static <T> T assertNotNull(T value, String name) {
     if (value == null)
       throw new NullPointerException(name);
@@ -25,6 +51,26 @@ public final class Assertions {
 
   }
 
+  /**
+   * Asserts that the specified string is not null and not empty.
+   * <p>
+   * This method validates that the provided string is not null and has a length greater than zero.
+   * If the value is null, a {@link NullPointerException} is thrown. If the value is an empty string,
+   * an {@link IllegalArgumentException} is thrown.
+   * </p>
+   *
+   * <p><b>Usage Examples:</b></p>
+   * <pre>{@code
+   * String host = assertNotEmpty(uri.getHost(), "host");
+   * String userName = assertNotEmpty(credentials.getUsername(), "userName");
+   * }</pre>
+   *
+   * @param value the string value to check
+   * @param name  the name of the parameter (used in error messages)
+   * @return the non-empty string value
+   * @throws NullPointerException     if the value is null
+   * @throws IllegalArgumentException if the value is an empty string
+   */
   public static String assertNotEmpty(String value, String name) {
     assertNotNull(value, name);
     if (value.length() == 0)

--- a/client/src/main/java/org/asynchttpclient/util/Counted.java
+++ b/client/src/main/java/org/asynchttpclient/util/Counted.java
@@ -1,23 +1,38 @@
 package org.asynchttpclient.util;
 
 /**
- * An interface that defines useful methods to check how many {@linkplain org.asynchttpclient.AsyncHttpClient}
- * instances this particular implementation is shared with.
+ * An interface that defines useful methods to track how many {@linkplain org.asynchttpclient.AsyncHttpClient}
+ * instances share this particular implementation.
+ * <p>
+ * This interface provides thread-safe counter operations for managing shared resources across
+ * multiple client instances. Implementations should ensure atomic operations for increment,
+ * decrement, and count retrieval.
+ * </p>
  */
 public interface Counted {
 
     /**
-     * Increment counter and return the incremented value
+     * Atomically increments the counter by one and returns the updated value.
+     *
+     * @return the updated counter value after incrementing
      */
     int incrementAndGet();
 
     /**
-     * Decrement counter and return the decremented value
+     * Atomically decrements the counter by one and returns the updated value.
+     *
+     * @return the updated counter value after decrementing
      */
     int decrementAndGet();
 
     /**
-     * Return the current counter
+     * Returns the current value of the counter.
+     * <p>
+     * Note: The returned value is a snapshot and may change immediately after this method returns
+     * if other threads are concurrently modifying the counter.
+     * </p>
+     *
+     * @return the current counter value
      */
     int count();
 }

--- a/client/src/main/java/org/asynchttpclient/util/DateUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/DateUtils.java
@@ -13,11 +13,36 @@
  */
 package org.asynchttpclient.util;
 
+/**
+ * Utility class for date and time operations.
+ * <p>
+ * This class provides convenience methods for working with time-related operations
+ * in the async-http-client library.
+ * </p>
+ */
 public final class DateUtils {
 
   private DateUtils() {
   }
 
+  /**
+   * Returns the current time in milliseconds.
+   * <p>
+   * This method is a wrapper around {@link System#currentTimeMillis()} and provides
+   * the current time in milliseconds since the Unix epoch (January 1, 1970, 00:00:00 GMT).
+   * The name "unprecise" indicates that the precision may vary depending on the underlying
+   * operating system.
+   * </p>
+   *
+   * <p><b>Usage Examples:</b></p>
+   * <pre>{@code
+   * long startTime = unpreciseMillisTime();
+   * // perform operation
+   * long elapsed = unpreciseMillisTime() - startTime;
+   * }</pre>
+   *
+   * @return the current time in milliseconds
+   */
   public static long unpreciseMillisTime() {
     return System.currentTimeMillis();
   }

--- a/client/src/main/java/org/asynchttpclient/util/HttpConstants.java
+++ b/client/src/main/java/org/asynchttpclient/util/HttpConstants.java
@@ -16,36 +16,131 @@ package org.asynchttpclient.util;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
+/**
+ * Constants for HTTP methods and response status codes.
+ * <p>
+ * This class provides convenient access to commonly used HTTP method names and
+ * response status codes as defined in HTTP/1.1 specifications.
+ * </p>
+ */
 public final class HttpConstants {
 
   private HttpConstants() {
   }
 
+  /**
+   * HTTP method name constants.
+   * <p>
+   * This class provides string constants for standard HTTP methods as defined in
+   * RFC 7231 and related specifications.
+   * </p>
+   */
   public static final class Methods {
+    /**
+     * The CONNECT method establishes a tunnel to the server identified by the target resource.
+     */
     public static final String CONNECT = HttpMethod.CONNECT.name();
+
+    /**
+     * The DELETE method deletes the specified resource.
+     */
     public static final String DELETE = HttpMethod.DELETE.name();
+
+    /**
+     * The GET method requests a representation of the specified resource.
+     */
     public static final String GET = HttpMethod.GET.name();
+
+    /**
+     * The HEAD method asks for a response identical to a GET request, but without the response body.
+     */
     public static final String HEAD = HttpMethod.HEAD.name();
+
+    /**
+     * The OPTIONS method describes the communication options for the target resource.
+     */
     public static final String OPTIONS = HttpMethod.OPTIONS.name();
+
+    /**
+     * The PATCH method applies partial modifications to a resource.
+     */
     public static final String PATCH = HttpMethod.PATCH.name();
+
+    /**
+     * The POST method submits an entity to the specified resource.
+     */
     public static final String POST = HttpMethod.POST.name();
+
+    /**
+     * The PUT method replaces all current representations of the target resource with the request payload.
+     */
     public static final String PUT = HttpMethod.PUT.name();
+
+    /**
+     * The TRACE method performs a message loop-back test along the path to the target resource.
+     */
     public static final String TRACE = HttpMethod.TRACE.name();
 
     private Methods() {
     }
   }
 
+  /**
+   * HTTP response status code constants.
+   * <p>
+   * This class provides integer constants for commonly used HTTP response status codes
+   * as defined in RFC 7231 and related specifications.
+   * </p>
+   */
   public static final class ResponseStatusCodes {
+    /**
+     * 100 Continue - The server has received the request headers and the client should proceed to send the request body.
+     */
     public static final int CONTINUE_100 = HttpResponseStatus.CONTINUE.code();
+
+    /**
+     * 101 Switching Protocols - The server is switching protocols as requested by the client.
+     */
     public static final int SWITCHING_PROTOCOLS_101 = HttpResponseStatus.SWITCHING_PROTOCOLS.code();
+
+    /**
+     * 200 OK - The request has succeeded.
+     */
     public static final int OK_200 = HttpResponseStatus.OK.code();
+
+    /**
+     * 301 Moved Permanently - The resource has been permanently moved to a new URI.
+     */
     public static final int MOVED_PERMANENTLY_301 = HttpResponseStatus.MOVED_PERMANENTLY.code();
+
+    /**
+     * 302 Found - The resource temporarily resides under a different URI.
+     */
     public static final int FOUND_302 = HttpResponseStatus.FOUND.code();
+
+    /**
+     * 303 See Other - The response can be found under a different URI using a GET method.
+     */
     public static final int SEE_OTHER_303 = HttpResponseStatus.SEE_OTHER.code();
+
+    /**
+     * 307 Temporary Redirect - The resource temporarily resides under a different URI, and the request method should not change.
+     */
     public static final int TEMPORARY_REDIRECT_307 = HttpResponseStatus.TEMPORARY_REDIRECT.code();
+
+    /**
+     * 308 Permanent Redirect - The resource has been permanently moved to a new URI, and the request method should not change.
+     */
     public static final int PERMANENT_REDIRECT_308 = HttpResponseStatus.PERMANENT_REDIRECT.code();
+
+    /**
+     * 401 Unauthorized - The request requires user authentication.
+     */
     public static final int UNAUTHORIZED_401 = HttpResponseStatus.UNAUTHORIZED.code();
+
+    /**
+     * 407 Proxy Authentication Required - The client must first authenticate itself with the proxy.
+     */
     public static final int PROXY_AUTHENTICATION_REQUIRED_407 = HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED.code();
 
     private ResponseStatusCodes() {

--- a/client/src/main/java/org/asynchttpclient/util/HttpUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/HttpUtils.java
@@ -29,12 +29,23 @@ import java.util.concurrent.ThreadLocalRandom;
 import static java.nio.charset.StandardCharsets.*;
 
 /**
- * {@link org.asynchttpclient.AsyncHttpClient} common utilities.
+ * Common utility methods for HTTP operations.
+ * <p>
+ * This class provides various helper methods for working with HTTP headers, URIs, encoding,
+ * and content types. It includes utilities for URL encoding, multipart boundaries, header
+ * parsing, and form parameter encoding.
+ * </p>
  */
 public class HttpUtils {
 
+  /**
+   * Header value for accepting all content types ("*&#47;*").
+   */
   public static final AsciiString ACCEPT_ALL_HEADER_VALUE = new AsciiString("*/*");
 
+  /**
+   * Header value for gzip and deflate compression encoding.
+   */
   public static final AsciiString GZIP_DEFLATE = new AsciiString(HttpHeaderValues.GZIP + "," + HttpHeaderValues.DEFLATE);
 
   private static final String CONTENT_TYPE_CHARSET_ATTRIBUTE = "charset=";
@@ -46,12 +57,32 @@ public class HttpUtils {
   private HttpUtils() {
   }
 
+  /**
+   * Computes the Host header value from a URI.
+   * <p>
+   * If the port is the default port for the scheme or is not specified, only the host is returned.
+   * Otherwise, the host and port are returned in the format "host:port".
+   * </p>
+   *
+   * @param uri the URI
+   * @return the Host header value
+   */
   public static String hostHeader(Uri uri) {
     String host = uri.getHost();
     int port = uri.getPort();
     return port == -1 || port == uri.getSchemeDefaultPort() ? host : host + ":" + port;
   }
 
+  /**
+   * Computes the Origin header value from a URI.
+   * <p>
+   * The Origin header includes the scheme, host, and port (if non-default).
+   * For secure URIs, "https://" is used; otherwise, "http://".
+   * </p>
+   *
+   * @param uri the URI
+   * @return the Origin header value
+   */
   public static String originHeader(Uri uri) {
     StringBuilder sb = StringBuilderPool.DEFAULT.stringBuilder();
     sb.append(uri.isSecured() ? "https://" : "http://").append(uri.getHost());
@@ -61,15 +92,44 @@ public class HttpUtils {
     return sb.toString();
   }
 
+  /**
+   * Extracts the charset attribute from a Content-Type header.
+   * <p>
+   * Parses the Content-Type header and returns the Charset specified in the charset attribute.
+   * </p>
+   *
+   * @param contentType the Content-Type header value
+   * @return the Charset, or null if not found or invalid
+   */
   public static Charset extractContentTypeCharsetAttribute(String contentType) {
     String charsetName = extractContentTypeAttribute(contentType, CONTENT_TYPE_CHARSET_ATTRIBUTE);
     return charsetName != null ? Charset.forName(charsetName) : null;
   }
 
+  /**
+   * Extracts the boundary attribute from a Content-Type header.
+   * <p>
+   * Parses the Content-Type header and returns the boundary value used for multipart content.
+   * </p>
+   *
+   * @param contentType the Content-Type header value
+   * @return the boundary value, or null if not found
+   */
   public static String extractContentTypeBoundaryAttribute(String contentType) {
     return extractContentTypeAttribute(contentType, CONTENT_TYPE_BOUNDARY_ATTRIBUTE);
   }
 
+  /**
+   * Extracts a specific attribute value from a Content-Type header.
+   * <p>
+   * Searches for the specified attribute name in the Content-Type header and returns
+   * its value, trimming any surrounding quotes or whitespace.
+   * </p>
+   *
+   * @param contentType the Content-Type header value
+   * @param attribute   the attribute name to extract (e.g., "charset=", "boundary=")
+   * @return the attribute value, or null if not found
+   */
   private static String extractContentTypeAttribute(String contentType, String attribute) {
     if (contentType == null) {
       return null;
@@ -114,7 +174,15 @@ public class HttpUtils {
   // The pool of ASCII chars to be used for generating a multipart boundary.
   private static byte[] MULTIPART_CHARS = "-_1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".getBytes(US_ASCII);
 
-  // a random size from 30 to 40
+  /**
+   * Computes a random multipart boundary.
+   * <p>
+   * Generates a random boundary string of 30-40 characters using alphanumeric characters,
+   * hyphens, and underscores. This boundary is used to delimit parts in multipart/form-data requests.
+   * </p>
+   *
+   * @return a byte array containing the random boundary
+   */
   public static byte[] computeMultipartBoundary() {
     ThreadLocalRandom random = ThreadLocalRandom.current();
     byte[] bytes = new byte[random.nextInt(11) + 30];
@@ -124,6 +192,17 @@ public class HttpUtils {
     return bytes;
   }
 
+  /**
+   * Adds a boundary attribute to a Content-Type header value.
+   * <p>
+   * Appends the boundary attribute to the given Content-Type base value, properly
+   * handling semicolon separators.
+   * </p>
+   *
+   * @param base     the base Content-Type value
+   * @param boundary the boundary value to add
+   * @return the complete Content-Type header value with boundary
+   */
   public static String patchContentTypeWithBoundaryAttribute(CharSequence base, byte[] boundary) {
     StringBuilder sb = StringBuilderPool.DEFAULT.stringBuilder().append(base);
     if (base.length() != 0 && base.charAt(base.length() - 1) != ';') {
@@ -132,14 +211,41 @@ public class HttpUtils {
     return sb.append(' ').append(CONTENT_TYPE_BOUNDARY_ATTRIBUTE).append(new String(boundary, US_ASCII)).toString();
   }
 
+  /**
+   * Determines whether to follow redirects for a request.
+   * <p>
+   * Returns the request-specific setting if present, otherwise falls back to the client configuration.
+   * </p>
+   *
+   * @param config  the client configuration
+   * @param request the request
+   * @return true if redirects should be followed, false otherwise
+   */
   public static boolean followRedirect(AsyncHttpClientConfig config, Request request) {
     return request.getFollowRedirect() != null ? request.getFollowRedirect() : config.isFollowRedirect();
   }
 
+  /**
+   * URL-encodes form parameters into a ByteBuffer.
+   * <p>
+   * Encodes the list of parameters in application/x-www-form-urlencoded format.
+   * </p>
+   *
+   * @param params  the list of parameters to encode
+   * @param charset the character set to use for encoding
+   * @return a ByteBuffer containing the encoded parameters
+   */
   public static ByteBuffer urlEncodeFormParams(List<Param> params, Charset charset) {
     return StringUtils.charSequence2ByteBuffer(urlEncodeFormParams0(params, charset), US_ASCII);
   }
 
+  /**
+   * URL-encodes form parameters into a StringBuilder.
+   *
+   * @param params  the list of parameters to encode
+   * @param charset the character set to use for encoding
+   * @return a StringBuilder containing the encoded parameters
+   */
   private static StringBuilder urlEncodeFormParams0(List<Param> params, Charset charset) {
     StringBuilder sb = StringBuilderPool.DEFAULT.stringBuilder();
     for (Param param : params) {
@@ -149,6 +255,14 @@ public class HttpUtils {
     return sb;
   }
 
+  /**
+   * Encodes and appends a single form parameter.
+   *
+   * @param sb      the StringBuilder to append to
+   * @param name    the parameter name
+   * @param value   the parameter value (may be null)
+   * @param charset the character set to use for encoding
+   */
   private static void encodeAndAppendFormParam(StringBuilder sb, String name, String value, Charset charset) {
     encodeAndAppendFormField(sb, name, charset);
     if (value != null) {
@@ -158,6 +272,13 @@ public class HttpUtils {
     sb.append('&');
   }
 
+  /**
+   * Encodes and appends a single form field (name or value).
+   *
+   * @param sb      the StringBuilder to append to
+   * @param field   the field to encode
+   * @param charset the character set to use for encoding
+   */
   private static void encodeAndAppendFormField(StringBuilder sb, String field, Charset charset) {
     if (charset.equals(UTF_8)) {
       Utf8UrlEncoder.encodeAndAppendFormElement(sb, field);
@@ -171,6 +292,15 @@ public class HttpUtils {
     }
   }
 
+  /**
+   * Filters out Brotli encoding from an Accept-Encoding header value.
+   * <p>
+   * Removes the ", br" suffix if present, as Brotli compression is not currently supported.
+   * </p>
+   *
+   * @param acceptEncoding the Accept-Encoding header value
+   * @return the filtered Accept-Encoding value
+   */
   public static CharSequence filterOutBrotliFromAcceptEncoding(String acceptEncoding) {
     // we don't support Brotly ATM
     if (acceptEncoding.endsWith(BROTLY_ACCEPT_ENCODING_SUFFIX)) {

--- a/client/src/main/java/org/asynchttpclient/util/MessageDigestUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/MessageDigestUtils.java
@@ -16,6 +16,14 @@ package org.asynchttpclient.util;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
+/**
+ * Utility class for managing pooled MessageDigest instances.
+ * <p>
+ * This class provides thread-local pools of MessageDigest instances for commonly used
+ * hashing algorithms (MD5 and SHA-1). Using pooled instances improves performance by
+ * avoiding the overhead of repeatedly creating new MessageDigest instances.
+ * </p>
+ */
 public final class MessageDigestUtils {
 
   private static final ThreadLocal<MessageDigest> MD5_MESSAGE_DIGESTS = ThreadLocal.withInitial(() -> {
@@ -34,12 +42,46 @@ public final class MessageDigestUtils {
     }
   });
 
+  /**
+   * Returns a thread-local, reset MD5 MessageDigest instance.
+   * <p>
+   * The returned MessageDigest is reset and ready for use. Each thread gets its own
+   * instance, making this method thread-safe without requiring synchronization.
+   * </p>
+   *
+   * <p><b>Usage Examples:</b></p>
+   * <pre>{@code
+   * MessageDigest md5 = pooledMd5MessageDigest();
+   * md5.update(data);
+   * byte[] hash = md5.digest();
+   * }</pre>
+   *
+   * @return a reset MD5 MessageDigest instance
+   * @throws InternalError if MD5 algorithm is not supported on this platform
+   */
   public static MessageDigest pooledMd5MessageDigest() {
     MessageDigest md = MD5_MESSAGE_DIGESTS.get();
     md.reset();
     return md;
   }
 
+  /**
+   * Returns a thread-local, reset SHA-1 MessageDigest instance.
+   * <p>
+   * The returned MessageDigest is reset and ready for use. Each thread gets its own
+   * instance, making this method thread-safe without requiring synchronization.
+   * </p>
+   *
+   * <p><b>Usage Examples:</b></p>
+   * <pre>{@code
+   * MessageDigest sha1 = pooledSha1MessageDigest();
+   * sha1.update(data);
+   * byte[] hash = sha1.digest();
+   * }</pre>
+   *
+   * @return a reset SHA-1 MessageDigest instance
+   * @throws InternalError if SHA-1 algorithm is not supported on this platform
+   */
   public static MessageDigest pooledSha1MessageDigest() {
     MessageDigest md = SHA1_MESSAGE_DIGESTS.get();
     md.reset();

--- a/client/src/main/java/org/asynchttpclient/util/MiscUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/MiscUtils.java
@@ -17,39 +17,105 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 
+/**
+ * Miscellaneous utility methods for common operations.
+ * <p>
+ * This class provides helper methods for checking emptiness of various data structures,
+ * handling default values, closing resources, and working with exceptions.
+ * </p>
+ */
 public class MiscUtils {
 
   private MiscUtils() {
   }
 
+  /**
+   * Checks if a string is non-empty (not null and has length greater than zero).
+   *
+   * @param string the string to check
+   * @return true if the string is non-empty, false otherwise
+   */
   public static boolean isNonEmpty(String string) {
     return !isEmpty(string);
   }
 
+  /**
+   * Checks if a string is empty (null or has zero length).
+   *
+   * @param string the string to check
+   * @return true if the string is empty or null, false otherwise
+   */
   public static boolean isEmpty(String string) {
     return string == null || string.isEmpty();
   }
 
+  /**
+   * Checks if an object array is non-empty (not null and has length greater than zero).
+   *
+   * @param array the array to check
+   * @return true if the array is non-empty, false otherwise
+   */
   public static boolean isNonEmpty(Object[] array) {
     return array != null && array.length != 0;
   }
 
+  /**
+   * Checks if a byte array is non-empty (not null and has length greater than zero).
+   *
+   * @param array the array to check
+   * @return true if the array is non-empty, false otherwise
+   */
   public static boolean isNonEmpty(byte[] array) {
     return array != null && array.length != 0;
   }
 
+  /**
+   * Checks if a collection is non-empty (not null and contains at least one element).
+   *
+   * @param collection the collection to check
+   * @return true if the collection is non-empty, false otherwise
+   */
   public static boolean isNonEmpty(Collection<?> collection) {
     return collection != null && !collection.isEmpty();
   }
 
+  /**
+   * Checks if a map is non-empty (not null and contains at least one entry).
+   *
+   * @param map the map to check
+   * @return true if the map is non-empty, false otherwise
+   */
   public static boolean isNonEmpty(Map<?, ?> map) {
     return map != null && !map.isEmpty();
   }
 
+  /**
+   * Returns the value if non-null, otherwise returns the default value.
+   *
+   * <p><b>Usage Examples:</b></p>
+   * <pre>{@code
+   * String result = withDefault(optionalValue, "defaultValue");
+   * Integer timeout = withDefault(config.getTimeout(), 30000);
+   * }</pre>
+   *
+   * @param <T>   the type of the value
+   * @param value the value to check
+   * @param def   the default value to return if value is null
+   * @return the value if non-null, otherwise the default value
+   */
   public static <T> T withDefault(T value, T def) {
     return value == null ? def : value;
   }
 
+  /**
+   * Closes a Closeable resource silently, suppressing any IOException.
+   * <p>
+   * This method is useful for cleanup operations where exceptions should not
+   * interrupt the flow of execution.
+   * </p>
+   *
+   * @param closeable the resource to close (may be null)
+   */
   public static void closeSilently(Closeable closeable) {
     if (closeable != null)
       try {
@@ -59,6 +125,16 @@ public class MiscUtils {
       }
   }
 
+  /**
+   * Recursively retrieves the root cause of a throwable.
+   * <p>
+   * Traverses the exception chain to find the deepest cause. If the throwable
+   * has no cause, returns the throwable itself.
+   * </p>
+   *
+   * @param t the throwable to analyze
+   * @return the root cause throwable
+   */
   public static Throwable getCause(Throwable t) {
     Throwable cause = t.getCause();
     return cause != null ? getCause(cause) : t;

--- a/client/src/main/java/org/asynchttpclient/util/ProxyUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/ProxyUtils.java
@@ -71,9 +71,16 @@ public final class ProxyUtils {
   }
 
   /**
-   * @param config  the global config
-   * @param request the request
-   * @return the proxy server to be used for this request (can be null)
+   * Determines the proxy server to use for a given request.
+   * <p>
+   * This method first checks if a proxy server is explicitly configured on the request.
+   * If not, it falls back to the proxy server selector configured on the client. The method
+   * also verifies that the determined proxy is not configured to be ignored for the request's host.
+   * </p>
+   *
+   * @param config  the global client configuration
+   * @param request the HTTP request
+   * @return the proxy server to be used for this request, or null if no proxy should be used
    */
   public static ProxyServer getProxyServer(AsyncHttpClientConfig config, Request request) {
     ProxyServer proxyServer = request.getProxyServer();
@@ -126,19 +133,28 @@ public final class ProxyUtils {
   }
 
   /**
-   * Get a proxy server selector based on the JDK default proxy selector.
+   * Gets a proxy server selector based on the JDK default proxy selector.
+   * <p>
+   * This method creates a selector that uses Java's default {@link ProxySelector} to
+   * determine proxy settings, which typically respects system proxy properties.
+   * </p>
    *
-   * @return The proxy server selector.
+   * @return the proxy server selector based on JDK defaults
    */
   public static ProxyServerSelector getJdkDefaultProxyServerSelector() {
     return createProxyServerSelector(ProxySelector.getDefault());
   }
 
   /**
-   * Create a proxy server selector based on the passed in JDK proxy selector.
+   * Creates a proxy server selector based on the specified JDK proxy selector.
+   * <p>
+   * This method wraps a {@link ProxySelector} to provide proxy selection functionality
+   * compatible with the async-http-client API. It handles HTTP proxies and properly
+   * manages direct connections.
+   * </p>
    *
-   * @param proxySelector The proxy selector to use.  Must not be null.
-   * @return The proxy server selector.
+   * @param proxySelector the JDK proxy selector to use (must not be null)
+   * @return the proxy server selector
    */
   private static ProxyServerSelector createProxyServerSelector(final ProxySelector proxySelector) {
     return uri -> {

--- a/client/src/main/java/org/asynchttpclient/util/StringBuilderPool.java
+++ b/client/src/main/java/org/asynchttpclient/util/StringBuilderPool.java
@@ -12,16 +12,42 @@
  */
 package org.asynchttpclient.util;
 
+/**
+ * A thread-local pool of StringBuilder instances for efficient string building.
+ * <p>
+ * This class maintains a thread-local pool of StringBuilder instances with an initial
+ * capacity of 512 characters. Using pooled StringBuilders reduces object allocation
+ * overhead for frequently performed string concatenation operations.
+ * </p>
+ */
 public class StringBuilderPool {
 
+  /**
+   * The default, shared StringBuilderPool instance.
+   */
   public static final StringBuilderPool DEFAULT = new StringBuilderPool();
 
   private final ThreadLocal<StringBuilder> pool = ThreadLocal.withInitial(() -> new StringBuilder(512));
 
   /**
-   * BEWARE: MUSTN'T APPEND TO ITSELF!
+   * Returns a reset, pooled StringBuilder ready for use.
+   * <p>
+   * The returned StringBuilder has its length reset to zero but retains its underlying
+   * character array capacity. Each thread gets its own instance, making this method
+   * thread-safe without requiring synchronization.
+   * </p>
+   * <p><b>IMPORTANT:</b> The returned StringBuilder must not be appended to itself,
+   * as it's reused across calls within the same thread.
+   * </p>
    *
-   * @return a pooled StringBuilder
+   * <p><b>Usage Examples:</b></p>
+   * <pre>{@code
+   * StringBuilder sb = StringBuilderPool.DEFAULT.stringBuilder();
+   * sb.append("hello").append(" ").append("world");
+   * String result = sb.toString();
+   * }</pre>
+   *
+   * @return a reset, pooled StringBuilder
    */
   public StringBuilder stringBuilder() {
     StringBuilder sb = pool.get();

--- a/client/src/main/java/org/asynchttpclient/util/StringUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/StringUtils.java
@@ -16,26 +16,79 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 
+/**
+ * Utility methods for string and byte conversions.
+ * <p>
+ * This class provides helper methods for converting between CharSequences, ByteBuffers,
+ * and byte arrays, as well as encoding bytes to hexadecimal string representations.
+ * </p>
+ */
 public final class StringUtils {
 
   private StringUtils() {
   }
 
+  /**
+   * Converts a CharSequence to a ByteBuffer using the specified charset.
+   * <p>
+   * This method encodes the character sequence into bytes according to the given charset.
+   * </p>
+   *
+   * @param cs      the CharSequence to convert
+   * @param charset the charset to use for encoding
+   * @return a ByteBuffer containing the encoded bytes
+   */
   public static ByteBuffer charSequence2ByteBuffer(CharSequence cs, Charset charset) {
     return charset.encode(CharBuffer.wrap(cs));
   }
 
+  /**
+   * Converts a ByteBuffer to a byte array.
+   * <p>
+   * This method extracts the remaining bytes from the ByteBuffer into a new byte array.
+   * The ByteBuffer's position is advanced by the number of bytes read.
+   * </p>
+   *
+   * @param bb the ByteBuffer to convert
+   * @return a byte array containing the remaining bytes
+   */
   public static byte[] byteBuffer2ByteArray(ByteBuffer bb) {
     byte[] rawBase = new byte[bb.remaining()];
     bb.get(rawBase);
     return rawBase;
   }
 
+  /**
+   * Converts a CharSequence to a byte array using the specified charset.
+   * <p>
+   * This is a convenience method that combines {@link #charSequence2ByteBuffer(CharSequence, Charset)}
+   * and {@link #byteBuffer2ByteArray(ByteBuffer)}.
+   * </p>
+   *
+   * @param sb      the CharSequence to convert
+   * @param charset the charset to use for encoding
+   * @return a byte array containing the encoded bytes
+   */
   public static byte[] charSequence2Bytes(CharSequence sb, Charset charset) {
     ByteBuffer bb = charSequence2ByteBuffer(sb, charset);
     return byteBuffer2ByteArray(bb);
   }
 
+  /**
+   * Converts a byte array to a hexadecimal string representation.
+   * <p>
+   * Each byte is represented as two hexadecimal digits (lowercase).
+   * </p>
+   *
+   * <p><b>Usage Examples:</b></p>
+   * <pre>{@code
+   * byte[] data = {0x1A, 0x2B, 0x3C};
+   * String hex = toHexString(data); // Returns "1a2b3c"
+   * }</pre>
+   *
+   * @param data the byte array to convert
+   * @return a hexadecimal string representation
+   */
   public static String toHexString(byte[] data) {
     StringBuilder buffer = StringBuilderPool.DEFAULT.stringBuilder();
     for (byte aData : data) {
@@ -45,6 +98,16 @@ public final class StringUtils {
     return buffer.toString();
   }
 
+  /**
+   * Appends the base-16 (hexadecimal) representation of bytes to a StringBuilder.
+   * <p>
+   * Each byte is represented as two hexadecimal digits (lowercase). This method
+   * modifies the provided StringBuilder in place.
+   * </p>
+   *
+   * @param buf   the StringBuilder to append to
+   * @param bytes the byte array to encode
+   */
   public static void appendBase16(StringBuilder buf, byte[] bytes) {
     int base = 16;
     for (byte b : bytes) {

--- a/client/src/main/java/org/asynchttpclient/util/ThrowableUtil.java
+++ b/client/src/main/java/org/asynchttpclient/util/ThrowableUtil.java
@@ -12,17 +12,45 @@
  */
 package org.asynchttpclient.util;
 
+/**
+ * Utility methods for working with Throwable instances.
+ * <p>
+ * This class provides helper methods for manipulating exceptions and their stack traces,
+ * particularly useful for performance optimization in high-throughput scenarios.
+ * </p>
+ */
 public final class ThrowableUtil {
 
   private ThrowableUtil() {
   }
 
   /**
+   * Replaces the stack trace of a throwable with a minimal, synthetic stack trace.
+   * <p>
+   * This method is useful for pre-allocated or frequently thrown exceptions where
+   * the overhead of capturing a full stack trace is undesirable. The resulting
+   * throwable has a single stack trace element indicating the caller class and method.
+   * </p>
+   * <p>
+   * Note: Use this method with caution, as it removes valuable debugging information.
+   * It's primarily intended for performance-critical paths where exceptions are expected
+   * and stack traces are not needed.
+   * </p>
+   *
+   * <p><b>Usage Examples:</b></p>
+   * <pre>{@code
+   * IOException exception = unknownStackTrace(
+   *     new IOException("Connection closed"),
+   *     MyClass.class,
+   *     "processRequest"
+   * );
+   * }</pre>
+   *
    * @param <T>    the Throwable type
-   * @param t      the throwable whose stacktrace we want to remove
-   * @param clazz  the caller class
-   * @param method the caller method
-   * @return the input throwable with removed stacktrace
+   * @param t      the throwable whose stack trace should be replaced
+   * @param clazz  the caller class to record in the synthetic stack trace
+   * @param method the caller method to record in the synthetic stack trace
+   * @return the input throwable with a minimal synthetic stack trace
    */
   public static <T extends Throwable> T unknownStackTrace(T t, Class<?> clazz, String method) {
     t.setStackTrace(new StackTraceElement[]{new StackTraceElement(clazz.getName(), method, null, -1)});

--- a/client/src/main/java/org/asynchttpclient/util/UriEncoder.java
+++ b/client/src/main/java/org/asynchttpclient/util/UriEncoder.java
@@ -20,9 +20,35 @@ import java.util.List;
 import static org.asynchttpclient.util.MiscUtils.isNonEmpty;
 import static org.asynchttpclient.util.Utf8UrlEncoder.encodeAndAppendQuery;
 
+/**
+ * Enumeration of URI encoding strategies for HTTP requests.
+ * <p>
+ * This enum provides two strategies for encoding URIs:
+ * </p>
+ * <ul>
+ *   <li>{@link #FIXING} - Properly encodes paths and query parameters according to RFC 3986</li>
+ *   <li>{@link #RAW} - Leaves URIs unencoded, passing them through as-is</li>
+ * </ul>
+ * <p>
+ * The appropriate encoder can be selected using {@link #uriEncoder(boolean)}.
+ * </p>
+ */
 public enum UriEncoder {
 
+  /**
+   * Encoder that properly encodes paths and query parameters according to RFC 3986.
+   * <p>
+   * This encoder ensures that URI components are properly percent-encoded, making them
+   * safe for transmission in HTTP requests.
+   * </p>
+   */
   FIXING {
+    /**
+     * Encodes a URI path according to RFC 3986.
+     *
+     * @param path the path to encode
+     * @return the encoded path
+     */
     public String encodePath(String path) {
       return Utf8UrlEncoder.encodePath(path);
     }
@@ -67,7 +93,21 @@ public enum UriEncoder {
     }
   },
 
+  /**
+   * Encoder that leaves URI components unencoded.
+   * <p>
+   * This encoder passes paths and query parameters through without any encoding.
+   * Use with caution, as it assumes the URI is already properly encoded or does not
+   * contain characters that require encoding.
+   * </p>
+   */
   RAW {
+    /**
+     * Returns the path without encoding.
+     *
+     * @param path the path
+     * @return the unmodified path
+     */
     public String encodePath(String path) {
       return path;
     }
@@ -107,24 +147,74 @@ public enum UriEncoder {
     }
   };
 
+  /**
+   * Returns the appropriate URI encoder based on the encoding preference.
+   *
+   * @param disableUrlEncoding true to disable URL encoding (returns {@link #RAW}),
+   *                          false to enable encoding (returns {@link #FIXING})
+   * @return the appropriate URI encoder
+   */
   public static UriEncoder uriEncoder(boolean disableUrlEncoding) {
     return disableUrlEncoding ? RAW : FIXING;
   }
 
+  /**
+   * Encodes a query string with additional query parameters.
+   *
+   * @param query       the existing query string
+   * @param queryParams additional query parameters to append
+   * @return the complete encoded query string
+   */
   protected abstract String withQueryWithParams(final String query, final List<Param> queryParams);
 
+  /**
+   * Encodes a query string without additional parameters.
+   *
+   * @param query the query string to encode
+   * @return the encoded query string
+   */
   protected abstract String withQueryWithoutParams(final String query);
 
+  /**
+   * Encodes query parameters when there is no existing query string.
+   *
+   * @param queryParams the query parameters to encode
+   * @return the encoded query string
+   */
   protected abstract String withoutQueryWithParams(final List<Param> queryParams);
 
+  /**
+   * Encodes a query string, optionally merging with additional query parameters.
+   *
+   * @param query       the existing query string
+   * @param queryParams additional query parameters
+   * @return the complete encoded query string
+   */
   private String withQuery(final String query, final List<Param> queryParams) {
     return isNonEmpty(queryParams) ? withQueryWithParams(query, queryParams) : withQueryWithoutParams(query);
   }
 
+  /**
+   * Encodes query parameters when there is no existing query string.
+   *
+   * @param queryParams the query parameters
+   * @return the encoded query string, or null if no parameters
+   */
   private String withoutQuery(final List<Param> queryParams) {
     return isNonEmpty(queryParams) ? withoutQueryWithParams(queryParams) : null;
   }
 
+  /**
+   * Encodes a URI with optional additional query parameters.
+   * <p>
+   * This method encodes the path and merges any additional query parameters with
+   * the existing query string, if present.
+   * </p>
+   *
+   * @param uri         the URI to encode
+   * @param queryParams additional query parameters to merge
+   * @return a new URI with encoded components
+   */
   public Uri encode(Uri uri, List<Param> queryParams) {
     String newPath = encodePath(uri.getPath());
     String newQuery = encodeQuery(uri.getQuery(), queryParams);
@@ -137,8 +227,21 @@ public enum UriEncoder {
             uri.getFragment());
   }
 
+  /**
+   * Encodes a URI path.
+   *
+   * @param path the path to encode
+   * @return the encoded path
+   */
   protected abstract String encodePath(String path);
 
+  /**
+   * Encodes a query string with optional additional parameters.
+   *
+   * @param query       the existing query string
+   * @param queryParams additional query parameters
+   * @return the encoded query string
+   */
   private String encodeQuery(final String query, final List<Param> queryParams) {
     return isNonEmpty(query) ? withQuery(query, queryParams) : withoutQuery(queryParams);
   }

--- a/client/src/main/java/org/asynchttpclient/util/Utf8UrlEncoder.java
+++ b/client/src/main/java/org/asynchttpclient/util/Utf8UrlEncoder.java
@@ -15,6 +15,23 @@ package org.asynchttpclient.util;
 
 import java.util.BitSet;
 
+/**
+ * UTF-8 URL encoder that follows RFC 3986 specifications.
+ * <p>
+ * This class provides methods to encode various URI components (path, query, form elements)
+ * according to RFC 3986 and HTML5 form encoding specifications. It efficiently handles
+ * UTF-8 multi-byte characters and uses predefined character sets to determine which
+ * characters should be percent-encoded.
+ * </p>
+ * <p>
+ * The encoder supports different encoding modes for different URI components:
+ * </p>
+ * <ul>
+ *   <li>Path encoding - for URI paths</li>
+ *   <li>Query encoding - for URI query strings</li>
+ *   <li>Form encoding - for application/x-www-form-urlencoded data</li>
+ * </ul>
+ */
 public final class Utf8UrlEncoder {
 
   // see http://tools.ietf.org/html/rfc3986#section-3.4
@@ -119,29 +136,88 @@ public final class Utf8UrlEncoder {
   private Utf8UrlEncoder() {
   }
 
+  /**
+   * Encodes a URI path according to RFC 3986.
+   * <p>
+   * This method percent-encodes characters that are not allowed in URI paths,
+   * while leaving valid path characters (including '/' separators) unencoded.
+   * If no encoding is needed, returns the original input string.
+   * </p>
+   *
+   * @param input the path to encode
+   * @return the encoded path
+   */
   public static String encodePath(String input) {
     StringBuilder sb = lazyAppendEncoded(null, input, BUILT_PATH_UNTOUCHED_CHARS, false);
     return sb == null ? input : sb.toString();
   }
 
+  /**
+   * Encodes and appends a query string to a StringBuilder.
+   * <p>
+   * This method encodes the query string according to RFC 3986, preserving
+   * valid query characters including '?' and '&'.
+   * </p>
+   *
+   * @param sb    the StringBuilder to append to
+   * @param query the query string to encode
+   * @return the StringBuilder with the encoded query appended
+   */
   public static StringBuilder encodeAndAppendQuery(StringBuilder sb, String query) {
     return appendEncoded(sb, query, BUILT_QUERY_UNTOUCHED_CHARS, false);
   }
 
+  /**
+   * Encodes a query parameter element (name or value).
+   * <p>
+   * This method encodes the input according to form URL encoding rules,
+   * percent-encoding special characters but not spaces (which are encoded as '+').
+   * </p>
+   *
+   * @param input the query element to encode
+   * @return the encoded query element
+   */
   public static String encodeQueryElement(String input) {
     StringBuilder sb = new StringBuilder(input.length() + 6);
     encodeAndAppendQueryElement(sb, input);
     return sb.toString();
   }
 
+  /**
+   * Encodes and appends a query parameter element to a StringBuilder.
+   *
+   * @param sb    the StringBuilder to append to
+   * @param input the query element to encode
+   * @return the StringBuilder with the encoded element appended
+   */
   public static StringBuilder encodeAndAppendQueryElement(StringBuilder sb, CharSequence input) {
     return appendEncoded(sb, input, FORM_URL_ENCODED_SAFE_CHARS, false);
   }
 
+  /**
+   * Encodes and appends a form parameter element to a StringBuilder.
+   * <p>
+   * This method uses HTML5 form encoding rules where spaces are encoded as '+'.
+   * </p>
+   *
+   * @param sb    the StringBuilder to append to
+   * @param input the form element to encode
+   * @return the StringBuilder with the encoded element appended
+   */
   public static StringBuilder encodeAndAppendFormElement(StringBuilder sb, CharSequence input) {
     return appendEncoded(sb, input, FORM_URL_ENCODED_SAFE_CHARS, true);
   }
 
+  /**
+   * Percent-encodes a query element using only RFC 3986 unreserved characters.
+   * <p>
+   * This is a stricter encoding that encodes all characters except alphanumerics
+   * and the unreserved set (- . _ ~).
+   * </p>
+   *
+   * @param input the string to encode
+   * @return the percent-encoded string, or null if input is null
+   */
   public static String percentEncodeQueryElement(String input) {
     if (input == null) {
       return null;
@@ -151,6 +227,13 @@ public final class Utf8UrlEncoder {
     return sb.toString();
   }
 
+  /**
+   * Encodes and appends a percent-encoded string to a StringBuilder.
+   *
+   * @param sb    the StringBuilder to append to
+   * @param input the string to encode
+   * @return the StringBuilder with the encoded string appended
+   */
   public static StringBuilder encodeAndAppendPercentEncoded(StringBuilder sb, CharSequence input) {
     return appendEncoded(sb, input, RFC3986_UNRESERVED_CHARS, false);
   }

--- a/client/src/main/java/org/asynchttpclient/webdav/WebDavResponse.java
+++ b/client/src/main/java/org/asynchttpclient/webdav/WebDavResponse.java
@@ -25,13 +25,36 @@ import java.nio.charset.Charset;
 import java.util.List;
 
 /**
- * Customized {@link Response} which add support for getting the response's body as an XML document (@link WebDavResponse#getBodyAsXML}
+ * Customized {@link Response} that adds support for getting the response body as an XML document.
+ * <p>
+ * This response wrapper is specifically designed for WebDAV operations, which typically return
+ * XML responses (especially for multi-status 207 responses). It provides access to the parsed
+ * XML document alongside all standard HTTP response properties.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * WebDavCompletionHandlerBase<WebDavResponse> handler = new WebDavCompletionHandlerBase<WebDavResponse>() {
+ *     @Override
+ *     public WebDavResponse onCompleted(WebDavResponse response) {
+ *         Document doc = response.getBodyAsXML();
+ *         // Process XML document
+ *         return response;
+ *     }
+ * };
+ * }</pre>
  */
 public class WebDavResponse implements Response {
 
   private final Response response;
   private final Document document;
 
+  /**
+   * Creates a new WebDAV response wrapping an HTTP response and its parsed XML document.
+   *
+   * @param response the underlying HTTP response
+   * @param document the parsed XML document from the response body (can be null)
+   */
   WebDavResponse(Response response, Document document) {
     this.response = response;
     this.document = document;
@@ -114,6 +137,16 @@ public class WebDavResponse implements Response {
     return response.getLocalAddress();
   }
 
+  /**
+   * Returns the response body as a parsed XML document.
+   * <p>
+   * This method provides access to the DOM document parsed from the response body.
+   * For WebDAV multi-status responses (HTTP 207), this contains the structured XML
+   * data describing the results of the operation.
+   * </p>
+   *
+   * @return the parsed XML document, or null if the response didn't contain XML
+   */
   public Document getBodyAsXML() {
     return document;
   }

--- a/client/src/main/java/org/asynchttpclient/ws/WebSocket.java
+++ b/client/src/main/java/org/asynchttpclient/ws/WebSocket.java
@@ -20,12 +20,45 @@ import io.netty.util.concurrent.Future;
 import java.net.SocketAddress;
 
 /**
- * A WebSocket client
+ * A WebSocket client interface for sending and receiving WebSocket frames.
+ * <p>
+ * This interface provides methods for sending various types of WebSocket frames
+ * (text, binary, ping, pong, close) and managing WebSocket listeners. It supports
+ * both simple and advanced use cases, including message fragmentation and WebSocket
+ * extensions through RSV bits.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Simple text message
+ * websocket.sendTextFrame("Hello, WebSocket!");
+ *
+ * // Binary message
+ * byte[] data = {1, 2, 3, 4};
+ * websocket.sendBinaryFrame(data);
+ *
+ * // Fragmented message (3 parts)
+ * websocket.sendTextFrame("First part ", false, 0);
+ * websocket.sendContinuationFrame("middle part ", false, 0);
+ * websocket.sendContinuationFrame("last part", true, 0);
+ *
+ * // Ping/Pong for keepalive
+ * websocket.sendPingFrame();
+ *
+ * // Close connection
+ * websocket.sendCloseFrame(1000, "Normal closure");
+ * }</pre>
  */
 public interface WebSocket {
 
   /**
-   * @return the headers received in the Upgrade response
+   * Returns the HTTP headers received in the WebSocket upgrade response.
+   * <p>
+   * These headers may include server information, protocol negotiation results,
+   * and custom headers sent by the server during the handshake.
+   * </p>
+   *
+   * @return the headers received in the upgrade response
    */
   HttpHeaders getUpgradeHeaders();
 

--- a/client/src/main/java/org/asynchttpclient/ws/WebSocketListener.java
+++ b/client/src/main/java/org/asynchttpclient/ws/WebSocketListener.java
@@ -13,31 +13,76 @@
 package org.asynchttpclient.ws;
 
 /**
- * A generic {@link WebSocketListener} for WebSocket events. Use the appropriate listener for receiving message bytes.
+ * Listener interface for WebSocket events and frame notifications.
+ * <p>
+ * This interface provides callbacks for WebSocket lifecycle events (open, close, error)
+ * and frame-level notifications (text, binary, ping, pong). Implementations can selectively
+ * override the frame methods they're interested in, as they provide default no-op implementations.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * WebSocketListener listener = new WebSocketListener() {
+ *     @Override
+ *     public void onOpen(WebSocket websocket) {
+ *         System.out.println("WebSocket opened");
+ *         websocket.sendTextFrame("Hello");
+ *     }
+ *
+ *     @Override
+ *     public void onTextFrame(String payload, boolean finalFragment, int rsv) {
+ *         System.out.println("Received: " + payload);
+ *     }
+ *
+ *     @Override
+ *     public void onClose(WebSocket websocket, int code, String reason) {
+ *         System.out.println("WebSocket closed: " + code + " " + reason);
+ *     }
+ *
+ *     @Override
+ *     public void onError(Throwable t) {
+ *         System.err.println("WebSocket error: " + t.getMessage());
+ *     }
+ * };
+ * }</pre>
  */
 public interface WebSocketListener {
 
   /**
-   * Invoked when the {@link WebSocket} is open.
+   * Invoked when the {@link WebSocket} connection is successfully established.
+   * <p>
+   * This callback is called after the WebSocket handshake completes successfully.
+   * The connection is now ready to send and receive frames.
+   * </p>
    *
-   * @param websocket the WebSocket
+   * @param websocket the WebSocket instance that was opened
    */
   void onOpen(WebSocket websocket);
 
   /**
-   * Invoked when the {@link WebSocket} is closed.
+   * Invoked when the {@link WebSocket} connection is closed.
+   * <p>
+   * This callback is triggered when a close frame is received or the connection
+   * is terminated. The status code and reason provide information about why
+   * the connection was closed.
+   * </p>
    *
-   * @param websocket the WebSocket
-   * @param code      the status code
-   * @param reason    the reason message
-   * @see "http://tools.ietf.org/html/rfc6455#section-5.5.1"
+   * @param websocket the WebSocket instance that was closed
+   * @param code the status code indicating the reason for closure (e.g., 1000 for normal closure)
+   * @param reason a textual description of the closure reason (may be empty)
+   * @see <a href="http://tools.ietf.org/html/rfc6455#section-5.5.1">RFC 6455 Section 5.5.1</a>
    */
   void onClose(WebSocket websocket, int code, String reason);
 
   /**
-   * Invoked when the {@link WebSocket} crashes.
+   * Invoked when an error occurs on the {@link WebSocket} connection.
+   * <p>
+   * This callback is triggered when an exception occurs during WebSocket
+   * communication, such as network errors, protocol violations, or application-level
+   * exceptions.
+   * </p>
    *
-   * @param t a {@link Throwable}
+   * @param t the Throwable that caused the error
    */
   void onError(Throwable t);
 

--- a/client/src/main/java/org/asynchttpclient/ws/WebSocketUpgradeHandler.java
+++ b/client/src/main/java/org/asynchttpclient/ws/WebSocketUpgradeHandler.java
@@ -25,35 +25,149 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * An {@link AsyncHandler} which is able to execute WebSocket upgrade. Use the Builder for configuring WebSocket options.
+ * An {@link AsyncHandler} that handles WebSocket protocol upgrade and connection management.
+ * <p>
+ * This handler manages the HTTP-to-WebSocket upgrade process by:
+ * </p>
+ * <ul>
+ *   <li>Validating the HTTP 101 Switching Protocols response</li>
+ *   <li>Processing the upgrade headers</li>
+ *   <li>Establishing the WebSocket connection</li>
+ *   <li>Notifying registered listeners of connection events</li>
+ * </ul>
+ * <p>
+ * Subclasses can override the protected hook methods (*0) to add custom behavior
+ * at various stages of the upgrade process.
+ * </p>
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * WebSocketUpgradeHandler handler = new WebSocketUpgradeHandler.Builder()
+ *     .addWebSocketListener(new WebSocketListener() {
+ *         @Override
+ *         public void onOpen(WebSocket websocket) {
+ *             websocket.sendTextFrame("Hello!");
+ *         }
+ *
+ *         @Override
+ *         public void onTextFrame(String payload, boolean finalFragment, int rsv) {
+ *             System.out.println("Received: " + payload);
+ *         }
+ *
+ *         @Override
+ *         public void onClose(WebSocket websocket, int code, String reason) {
+ *             System.out.println("Connection closed");
+ *         }
+ *
+ *         @Override
+ *         public void onError(Throwable t) {
+ *             System.err.println("Error: " + t.getMessage());
+ *         }
+ *     })
+ *     .build();
+ *
+ * WebSocket websocket = asyncHttpClient
+ *     .prepareGet("ws://echo.websocket.org")
+ *     .execute(handler)
+ *     .get();
+ * }</pre>
  */
 public class WebSocketUpgradeHandler implements AsyncHandler<NettyWebSocket> {
 
   private final List<WebSocketListener> listeners;
   private NettyWebSocket webSocket;
 
+  /**
+   * Creates a new WebSocket upgrade handler with the specified listeners.
+   *
+   * @param listeners the list of WebSocket listeners to notify of events
+   */
   public WebSocketUpgradeHandler(List<WebSocketListener> listeners) {
     this.listeners = listeners;
   }
 
+  /**
+   * Extension point called when the WebSocket instance is set.
+   * <p>
+   * Subclasses can override this method to perform additional initialization
+   * or configuration when the WebSocket connection is established.
+   * </p>
+   *
+   * @param webSocket the WebSocket instance
+   */
   protected void setWebSocket0(NettyWebSocket webSocket) {
   }
 
+  /**
+   * Extension point called when the HTTP response status is received.
+   * <p>
+   * Subclasses can override this method to inspect or validate the status
+   * before the upgrade proceeds.
+   * </p>
+   *
+   * @param responseStatus the HTTP response status
+   * @throws Exception if an error occurs during status processing
+   */
   protected void onStatusReceived0(HttpResponseStatus responseStatus) throws Exception {
   }
 
+  /**
+   * Extension point called when the HTTP response headers are received.
+   * <p>
+   * Subclasses can override this method to inspect or validate the upgrade
+   * headers before the connection is established.
+   * </p>
+   *
+   * @param headers the HTTP response headers
+   * @throws Exception if an error occurs during header processing
+   */
   protected void onHeadersReceived0(HttpHeaders headers) throws Exception {
   }
 
+  /**
+   * Extension point called when the HTTP response body part is received.
+   * <p>
+   * Subclasses can override this method to process any response body data
+   * received during the upgrade (though typically there isn't any).
+   * </p>
+   *
+   * @param bodyPart the HTTP response body part
+   * @throws Exception if an error occurs during body part processing
+   */
   protected void onBodyPartReceived0(HttpResponseBodyPart bodyPart) throws Exception {
   }
 
+  /**
+   * Extension point called when the upgrade completes successfully.
+   * <p>
+   * Subclasses can override this method to perform actions after the
+   * WebSocket connection is fully established.
+   * </p>
+   *
+   * @throws Exception if an error occurs during completion processing
+   */
   protected void onCompleted0() throws Exception {
   }
 
+  /**
+   * Extension point called when an error occurs during the upgrade.
+   * <p>
+   * Subclasses can override this method to add custom error handling
+   * logic before listeners are notified.
+   * </p>
+   *
+   * @param t the Throwable that caused the error
+   */
   protected void onThrowable0(Throwable t) {
   }
 
+  /**
+   * Extension point called when the WebSocket connection is opened.
+   * <p>
+   * Subclasses can override this method to perform actions when the
+   * connection is ready to send and receive frames.
+   * </p>
+   */
   protected void onOpen0() {
   }
 

--- a/client/src/main/java/org/asynchttpclient/ws/WebSocketUtils.java
+++ b/client/src/main/java/org/asynchttpclient/ws/WebSocketUtils.java
@@ -20,9 +20,30 @@ import java.util.Base64;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.asynchttpclient.util.MessageDigestUtils.pooledSha1MessageDigest;
 
+/**
+ * Utility class for WebSocket protocol operations.
+ * <p>
+ * This class provides helper methods for WebSocket handshake key generation and validation
+ * according to RFC 6455 (The WebSocket Protocol). It handles the cryptographic operations
+ * required for the WebSocket opening handshake.
+ * </p>
+ */
 public final class WebSocketUtils {
+  /**
+   * Magic GUID defined in RFC 6455 for WebSocket handshake accept key calculation.
+   */
   private static final String MAGIC_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
+  /**
+   * Generates a random WebSocket key for the client handshake.
+   * <p>
+   * This method creates a Base64-encoded random 16-byte value to be sent in the
+   * Sec-WebSocket-Key header during the WebSocket opening handshake. The server
+   * will use this key to generate the Sec-WebSocket-Accept response header.
+   * </p>
+   *
+   * @return a Base64-encoded random key suitable for WebSocket handshake
+   */
   public static String getWebSocketKey() {
     byte[] nonce = new byte[16];
     ThreadLocalRandom random = ThreadLocalRandom.current();
@@ -32,6 +53,21 @@ public final class WebSocketUtils {
     return Base64.getEncoder().encodeToString(nonce);
   }
 
+  /**
+   * Computes the WebSocket accept key from a client key.
+   * <p>
+   * This method implements the algorithm defined in RFC 6455 for computing the
+   * Sec-WebSocket-Accept header value. It concatenates the client key with the
+   * magic GUID, computes SHA-1 hash, and Base64-encodes the result.
+   * </p>
+   * <p>
+   * This is used by clients to validate server responses and by servers to
+   * generate the accept header.
+   * </p>
+   *
+   * @param key the Sec-WebSocket-Key value from the client handshake
+   * @return the Base64-encoded accept key for the Sec-WebSocket-Accept header
+   */
   public static String getAcceptKey(String key) {
     return Base64.getEncoder().encodeToString(pooledSha1MessageDigest().digest(
               (key + MAGIC_GUID).getBytes(US_ASCII)));

--- a/extras/guava/src/main/java/org/asynchttpclient/extras/guava/ListenableFutureAdapter.java
+++ b/extras/guava/src/main/java/org/asynchttpclient/extras/guava/ListenableFutureAdapter.java
@@ -19,12 +19,41 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+/**
+ * Adapter utility to convert AsyncHttpClient's ListenableFuture to Guava's ListenableFuture.
+ * <p>
+ * This adapter allows seamless integration between AsyncHttpClient and Guava's utilities
+ * for working with futures and callbacks.
+ */
 public final class ListenableFutureAdapter {
 
   /**
-   * @param future an AHC ListenableFuture
-   * @param <V>    the Future's value type
-   * @return a Guava ListenableFuture
+   * Converts an AsyncHttpClient ListenableFuture to a Guava ListenableFuture.
+   * <p>
+   * The returned future delegates all operations to the original AsyncHttpClient future,
+   * preserving cancellation, execution, and listener behavior.
+   *
+   * <p><b>Usage Examples:</b></p>
+   * <pre>{@code
+   * AsyncHttpClient client = asyncHttpClient();
+   * ListenableFuture<Response> ahcFuture = client.prepareGet("http://www.example.com").execute();
+   * com.google.common.util.concurrent.ListenableFuture<Response> guavaFuture =
+   *     ListenableFutureAdapter.asGuavaFuture(ahcFuture);
+   *
+   * // Now you can use Guava utilities
+   * Futures.addCallback(guavaFuture, new FutureCallback<Response>() {
+   *     public void onSuccess(Response response) {
+   *         System.out.println("Status: " + response.getStatusCode());
+   *     }
+   *     public void onFailure(Throwable thrown) {
+   *         System.err.println("Request failed: " + thrown);
+   *     }
+   * }, MoreExecutors.directExecutor());
+   * }</pre>
+   *
+   * @param future an AsyncHttpClient ListenableFuture to adapt
+   * @param <V>    the type of the future's result value
+   * @return a Guava ListenableFuture that delegates to the provided future
    */
   public static <V> com.google.common.util.concurrent.ListenableFuture<V> asGuavaFuture(final ListenableFuture<V> future) {
 

--- a/extras/registry/src/main/java/org/asynchttpclient/extras/registry/AsyncHttpClientRegistry.java
+++ b/extras/registry/src/main/java/org/asynchttpclient/extras/registry/AsyncHttpClientRegistry.java
@@ -16,13 +16,36 @@ import org.asynchttpclient.AsyncHttpClient;
 
 import java.util.Set;
 
+/**
+ * A registry for managing named AsyncHttpClient instances.
+ * <p>
+ * This interface provides a centralized repository for storing and retrieving
+ * AsyncHttpClient instances by name, enabling sharing of client instances
+ * across an application and preventing resource leaks.
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * AsyncHttpClientRegistry registry = AsyncHttpClientRegistryImpl.getInstance();
+ *
+ * // Register a client
+ * AsyncHttpClient client = asyncHttpClient();
+ * registry.addOrReplace("myClient", client);
+ *
+ * // Retrieve it later
+ * AsyncHttpClient retrieved = registry.get("myClient");
+ *
+ * // Unregister when done
+ * registry.unregister("myClient");
+ * client.close();
+ * }</pre>
+ */
 public interface AsyncHttpClientRegistry {
 
   /**
-   * Returns back the AsyncHttpClient associated with this name
+   * Retrieves the AsyncHttpClient associated with the specified name.
    *
    * @param name the name of the client instance in the registry
-   * @return the client
+   * @return the client instance, or null if no client is registered with this name
    */
   AsyncHttpClient get(String name);
 

--- a/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/AsyncHttpObservable.java
+++ b/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/AsyncHttpObservable.java
@@ -21,17 +21,45 @@ import rx.functions.Func0;
 import rx.subjects.ReplaySubject;
 
 /**
- * Provide RxJava support for executing requests. Request can be subscribed to and manipulated as needed.
+ * Provides RxJava support for executing HTTP requests as Observables.
+ * <p>
+ * This class enables integration between AsyncHttpClient and RxJava, allowing
+ * HTTP requests to be observed and manipulated using reactive programming patterns.
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * AsyncHttpClient client = asyncHttpClient();
+ *
+ * // Cold Observable - executes when subscribed
+ * Observable<Response> coldObservable = AsyncHttpObservable.toObservable(
+ *     () -> client.prepareGet("http://www.example.com")
+ * );
+ * coldObservable.subscribe(response -> {
+ *     System.out.println("Status: " + response.getStatusCode());
+ * });
+ *
+ * // Hot Observable - executes immediately
+ * Observable<Response> hotObservable = AsyncHttpObservable.observe(
+ *     () -> client.prepareGet("http://www.example.com")
+ * );
+ * // Request starts executing immediately, even before subscription
+ * hotObservable.subscribe(response -> {
+ *     System.out.println("Status: " + response.getStatusCode());
+ * });
+ * }</pre>
  *
  * @see <a href="https://github.com/ReactiveX/RxJava">https://github.com/ReactiveX/RxJava</a>
  */
 public class AsyncHttpObservable {
 
   /**
-   * Observe a request execution and emit the response to the observer.
+   * Creates a cold Observable that executes the HTTP request when subscribed.
+   * <p>
+   * Each subscription triggers a new HTTP request execution. The request is not
+   * executed until the Observable is subscribed to.
    *
-   * @param supplier the supplier
-   * @return The cold observable (must be subscribed to in order to execute).
+   * @param supplier a function that provides the BoundRequestBuilder for the HTTP request
+   * @return a cold Observable that emits the HTTP response when subscribed
    */
   public static Observable<Response> toObservable(final Func0<BoundRequestBuilder> supplier) {
 
@@ -68,10 +96,14 @@ public class AsyncHttpObservable {
   }
 
   /**
-   * Observe a request execution and emit the response to the observer.
+   * Creates a hot Observable that executes the HTTP request immediately.
+   * <p>
+   * The request begins execution as soon as this method is called, regardless of
+   * whether any observers have subscribed. Multiple subscribers will receive the
+   * same response via a ReplaySubject.
    *
-   * @param supplier teh supplier
-   * @return The hot observable (eagerly executes).
+   * @param supplier a function that provides the BoundRequestBuilder for the HTTP request
+   * @return a hot Observable that emits the HTTP response (request executes eagerly)
    */
   public static Observable<Response> observe(final Func0<BoundRequestBuilder> supplier) {
     //use a ReplaySubject to buffer the eagerly subscribed-to Observable

--- a/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/UnsubscribedException.java
+++ b/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/UnsubscribedException.java
@@ -15,14 +15,25 @@ package org.asynchttpclient.extras.rxjava;
 import java.util.concurrent.CancellationException;
 
 /**
- * Indicates that an {@code Observer} unsubscribed during the processing of a HTTP request.
+ * Indicates that an {@code Observer} unsubscribed during the processing of an HTTP request.
+ * <p>
+ * This exception is used to signal early termination of HTTP request processing when
+ * the RxJava subscriber unsubscribes before the request completes.
  */
 @SuppressWarnings("serial")
 public class UnsubscribedException extends CancellationException {
 
+  /**
+   * Creates a new UnsubscribedException with no detail message.
+   */
   public UnsubscribedException() {
   }
 
+  /**
+   * Creates a new UnsubscribedException with the specified cause.
+   *
+   * @param cause the underlying cause of this exception
+   */
   public UnsubscribedException(final Throwable cause) {
     initCause(cause);
   }

--- a/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/single/AbstractProgressSingleSubscriberBridge.java
+++ b/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/single/AbstractProgressSingleSubscriberBridge.java
@@ -15,27 +15,70 @@ package org.asynchttpclient.extras.rxjava.single;
 import org.asynchttpclient.handler.ProgressAsyncHandler;
 import rx.SingleSubscriber;
 
+/**
+ * Abstract bridge implementation that adapts ProgressAsyncHandler to RxJava SingleSubscriber.
+ * <p>
+ * This bridge extends the base subscriber bridge to support progress tracking callbacks
+ * for content write operations during HTTP request execution.
+ */
 abstract class AbstractProgressSingleSubscriberBridge<T> extends AbstractSingleSubscriberBridge<T> implements ProgressAsyncHandler<Void> {
 
+  /**
+   * Creates a new progress-aware subscriber bridge.
+   *
+   * @param subscriber the RxJava SingleSubscriber to bridge to
+   */
   protected AbstractProgressSingleSubscriberBridge(SingleSubscriber<T> subscriber) {
     super(subscriber);
   }
 
+  /**
+   * Called when request headers have been written.
+   * <p>
+   * Aborts the request if the subscriber has unsubscribed, otherwise delegates
+   * to the underlying handler.
+   *
+   * @return the handler state indicating whether to continue or abort
+   */
   @Override
   public State onHeadersWritten() {
     return subscriber.isUnsubscribed() ? abort() : delegate().onHeadersWritten();
   }
 
+  /**
+   * Called when request content has been written.
+   * <p>
+   * Aborts the request if the subscriber has unsubscribed, otherwise delegates
+   * to the underlying handler.
+   *
+   * @return the handler state indicating whether to continue or abort
+   */
   @Override
   public State onContentWritten() {
     return subscriber.isUnsubscribed() ? abort() : delegate().onContentWritten();
   }
 
+  /**
+   * Called to report progress of content write operations.
+   * <p>
+   * Aborts the request if the subscriber has unsubscribed, otherwise delegates
+   * to the underlying handler.
+   *
+   * @param amount the amount of bytes written in this update
+   * @param current the total number of bytes written so far
+   * @param total the total number of bytes to write
+   * @return the handler state indicating whether to continue or abort
+   */
   @Override
   public State onContentWriteProgress(long amount, long current, long total) {
     return subscriber.isUnsubscribed() ? abort() : delegate().onContentWriteProgress(amount, current, total);
   }
 
+  /**
+   * Returns the underlying ProgressAsyncHandler to which operations are delegated.
+   *
+   * @return the delegate handler
+   */
   @Override
   protected abstract ProgressAsyncHandler<? extends T> delegate();
 

--- a/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/single/AbstractSingleSubscriberBridge.java
+++ b/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/single/AbstractSingleSubscriberBridge.java
@@ -28,6 +28,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Abstract bridge implementation that adapts AsyncHandler to RxJava SingleSubscriber.
+ * <p>
+ * This bridge handles the integration between AsyncHttpClient's callback-based AsyncHandler
+ * and RxJava's subscriber model, managing state transitions and error handling.
+ */
 abstract class AbstractSingleSubscriberBridge<T> implements AsyncHandler<Void> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractSingleSubscriberBridge.class);
@@ -36,30 +42,83 @@ abstract class AbstractSingleSubscriberBridge<T> implements AsyncHandler<Void> {
 
   private final AtomicBoolean delegateTerminated = new AtomicBoolean();
 
+  /**
+   * Creates a new subscriber bridge.
+   *
+   * @param subscriber the RxJava SingleSubscriber to bridge to
+   */
   protected AbstractSingleSubscriberBridge(SingleSubscriber<T> subscriber) {
     this.subscriber = requireNonNull(subscriber);
   }
 
+  /**
+   * Called when a response body part is received.
+   * <p>
+   * Aborts the request if the subscriber has unsubscribed, otherwise delegates
+   * to the underlying handler.
+   *
+   * @param content the received body part
+   * @return the handler state indicating whether to continue or abort
+   * @throws Exception if an error occurs during processing
+   */
   @Override
   public State onBodyPartReceived(HttpResponseBodyPart content) throws Exception {
     return subscriber.isUnsubscribed() ? abort() : delegate().onBodyPartReceived(content);
   }
 
+  /**
+   * Called when the response status is received.
+   * <p>
+   * Aborts the request if the subscriber has unsubscribed, otherwise delegates
+   * to the underlying handler.
+   *
+   * @param status the received response status
+   * @return the handler state indicating whether to continue or abort
+   * @throws Exception if an error occurs during processing
+   */
   @Override
   public State onStatusReceived(HttpResponseStatus status) throws Exception {
     return subscriber.isUnsubscribed() ? abort() : delegate().onStatusReceived(status);
   }
 
+  /**
+   * Called when response headers are received.
+   * <p>
+   * Aborts the request if the subscriber has unsubscribed, otherwise delegates
+   * to the underlying handler.
+   *
+   * @param headers the received headers
+   * @return the handler state indicating whether to continue or abort
+   * @throws Exception if an error occurs during processing
+   */
   @Override
   public State onHeadersReceived(HttpHeaders headers) throws Exception {
     return subscriber.isUnsubscribed() ? abort() : delegate().onHeadersReceived(headers);
   }
 
+  /**
+   * Called when trailing headers are received.
+   * <p>
+   * Aborts the request if the subscriber has unsubscribed, otherwise delegates
+   * to the underlying handler.
+   *
+   * @param headers the received trailing headers
+   * @return the handler state indicating whether to continue or abort
+   * @throws Exception if an error occurs during processing
+   */
   @Override
   public State onTrailingHeadersReceived(HttpHeaders headers) throws Exception {
     return subscriber.isUnsubscribed() ? abort() : delegate().onTrailingHeadersReceived(headers);
   }
 
+  /**
+   * Called when the request completes successfully.
+   * <p>
+   * Delegates to the underlying handler to produce the result, then emits
+   * it to the subscriber via onSuccess unless the subscriber has unsubscribed.
+   *
+   * @return null (Void return type)
+   */
   @Override
   public Void onCompleted() {
     if (delegateTerminated.getAndSet(true)) {
@@ -81,6 +140,15 @@ abstract class AbstractSingleSubscriberBridge<T> implements AsyncHandler<Void> {
     return null;
   }
 
+  /**
+   * Called when an error occurs during request processing.
+   * <p>
+   * Delegates to the underlying handler, then emits the error to the subscriber.
+   * If the delegate throws an exception, both exceptions are combined into a
+   * CompositeException.
+   *
+   * @param t the error that occurred
+   */
   @Override
   public void onThrowable(Throwable t) {
     if (delegateTerminated.getAndSet(true)) {
@@ -97,6 +165,14 @@ abstract class AbstractSingleSubscriberBridge<T> implements AsyncHandler<Void> {
     emitOnError(error);
   }
 
+  /**
+   * Aborts the request and notifies the delegate handler.
+   * <p>
+   * This method is called when the subscriber unsubscribes. It ensures the
+   * delegate handler receives an UnsubscribedException for cleanup purposes.
+   *
+   * @return ABORT state to signal request termination
+   */
   protected AsyncHandler.State abort() {
     if (!delegateTerminated.getAndSet(true)) {
       // send a terminal event to the delegate
@@ -107,6 +183,11 @@ abstract class AbstractSingleSubscriberBridge<T> implements AsyncHandler<Void> {
     return State.ABORT;
   }
 
+  /**
+   * Returns the underlying AsyncHandler to which operations are delegated.
+   *
+   * @return the delegate handler
+   */
   protected abstract AsyncHandler<? extends T> delegate();
 
   private void emitOnError(Throwable error) {

--- a/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/single/AsyncSingleSubscriberBridge.java
+++ b/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/single/AsyncSingleSubscriberBridge.java
@@ -17,15 +17,32 @@ import rx.SingleSubscriber;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Concrete bridge implementation for standard AsyncHandlers.
+ * <p>
+ * This bridge adapts a regular AsyncHandler to work with RxJava Singles,
+ * without progress tracking support.
+ */
 final class AsyncSingleSubscriberBridge<T> extends AbstractSingleSubscriberBridge<T> {
 
   private final AsyncHandler<? extends T> delegate;
 
+  /**
+   * Creates a new async subscriber bridge.
+   *
+   * @param subscriber the RxJava SingleSubscriber to bridge to
+   * @param delegate the AsyncHandler to delegate operations to
+   */
   public AsyncSingleSubscriberBridge(SingleSubscriber<T> subscriber, AsyncHandler<? extends T> delegate) {
     super(subscriber);
     this.delegate = requireNonNull(delegate);
   }
 
+  /**
+   * Returns the underlying AsyncHandler delegate.
+   *
+   * @return the delegate handler
+   */
   @Override
   protected AsyncHandler<? extends T> delegate() {
     return delegate;

--- a/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/single/ProgressAsyncSingleSubscriberBridge.java
+++ b/extras/rxjava/src/main/java/org/asynchttpclient/extras/rxjava/single/ProgressAsyncSingleSubscriberBridge.java
@@ -17,15 +17,32 @@ import rx.SingleSubscriber;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Concrete bridge implementation for ProgressAsyncHandlers.
+ * <p>
+ * This bridge adapts a ProgressAsyncHandler to work with RxJava Singles,
+ * providing progress tracking support for content write operations.
+ */
 final class ProgressAsyncSingleSubscriberBridge<T> extends AbstractProgressSingleSubscriberBridge<T> {
 
   private final ProgressAsyncHandler<? extends T> delegate;
 
+  /**
+   * Creates a new progress-aware subscriber bridge.
+   *
+   * @param subscriber the RxJava SingleSubscriber to bridge to
+   * @param delegate the ProgressAsyncHandler to delegate operations to
+   */
   public ProgressAsyncSingleSubscriberBridge(SingleSubscriber<T> subscriber, ProgressAsyncHandler<? extends T> delegate) {
     super(subscriber);
     this.delegate = requireNonNull(delegate);
   }
 
+  /**
+   * Returns the underlying ProgressAsyncHandler delegate.
+   *
+   * @return the delegate handler
+   */
   @Override
   protected ProgressAsyncHandler<? extends T> delegate() {
     return delegate;

--- a/extras/rxjava2/src/main/java/org/asynchttpclient/extras/rxjava2/DisposedException.java
+++ b/extras/rxjava2/src/main/java/org/asynchttpclient/extras/rxjava2/DisposedException.java
@@ -16,11 +16,19 @@ package org.asynchttpclient.extras.rxjava2;
 import java.util.concurrent.CancellationException;
 
 /**
- * Indicates that the HTTP request has been disposed asynchronously via RxJava.
+ * Indicates that the HTTP request has been disposed asynchronously via RxJava 2.
+ * <p>
+ * This exception is used to signal early termination of HTTP request processing when
+ * the RxJava 2 observer disposes of the subscription before the request completes.
  */
 public class DisposedException extends CancellationException {
   private static final long serialVersionUID = -5885577182105850384L;
 
+  /**
+   * Creates a new DisposedException with the specified detail message.
+   *
+   * @param message the detail message explaining the disposal
+   */
   public DisposedException(String message) {
     super(message);
   }

--- a/extras/rxjava2/src/main/java/org/asynchttpclient/extras/rxjava2/maybe/AbstractMaybeProgressAsyncHandlerBridge.java
+++ b/extras/rxjava2/src/main/java/org/asynchttpclient/extras/rxjava2/maybe/AbstractMaybeProgressAsyncHandlerBridge.java
@@ -18,31 +18,71 @@ import org.asynchttpclient.handler.ProgressAsyncHandler;
 
 /**
  * An extension to {@code AbstractMaybeAsyncHandlerBridge} for {@code ProgressAsyncHandlers}.
+ * <p>
+ * This bridge adds support for progress tracking callbacks during content write operations,
+ * while maintaining the same disposal and error handling semantics as the base class.
  *
  * @param <T> the result type produced by the wrapped {@code ProgressAsyncHandler} and emitted via RxJava
  */
 public abstract class AbstractMaybeProgressAsyncHandlerBridge<T> extends AbstractMaybeAsyncHandlerBridge<T>
         implements ProgressAsyncHandler<Void> {
 
+  /**
+   * Creates a new progress-aware handler bridge.
+   *
+   * @param emitter the RxJava MaybeEmitter to bridge to
+   */
   protected AbstractMaybeProgressAsyncHandlerBridge(MaybeEmitter<T> emitter) {
     super(emitter);
   }
 
+  /**
+   * Called when request headers have been written.
+   * <p>
+   * Aborts the request if the emitter has been disposed, otherwise delegates
+   * to the underlying handler.
+   *
+   * @return the handler state indicating whether to continue or abort
+   */
   @Override
   public final State onHeadersWritten() {
     return emitter.isDisposed() ? disposed() : delegate().onHeadersWritten();
   }
 
+  /**
+   * Called when request content has been written.
+   * <p>
+   * Aborts the request if the emitter has been disposed, otherwise delegates
+   * to the underlying handler.
+   *
+   * @return the handler state indicating whether to continue or abort
+   */
   @Override
   public final State onContentWritten() {
     return emitter.isDisposed() ? disposed() : delegate().onContentWritten();
   }
 
+  /**
+   * Called to report progress of content write operations.
+   * <p>
+   * Aborts the request if the emitter has been disposed, otherwise delegates
+   * to the underlying handler.
+   *
+   * @param amount the amount of bytes written in this update
+   * @param current the total number of bytes written so far
+   * @param total the total number of bytes to write
+   * @return the handler state indicating whether to continue or abort
+   */
   @Override
   public final State onContentWriteProgress(long amount, long current, long total) {
     return emitter.isDisposed() ? disposed() : delegate().onContentWriteProgress(amount, current, total);
   }
 
+  /**
+   * Returns the underlying ProgressAsyncHandler to which operations are delegated.
+   *
+   * @return the delegate handler
+   */
   @Override
   protected abstract ProgressAsyncHandler<? extends T> delegate();
 

--- a/extras/rxjava2/src/main/java/org/asynchttpclient/extras/rxjava2/maybe/MaybeAsyncHandlerBridge.java
+++ b/extras/rxjava2/src/main/java/org/asynchttpclient/extras/rxjava2/maybe/MaybeAsyncHandlerBridge.java
@@ -18,15 +18,35 @@ import org.asynchttpclient.AsyncHandler;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Concrete bridge implementation for standard AsyncHandlers.
+ * <p>
+ * This bridge adapts a regular AsyncHandler to work with RxJava 2 Maybe,
+ * without progress tracking support. It handles the conversion between
+ * AsyncHttpClient's callback-based API and RxJava's reactive API.
+ *
+ * @param <T> the result type produced by the wrapped AsyncHandler and emitted via RxJava
+ */
 public final class MaybeAsyncHandlerBridge<T> extends AbstractMaybeAsyncHandlerBridge<T> {
 
   private final AsyncHandler<? extends T> delegate;
 
+  /**
+   * Creates a new async handler bridge.
+   *
+   * @param emitter the RxJava MaybeEmitter to bridge to
+   * @param delegate the AsyncHandler to delegate operations to
+   */
   public MaybeAsyncHandlerBridge(MaybeEmitter<T> emitter, AsyncHandler<? extends T> delegate) {
     super(emitter);
     this.delegate = requireNonNull(delegate);
   }
 
+  /**
+   * Returns the underlying AsyncHandler delegate.
+   *
+   * @return the delegate handler
+   */
   @Override
   protected AsyncHandler<? extends T> delegate() {
     return delegate;

--- a/extras/rxjava2/src/main/java/org/asynchttpclient/extras/rxjava2/maybe/ProgressAsyncMaybeEmitterBridge.java
+++ b/extras/rxjava2/src/main/java/org/asynchttpclient/extras/rxjava2/maybe/ProgressAsyncMaybeEmitterBridge.java
@@ -18,15 +18,36 @@ import org.asynchttpclient.handler.ProgressAsyncHandler;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Concrete bridge implementation for ProgressAsyncHandlers.
+ * <p>
+ * This bridge adapts a ProgressAsyncHandler to work with RxJava 2 Maybe,
+ * providing progress tracking support for content write operations. It handles
+ * the conversion between AsyncHttpClient's callback-based API and RxJava's
+ * reactive API while supporting progress callbacks.
+ *
+ * @param <T> the result type produced by the wrapped ProgressAsyncHandler and emitted via RxJava
+ */
 public final class ProgressAsyncMaybeEmitterBridge<T> extends AbstractMaybeProgressAsyncHandlerBridge<T> {
 
   private final ProgressAsyncHandler<? extends T> delegate;
 
+  /**
+   * Creates a new progress-aware async handler bridge.
+   *
+   * @param emitter the RxJava MaybeEmitter to bridge to
+   * @param delegate the ProgressAsyncHandler to delegate operations to
+   */
   public ProgressAsyncMaybeEmitterBridge(MaybeEmitter<T> emitter, ProgressAsyncHandler<? extends T> delegate) {
     super(emitter);
     this.delegate = requireNonNull(delegate);
   }
 
+  /**
+   * Returns the underlying ProgressAsyncHandler delegate.
+   *
+   * @return the delegate handler
+   */
   @Override
   protected ProgressAsyncHandler<? extends T> delegate() {
     return delegate;

--- a/extras/simple/src/main/java/org/asynchttpclient/extras/simple/AppendableBodyConsumer.java
+++ b/extras/simple/src/main/java/org/asynchttpclient/extras/simple/AppendableBodyConsumer.java
@@ -20,29 +20,72 @@ import java.nio.charset.Charset;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
- * An {@link Appendable} customer for {@link ByteBuffer}
+ * A {@link BodyConsumer} that consumes response body bytes by appending them to an {@link Appendable}.
+ * <p>
+ * This consumer converts ByteBuffers to Strings using the specified charset and appends
+ * them to the provided Appendable (such as StringBuilder, StringBuffer, or Writer).
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Consume to StringBuilder
+ * StringBuilder sb = new StringBuilder();
+ * BodyConsumer consumer = new AppendableBodyConsumer(sb);
+ *
+ * // Consume to StringBuffer with custom charset
+ * StringBuffer buffer = new StringBuffer();
+ * BodyConsumer consumer = new AppendableBodyConsumer(buffer, StandardCharsets.ISO_8859_1);
+ *
+ * // Use with SimpleAsyncHttpClient
+ * SimpleAsyncHttpClient client = new SimpleAsyncHttpClient.Builder()
+ *     .setUrl("http://www.example.com")
+ *     .build();
+ * StringBuilder response = new StringBuilder();
+ * client.get(new AppendableBodyConsumer(response));
+ * }</pre>
  */
 public class AppendableBodyConsumer implements BodyConsumer {
 
   private final Appendable appendable;
   private final Charset charset;
 
+  /**
+   * Creates a new AppendableBodyConsumer with a specified charset.
+   *
+   * @param appendable the Appendable to which response bytes will be appended
+   * @param charset the charset to use for decoding bytes to strings
+   */
   public AppendableBodyConsumer(Appendable appendable, Charset charset) {
     this.appendable = appendable;
     this.charset = charset;
   }
 
+  /**
+   * Creates a new AppendableBodyConsumer using UTF-8 charset.
+   *
+   * @param appendable the Appendable to which response bytes will be appended
+   */
   public AppendableBodyConsumer(Appendable appendable) {
     this.appendable = appendable;
     this.charset = UTF_8;
   }
 
+  /**
+   * Consumes the ByteBuffer by converting it to a String and appending to the Appendable.
+   *
+   * @param byteBuffer the buffer containing response body bytes
+   * @throws IOException if an I/O error occurs during appending
+   */
   @Override
   public void consume(ByteBuffer byteBuffer) throws IOException {
     appendable
             .append(new String(byteBuffer.array(), byteBuffer.arrayOffset() + byteBuffer.position(), byteBuffer.remaining(), charset));
   }
 
+  /**
+   * Closes the underlying Appendable if it implements {@link Closeable}.
+   *
+   * @throws IOException if an I/O error occurs during closing
+   */
   @Override
   public void close() throws IOException {
     if (appendable instanceof Closeable) {

--- a/extras/simple/src/main/java/org/asynchttpclient/extras/simple/BodyConsumer.java
+++ b/extras/simple/src/main/java/org/asynchttpclient/extras/simple/BodyConsumer.java
@@ -18,15 +18,34 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /**
- * A simple API to be used with the {@link SimpleAsyncHttpClient} class in order to process response's bytes.
+ * A simple API to be used with the {@link SimpleAsyncHttpClient} class in order to process response bytes.
+ * <p>
+ * Implementations of this interface consume response body chunks as they arrive, enabling
+ * streaming processing of HTTP responses without loading the entire response into memory.
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Consume to StringBuilder
+ * StringBuilder sb = new StringBuilder();
+ * BodyConsumer consumer = new AppendableBodyConsumer(sb);
+ *
+ * // Consume to File
+ * BodyConsumer fileConsumer = new FileBodyConsumer(new File("output.txt"));
+ *
+ * // Consume to OutputStream
+ * BodyConsumer streamConsumer = new OutputStreamBodyConsumer(outputStream);
+ * }</pre>
  */
 public interface BodyConsumer extends Closeable {
 
   /**
-   * Consume the received bytes.
+   * Consumes the received bytes from an HTTP response body chunk.
+   * <p>
+   * This method is called multiple times as response body chunks arrive,
+   * allowing for streaming processing of the response.
    *
-   * @param byteBuffer a {@link ByteBuffer} representation of the response's chunk.
-   * @throws IOException IO exception
+   * @param byteBuffer a ByteBuffer containing a chunk of the response body
+   * @throws IOException if an I/O error occurs during consumption
    */
   void consume(ByteBuffer byteBuffer) throws IOException;
 }

--- a/extras/simple/src/main/java/org/asynchttpclient/extras/simple/ByteBufferBodyConsumer.java
+++ b/extras/simple/src/main/java/org/asynchttpclient/extras/simple/ByteBufferBodyConsumer.java
@@ -16,18 +16,42 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /**
- * A {@link ByteBuffer} implementation of {@link BodyConsumer}
+ * A {@link BodyConsumer} that writes response body bytes into a {@link ByteBuffer}.
+ * <p>
+ * This consumer accumulates response bytes directly into a ByteBuffer, which is
+ * useful when you need the response data in ByteBuffer form for further processing.
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * ByteBuffer buffer = ByteBuffer.allocate(8192);
+ * ByteBufferBodyConsumer consumer = new ByteBufferBodyConsumer(buffer);
+ *
+ * SimpleAsyncHttpClient client = new SimpleAsyncHttpClient.Builder()
+ *     .setUrl("http://www.example.com")
+ *     .build();
+ *
+ * Future<Response> future = client.get(consumer);
+ * // After completion, buffer contains the response data
+ * }</pre>
  */
 public class ByteBufferBodyConsumer implements BodyConsumer {
 
   private final ByteBuffer byteBuffer;
 
+  /**
+   * Creates a new ByteBufferBodyConsumer that writes to the specified buffer.
+   *
+   * @param byteBuffer the ByteBuffer to write response body bytes into
+   */
   public ByteBufferBodyConsumer(ByteBuffer byteBuffer) {
     this.byteBuffer = byteBuffer;
   }
 
   /**
-   * {@inheritDoc}
+   * Writes the received bytes into the underlying ByteBuffer.
+   *
+   * @param byteBuffer the buffer containing response body bytes
+   * @throws IOException if an I/O error occurs during writing
    */
   @Override
   public void consume(ByteBuffer byteBuffer) throws IOException {
@@ -35,7 +59,11 @@ public class ByteBufferBodyConsumer implements BodyConsumer {
   }
 
   /**
-   * {@inheritDoc}
+   * Flips the underlying ByteBuffer, preparing it for reading.
+   * <p>
+   * After this call, the buffer is ready to be read from the beginning.
+   *
+   * @throws IOException if an I/O error occurs
    */
   @Override
   public void close() throws IOException {

--- a/extras/simple/src/main/java/org/asynchttpclient/extras/simple/OutputStreamBodyConsumer.java
+++ b/extras/simple/src/main/java/org/asynchttpclient/extras/simple/OutputStreamBodyConsumer.java
@@ -17,18 +17,45 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
 /**
- * A simple {@link OutputStream} implementation for {@link BodyConsumer}
+ * A {@link BodyConsumer} that writes response body bytes to an {@link OutputStream}.
+ * <p>
+ * This consumer writes response bytes directly to any OutputStream, making it
+ * flexible for writing to files, network streams, or any other output destination.
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Write to file
+ * OutputStream fos = new FileOutputStream("output.dat");
+ * OutputStreamBodyConsumer consumer = new OutputStreamBodyConsumer(fos);
+ *
+ * // Write to byte array
+ * ByteArrayOutputStream baos = new ByteArrayOutputStream();
+ * OutputStreamBodyConsumer consumer = new OutputStreamBodyConsumer(baos);
+ *
+ * SimpleAsyncHttpClient client = new SimpleAsyncHttpClient.Builder()
+ *     .setUrl("http://www.example.com/data")
+ *     .build();
+ * client.get(consumer);
+ * }</pre>
  */
 public class OutputStreamBodyConsumer implements BodyConsumer {
 
   private final OutputStream outputStream;
 
+  /**
+   * Creates a new OutputStreamBodyConsumer that writes to the specified stream.
+   *
+   * @param outputStream the OutputStream to write response body bytes to
+   */
   public OutputStreamBodyConsumer(OutputStream outputStream) {
     this.outputStream = outputStream;
   }
 
   /**
-   * {@inheritDoc}
+   * Writes the received bytes to the underlying OutputStream.
+   *
+   * @param byteBuffer the buffer containing response body bytes
+   * @throws IOException if an I/O error occurs during writing
    */
   @Override
   public void consume(ByteBuffer byteBuffer) throws IOException {
@@ -36,7 +63,9 @@ public class OutputStreamBodyConsumer implements BodyConsumer {
   }
 
   /**
-   * {@inheritDoc}
+   * Closes the underlying OutputStream.
+   *
+   * @throws IOException if an I/O error occurs during closing
    */
   @Override
   public void close() throws IOException {

--- a/extras/simple/src/main/java/org/asynchttpclient/extras/simple/ResumableBodyConsumer.java
+++ b/extras/simple/src/main/java/org/asynchttpclient/extras/simple/ResumableBodyConsumer.java
@@ -16,22 +16,49 @@ package org.asynchttpclient.extras.simple;
 import java.io.IOException;
 
 /**
+ * A {@link BodyConsumer} that supports resuming interrupted downloads.
+ * <p>
+ * This interface extends BodyConsumer to provide methods for tracking the number
+ * of bytes already transferred and resuming from that position. This is useful
+ * for large file downloads that may be interrupted and need to continue from
+ * where they left off.
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * RandomAccessFile file = new RandomAccessFile("large-file.zip", "rw");
+ * ResumableBodyConsumer consumer = new FileBodyConsumer(file);
+ *
+ * SimpleAsyncHttpClient client = new SimpleAsyncHttpClient.Builder()
+ *     .setUrl("http://www.example.com/large-file.zip")
+ *     .setResumableDownload(true)
+ *     .build();
+ *
+ * // Download will resume from current file position if interrupted
+ * Future<Response> future = client.get(consumer);
+ * }</pre>
+ *
  * @author Benjamin Hanzelmann
  */
 public interface ResumableBodyConsumer extends BodyConsumer {
 
   /**
-   * Prepare this consumer to resume a download, for example by seeking to the end of the underlying file.
+   * Prepares this consumer to resume a download from the current position.
+   * <p>
+   * For example, a file-based implementation would seek to the end of the file
+   * so that new bytes will be appended.
    *
-   * @throws IOException IO exception
+   * @throws IOException if an I/O error occurs during preparation
    */
   void resume() throws IOException;
 
   /**
-   * Get the previously transferred bytes, for example the current file size.
+   * Returns the number of bytes already transferred.
+   * <p>
+   * For example, a file-based implementation would return the current file size.
+   * This value is used to send a Range header to continue the download.
    *
    * @return the number of transferred bytes
-   * @throws IOException IO exception
+   * @throws IOException if an I/O error occurs reading the transferred byte count
    */
   long getTransferredBytes() throws IOException;
 }

--- a/extras/simple/src/main/java/org/asynchttpclient/extras/simple/ThrowableHandler.java
+++ b/extras/simple/src/main/java/org/asynchttpclient/extras/simple/ThrowableHandler.java
@@ -15,9 +15,30 @@ package org.asynchttpclient.extras.simple;
 
 
 /**
- * Simple {@link Throwable} handler to be used with {@link SimpleAsyncHttpClient}
+ * Simple {@link Throwable} handler to be used with {@link SimpleAsyncHttpClient}.
+ * <p>
+ * This interface provides a callback mechanism for handling exceptions that occur
+ * during HTTP request execution, allowing custom error handling logic.
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * ThrowableHandler handler = throwable -> {
+ *     logger.error("Request failed: " + throwable.getMessage(), throwable);
+ *     // Custom error handling logic
+ * };
+ *
+ * SimpleAsyncHttpClient client = new SimpleAsyncHttpClient.Builder()
+ *     .setDefaultThrowableHandler(handler)
+ *     .setUrl("http://www.example.com")
+ *     .build();
+ * }</pre>
  */
 public interface ThrowableHandler {
 
+  /**
+   * Handles a throwable that occurred during HTTP request processing.
+   *
+   * @param t the throwable that was thrown during request execution
+   */
   void onThrowable(Throwable t);
 }

--- a/extras/typesafeconfig/src/main/java/org/asynchttpclient/extras/typesafeconfig/AsyncHttpClientTypesafeConfig.java
+++ b/extras/typesafeconfig/src/main/java/org/asynchttpclient/extras/typesafeconfig/AsyncHttpClientTypesafeConfig.java
@@ -41,10 +41,37 @@ import java.util.function.Function;
 
 import static org.asynchttpclient.config.AsyncHttpClientConfigDefaults.*;
 
+/**
+ * An {@link AsyncHttpClientConfig} implementation that reads configuration from Typesafe Config.
+ * <p>
+ * This class allows AsyncHttpClient to be configured using Typesafe Config (now Lightbend Config),
+ * enabling externalized configuration through application.conf, application.json, or other
+ * supported configuration sources.
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * // Load from application.conf
+ * Config config = ConfigFactory.load();
+ * AsyncHttpClientConfig ahcConfig = new AsyncHttpClientTypesafeConfig(config);
+ * AsyncHttpClient client = asyncHttpClient(ahcConfig);
+ *
+ * // Load from custom config
+ * Config custom = ConfigFactory.parseString(
+ *     "org.asynchttpclient.maxConnections = 100\n" +
+ *     "org.asynchttpclient.requestTimeout = 30000"
+ * );
+ * AsyncHttpClientConfig ahcConfig = new AsyncHttpClientTypesafeConfig(custom);
+ * }</pre>
+ */
 public class AsyncHttpClientTypesafeConfig implements AsyncHttpClientConfig {
 
   private final Config config;
 
+  /**
+   * Creates a new configuration instance from the specified Typesafe Config.
+   *
+   * @param config the Typesafe Config containing AsyncHttpClient configuration properties
+   */
   public AsyncHttpClientTypesafeConfig(Config config) {
     this.config = config;
   }

--- a/netty-utils/src/main/java/org/asynchttpclient/netty/util/ByteBufUtils.java
+++ b/netty-utils/src/main/java/org/asynchttpclient/netty/util/ByteBufUtils.java
@@ -28,6 +28,26 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.asynchttpclient.netty.util.Utf8ByteBufCharsetDecoder.*;
 
+/**
+ * Utility class for converting Netty ByteBuf instances to bytes, strings, and character arrays.
+ * <p>
+ * This class provides optimized conversion methods that handle both heap and direct buffers
+ * efficiently, with special optimizations for UTF-8 and US-ASCII charsets.
+ *
+ * <p><b>Usage Examples:</b></p>
+ * <pre>{@code
+ * ByteBuf buf = Unpooled.copiedBuffer("Hello World", UTF_8);
+ *
+ * // Convert to byte array
+ * byte[] bytes = ByteBufUtils.byteBuf2Bytes(buf);
+ *
+ * // Convert to String
+ * String str = ByteBufUtils.byteBuf2String(UTF_8, buf);
+ *
+ * // Convert to char array
+ * char[] chars = ByteBufUtils.byteBuf2Chars(UTF_8, buf);
+ * }</pre>
+ */
 public final class ByteBufUtils {
 
   private static final char[] EMPTY_CHARS = new char[0];
@@ -36,6 +56,15 @@ public final class ByteBufUtils {
   private ByteBufUtils() {
   }
 
+  /**
+   * Converts a ByteBuf to a byte array.
+   * <p>
+   * If the ByteBuf is backed by an array and the array covers the entire readable range,
+   * the underlying array is returned directly. Otherwise, a copy is made.
+   *
+   * @param buf the ByteBuf to convert
+   * @return a byte array containing the readable bytes from the buffer
+   */
   public static byte[] byteBuf2Bytes(ByteBuf buf) {
     int readable = buf.readableBytes();
     int readerIndex = buf.readerIndex();
@@ -50,18 +79,54 @@ public final class ByteBufUtils {
     return array;
   }
 
+  /**
+   * Converts a ByteBuf to a String using the specified charset.
+   * <p>
+   * Uses optimized UTF-8 decoding for UTF-8 and US-ASCII charsets.
+   *
+   * @param charset the charset to use for decoding
+   * @param buf the ByteBuf to convert
+   * @return a String containing the decoded bytes
+   */
   public static String byteBuf2String(Charset charset, ByteBuf buf) {
     return isUtf8OrUsAscii(charset) ? decodeUtf8(buf) : buf.toString(charset);
   }
 
+  /**
+   * Converts multiple ByteBufs to a single String using the specified charset.
+   * <p>
+   * Uses optimized UTF-8 decoding for UTF-8 and US-ASCII charsets.
+   *
+   * @param charset the charset to use for decoding
+   * @param bufs the ByteBufs to convert
+   * @return a String containing the decoded bytes from all buffers
+   */
   public static String byteBuf2String(Charset charset, ByteBuf... bufs) {
     return isUtf8OrUsAscii(charset) ? decodeUtf8(bufs) : byteBuf2String0(charset, bufs);
   }
 
+  /**
+   * Converts a ByteBuf to a character array using the specified charset.
+   * <p>
+   * Uses optimized UTF-8 decoding for UTF-8 and US-ASCII charsets.
+   *
+   * @param charset the charset to use for decoding
+   * @param buf the ByteBuf to convert
+   * @return a character array containing the decoded bytes
+   */
   public static char[] byteBuf2Chars(Charset charset, ByteBuf buf) {
     return isUtf8OrUsAscii(charset) ? decodeUtf8Chars(buf) : decodeChars(buf, charset);
   }
 
+  /**
+   * Converts multiple ByteBufs to a single character array using the specified charset.
+   * <p>
+   * Uses optimized UTF-8 decoding for UTF-8 and US-ASCII charsets.
+   *
+   * @param charset the charset to use for decoding
+   * @param bufs the ByteBufs to convert
+   * @return a character array containing the decoded bytes from all buffers
+   */
   public static char[] byteBuf2Chars(Charset charset, ByteBuf... bufs) {
     return isUtf8OrUsAscii(charset) ? decodeUtf8Chars(bufs) : byteBuf2Chars0(charset, bufs);
   }


### PR DESCRIPTION
This commit comprehensively improves Javadoc documentation for all public methods in the async-http-client library, ensuring consistency, clarity, and accuracy throughout the codebase.

Key improvements:
- Enhanced class-level documentation with comprehensive descriptions
- Added usage examples using standardized {@code} block format
- Harmonized method documentation across similar classes
- Improved @param, @return, and @throws tags for clarity
- Added cross-references with proper @link and @see tags
- Fixed typos and corrected technical inaccuracies
- Documented thread-safety and lifecycle characteristics
- Added missing copyright header to DefaultKeepAliveStrategy.java

Files updated (165 files, +8,236 lines, -764 lines):
- Core API: AsyncHttpClient, Request, Response, handlers
- Netty implementation: handlers, channels, request processing
- Request body: generators, multipart, reactive streams
- Configuration: filters, cookies, exceptions
- Authentication: OAuth, NTLM, SPNEGO
- Proxy and WebSocket support
- Utility classes and helpers
- All extras modules: guava, rxjava, rxjava2, simple, registry, etc.

All documentation now follows consistent patterns:
- Clear behavior descriptions in present tense
- Complete parameter and return value documentation
- Practical usage examples where appropriate
- RFC and specification references where applicable
- Consistent terminology and formatting

This enhancement significantly improves the developer experience and maintainability of the async-http-client library.