### PR TITLE
escape quote and crlf in multipart content-disposition values

### DIFF
--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/part/FileLikeMultipartPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/part/FileLikeMultipartPart.java
@@ -37,7 +37,7 @@ public abstract class FileLikeMultipartPart<T extends FileLikePart> extends Mult
         if (part.getFileName() != null) {
             visitor.withBytes(FILE_NAME_BYTES);
             visitor.withByte(QUOTE_BYTE);
-            visitor.withBytes(part.getFileName().getBytes(part.getCharset() != null ? part.getCharset() : UTF_8));
+            visitor.withBytes(escapeQuotedString(part.getFileName()).getBytes(part.getCharset() != null ? part.getCharset() : UTF_8));
             visitor.withByte(QUOTE_BYTE);
         }
     }

--- a/client/src/main/java/org/asynchttpclient/request/body/multipart/part/MultipartPart.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/multipart/part/MultipartPart.java
@@ -264,9 +264,43 @@ public abstract class MultipartPart<T extends PartBase> implements Closeable {
         if (part.getName() != null) {
             visitor.withBytes(NAME_BYTES);
             visitor.withByte(QUOTE_BYTE);
-            visitor.withBytes(part.getName().getBytes(US_ASCII));
+            visitor.withBytes(escapeQuotedString(part.getName()).getBytes(US_ASCII));
             visitor.withByte(QUOTE_BYTE);
         }
+    }
+
+    /**
+     * Escape the characters that would let a name or filename break out of its
+     * quoted Content-Disposition parameter (RFC 7578 section 5.1): a double quote
+     * closes the value, CR/LF inject extra part headers.
+     */
+    protected static String escapeQuotedString(String value) {
+        StringBuilder sb = null;
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            String replacement;
+            switch (c) {
+                case '"':
+                    replacement = "%22";
+                    break;
+                case '\r':
+                    replacement = "%0D";
+                    break;
+                case '\n':
+                    replacement = "%0A";
+                    break;
+                default:
+                    if (sb != null) {
+                        sb.append(c);
+                    }
+                    continue;
+            }
+            if (sb == null) {
+                sb = new StringBuilder(value.length() + 6).append(value, 0, i);
+            }
+            sb.append(replacement);
+        }
+        return sb == null ? value : sb.toString();
     }
 
     protected void visitContentTypeHeader(PartVisitor visitor) {

--- a/client/src/test/java/org/asynchttpclient/request/body/multipart/part/MultipartPartTest.java
+++ b/client/src/test/java/org/asynchttpclient/request/body/multipart/part/MultipartPartTest.java
@@ -96,6 +96,23 @@ public class MultipartPartTest {
     }
 
     @RepeatedIfExceptionsTest(repeats = 5)
+    public void testVisitDispositionHeaderEscapesNameAndFileName() {
+        TestFileLikePart fileLikePart = new TestFileLikePart("na\"me\r\nX-Injected: 1", null, null, null, null, "ev\"il\r\nfilename");
+        try (TestMultipartPart multipartPart = new TestMultipartPart(fileLikePart, EMPTY_BYTE_ARRAY)) {
+            ByteBuf buffer = ByteBufAllocator.DEFAULT.buffer();
+            try {
+                multipartPart.visitDispositionHeader(new PartVisitor.ByteBufVisitor(buffer));
+                String header = buffer.toString(UTF_8);
+                assertEquals("\r\nContent-Disposition: form-data; name=\"na%22me%0D%0AX-Injected: 1\""
+                        + "; filename=\"ev%22il%0D%0Afilename\"", header,
+                        "quote and CRLF in name and filename must be percent-escaped so they cannot break out of the quoted value");
+            } finally {
+                buffer.release();
+            }
+        }
+    }
+
+    @RepeatedIfExceptionsTest(repeats = 5)
     public void testVisitContentTypeHeaderWithCharset() {
         TestFileLikePart fileLikePart = new TestFileLikePart(null, "application/test", UTF_8, null, null);
         try (TestMultipartPart multipartPart = new TestMultipartPart(fileLikePart, EMPTY_BYTE_ARRAY)) {


### PR DESCRIPTION
Unescaped values in the multipart Content-Disposition header:
- visitDispositionHeader writes the part name between quotes with no escaping
- the filename in FileLikeMultipartPart repeats the same pattern
- a name or filename holding a quote or CR/LF closes the value and injects extra part headers or parts

Percent-escape ", CR and LF in both before the bytes are written, per RFC 7578 section 5.1.