### PR TITLE
Improve CI Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,21 +7,29 @@ on:
 
   workflow_dispatch:
     inputs:
-      snapshot:
-        description: 'Deploy SNAPSHOT'
+      release:
+        description: 'Release final version to Maven Central (strips -SNAPSHOT, tags, then bumps to the next -SNAPSHOT)'
         type: boolean
         default: false
 
 permissions:
-  contents: read
+  contents: write
+
+# Never let a push-triggered SNAPSHOT deploy race a manual release on the same branch.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
 
   deploy:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    # Skip the automated commits the release plugin pushes back to main.
+    if: github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, '[maven-release-plugin]')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-java@v5
         with:
@@ -31,14 +39,11 @@ jobs:
       - name: Grant Permission
         run: chmod +x ./mvnw
 
-      - name: Validate SNAPSHOT version
-        if: inputs.snapshot == true
+      - name: Configure Git User
+        if: inputs.release == true
         run: |
-          VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
-          if [[ "$VERSION" != *-SNAPSHOT ]]; then
-            echo "::error::Version $VERSION is not a SNAPSHOT version"
-            exit 1
-          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Remove old Maven Settings
         run: rm -f /home/runner/.m2/settings.xml
@@ -59,8 +64,31 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Deploy
+      # Every push to main (and manual runs with the checkbox unticked) publishes a
+      # SNAPSHOT. SNAPSHOTs are mutable, so re-publishing the same version never collides.
+      - name: Deploy SNAPSHOT
+        if: inputs.release != true
         env:
-            GPG_KEY_NAME: ${{ secrets.GPG_KEY_NAME }}
-            GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: ./mvnw -B -ntp deploy -DskipTests -Dgpg.keyname=${GPG_KEY_NAME} -Dgpg.passphrase=${GPG_PASSPHRASE}
+          GPG_KEY_NAME: ${{ secrets.GPG_KEY_NAME }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          if [[ "$VERSION" != *-SNAPSHOT ]]; then
+            echo "::error::Version $VERSION is not a SNAPSHOT. Push-triggered runs only publish SNAPSHOTs; use the manual 'Release' run to cut a final version."
+            exit 1
+          fi
+          ./mvnw -B -ntp deploy -DskipTests -Dgpg.keyname=${GPG_KEY_NAME} -Dgpg.passphrase=${GPG_PASSPHRASE}
+
+      # Manual run with the checkbox ticked: maven-release-plugin strips -SNAPSHOT,
+      # tags the release, deploys it to Maven Central, then bumps to the next
+      # -SNAPSHOT and pushes both commits + the tag back to main.
+      - name: Release
+        if: inputs.release == true
+        env:
+          GPG_KEY_NAME: ${{ secrets.GPG_KEY_NAME }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          ./mvnw -B -ntp release:prepare release:perform \
+            -DskipTests \
+            -DlocalCheckout=true \
+            -Darguments="-DskipTests -Dgpg.keyname=${GPG_KEY_NAME} -Dgpg.passphrase=${GPG_PASSPHRASE}"

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.asynchttpclient</groupId>
     <artifactId>async-http-client-project</artifactId>
-    <version>3.0.11</version>
+    <version>3.0.12-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>AHC/Project</name>
@@ -68,8 +68,8 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git@github.com:AsyncHttpClient/async-http-client.git</connection>
-        <developerConnection>scm:git:git@github.com:AsyncHttpClient/async-http-client.git</developerConnection>
+        <connection>scm:git:https://github.com/AsyncHttpClient/async-http-client.git</connection>
+        <developerConnection>scm:git:https://github.com/AsyncHttpClient/async-http-client.git</developerConnection>
         <url>https://github.com/AsyncHttpClient/async-http-client/tree/main</url>
         <tag>HEAD</tag>
     </scm>
@@ -406,7 +406,32 @@
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>3.3.1</version>
+                <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <tagNameFormat>async-http-client-project-@{project.version}</tagNameFormat>
+                    <preparationGoals>clean verify</preparationGoals>
+                    <signTag>false</signTag>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.scm</groupId>
+                        <artifactId>maven-scm-api</artifactId>
+                        <version>2.2.1</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.scm</groupId>
+                        <artifactId>maven-scm-provider-gitexe</artifactId>
+                        <version>2.2.1</version>
+                    </dependency>
+                </dependencies>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
Motivation:

The Release workflow failed on every push to main — it ran mvnw deploy on each commit, but main sat on the already-released 3.0.11, and Maven Central rejected re-publishing immutable coordinates (async-http-client@3.0.11 already exists).

Modification:

Keep main on -SNAPSHOT and drive releases via maven-release-plugin — pushes deploy SNAPSHOTs, while a manual workflow_dispatch release checkbox strips -SNAPSHOT, tags, publishes to Central (autoPublish=true), and auto-bumps to the next -SNAPSHOT.

Result:

Pushes publish SNAPSHOTs without collision and final releases are a one-click auto-bumping run, so the pipeline no longer fails on every commit.