### PR TITLE
Upgrade to Java 17

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '17'
       - name: Verify
         run: ./mvnw -B -ntp clean verify -DskipTests -Dgpg.skip=true
 
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '17'
       - name: Run Tests
         run: ./mvnw -B -ntp test -Ddocker.tests=true
 
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '17'
       - name: Run Tests
         run: ./mvnw -B -ntp test
 
@@ -54,6 +54,6 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '17'
       - name: Run Tests
         run: ./mvnw.cmd -B -ntp test

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '17'
       - name: Grant Permission
         run: chmod +x ./mvnw
       - name: Compile and API compatibility check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '17'
 
       - name: Grant Permission
         run: chmod +x ./mvnw

--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,7 @@
     </licenses>
 
     <properties>
-        <java.version>11</java.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <netty.version>4.2.15.Final</netty.version>
@@ -303,8 +301,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.15.0</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
                     <encoding>UTF-8</encoding>
                     <compilerArgs>
                         <arg>-XDcompilePolicy=simple</arg>
@@ -338,6 +334,7 @@
                             <version>${nullaway.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <release>${java.version}</release>
                 </configuration>
             </plugin>
 
@@ -544,6 +541,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.15.0</version>
                         <configuration>
                             <compilerArgs combine.children="append">
                                 <arg>--should-stop=ifError=FLOW</arg>


### PR DESCRIPTION
Upgrades the build from Java 11 to Java 17 (LTS).

- `pom.xml`: compiler target 11 → 17 (consolidated to the `<java.version>` property + `<release>${java.version}>`)
- `.github/workflows/*` (builds, maven, release): `java-version` 11 → 17 so CI builds on the new target

**Verification:** the project compiles under JDK 17 and all 1192 tests pass, with none lost versus the JDK-11 baseline. No production or test code was changed — only the compiler target and the CI JDK.



---
### How this was produced
This change was produced by running the OpenRewrite recipe below — the committed diff is the recipe output (no hand-editing):

```yaml
# rewrite.yml
type: specs.openrewrite.org/v1beta/recipe
name: com.example.UpgradeJava
recipeList:
  - org.openrewrite.java.migrate.UpgradePluginsForJava17
  - org.openrewrite.java.migrate.UpgradeBuildToJava17
  - org.openrewrite.java.migrate.UpgradeJavaVersion:
      version: 17
```
```bash
mvn -U org.openrewrite.maven:rewrite-maven-plugin:RELEASE:run \
  -Drewrite.configLocation=$(pwd)/rewrite.yml \
  -Drewrite.activeRecipes=com.example.UpgradeJava \
  -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-migrate-java:RELEASE
```

_Verified: all 1192 tests pass under JDK 17, none lost versus the baseline._
