### PR TITLE
reject set-cookie domain that doesn't match the request host

### DIFF
--- a/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
@@ -165,6 +165,11 @@ public final class ThreadSafeCookieStore implements CookieStore {
         }
     }
 
+    // rfc6265#section-5.1.3
+    private static boolean domainsMatch(String cookieDomain, String requestDomain) {
+        return requestDomain.equals(cookieDomain) || requestDomain.endsWith('.' + cookieDomain);
+    }
+
     // rfc6265#section-5.1.4
     private static boolean pathsMatch(String cookiePath, String requestPath) {
         return Objects.equals(cookiePath, requestPath) ||
@@ -175,6 +180,14 @@ public final class ThreadSafeCookieStore implements CookieStore {
         AbstractMap.SimpleEntry<String, Boolean> pair = cookieDomain(cookie.domain(), requestDomain);
         String keyDomain = pair.getKey();
         boolean hostOnly = pair.getValue();
+
+        // rfc6265#section-5.3 step 6: ignore a cookie whose Domain attribute is not
+        // domain-matched by the request host, otherwise a host can plant cookies for
+        // unrelated domains (cookie tossing).
+        if (!hostOnly && !domainsMatch(keyDomain, requestDomain)) {
+            return;
+        }
+
         String keyPath = cookiePath(cookie.path(), requestPath);
         CookieKey key = new CookieKey(cookie.name().toLowerCase(), keyPath);
 

--- a/client/src/test/java/org/asynchttpclient/CookieStoreTest.java
+++ b/client/src/test/java/org/asynchttpclient/CookieStoreTest.java
@@ -56,6 +56,7 @@ public class CookieStoreTest {
     public void runAllSequentiallyBecauseNotThreadSafe() throws Exception {
         addCookieWithEmptyPath();
         dontReturnCookieForAnotherDomain();
+        dontStoreCookieForUnrelatedDomainAttribute();
         returnCookieWhenItWasSetOnSamePath();
         returnCookieWhenItWasSetOnParentPath();
         dontReturnCookieWhenDomainMatchesButPathIsDifferent();
@@ -98,6 +99,14 @@ public class CookieStoreTest {
         CookieStore store = new ThreadSafeCookieStore();
         store.add(Uri.create("http://www.foo.com"), ClientCookieDecoder.LAX.decode("ALPHA=VALUE1; path="));
         assertTrue(store.get(Uri.create("http://www.bar.com")).isEmpty());
+    }
+
+    // rfc6265#section-5.3 step 6: a host must not be able to set a cookie for an unrelated domain
+    private static void dontStoreCookieForUnrelatedDomainAttribute() {
+        CookieStore store = new ThreadSafeCookieStore();
+        store.add(Uri.create("http://www.evil.com/"), ClientCookieDecoder.LAX.decode("SID=attacker; Domain=victim.com"));
+        assertTrue(store.get(Uri.create("https://victim.com/account")).isEmpty());
+        assertTrue(store.getAll().isEmpty());
     }
 
     private static void returnCookieWhenItWasSetOnSamePath() {


### PR DESCRIPTION
ThreadSafeCookieStore stores a cookie under its Domain attribute without checking the response host is allowed to set it (rfc6265 5.3 step 6), so a host can plant cookies for unrelated domains:
- a response from www.evil.com with `Set-Cookie: SID=x; Domain=victim.com` is stored under victim.com
- the cookie is then sent on later requests to victim.com (cookie tossing)
- add() now drops the cookie when the request host does not domain-match the cookie domain

Added a CookieStoreTest case; the existing subdomain-match cases still pass.