### PR TITLE
Replace umbrella netty-codec with netty-codec-base and netty-codec-compression

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,13 @@
 
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-codec</artifactId>
+            <artifactId>netty-codec-base</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-compression</artifactId>
             <version>${netty.version}</version>
         </dependency>
 


### PR DESCRIPTION
Motivation:

Netty 4.2 split netty-codec into sub-modules; the umbrella artifact now only aggregates them and transitively pulls in netty-codec-protobuf and netty-codec-marshalling, neither of which AHC uses.

Modification:

Replaced the `io.netty:netty-codec` dependency with the two sub-modules AHC actually references: `netty-codec-base` (DecoderResultProvider, PrematureChannelClosureException) and `netty-codec-compression` (Brotli, Zstd, JdkZlibDecoder, ZlibWrapper)

Result:

Fixes #2191