### PR TITLE
Localize tests that depended on public endpoints

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -30,7 +30,7 @@ jobs:
           distribution: 'corretto'
           java-version: '11'
       - name: Run Tests
-        run: ./mvnw -B -ntp test -Ddocker.tests=true
+        run: ./mvnw -B -ntp test -Ddocker.tests=true -Dexternal.tests=true
 
   RunOnMacOs:
     runs-on: macos-latest
@@ -44,7 +44,7 @@ jobs:
           distribution: 'corretto'
           java-version: '11'
       - name: Run Tests
-        run: ./mvnw -B -ntp test
+        run: ./mvnw -B -ntp test -Dexternal.tests=true
 
   RunOnWindows:
     runs-on: windows-latest
@@ -56,4 +56,4 @@ jobs:
           distribution: 'corretto'
           java-version: '11'
       - name: Run Tests
-        run: ./mvnw.cmd -B -ntp test
+        run: ./mvnw.cmd -B -ntp test "-Dexternal.tests=true"

--- a/client/src/test/java/org/asynchttpclient/AddressResolverGroupTest.java
+++ b/client/src/test/java/org/asynchttpclient/AddressResolverGroupTest.java
@@ -24,9 +24,8 @@ import org.asynchttpclient.testserver.HttpServer;
 import org.asynchttpclient.testserver.HttpTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 
-import java.net.InetSocketAddress;
-import java.net.Socket;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -35,6 +34,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.asynchttpclient.Dsl.asyncHttpClient;
 import static org.asynchttpclient.Dsl.config;
 import static org.asynchttpclient.Dsl.get;
+import static org.asynchttpclient.test.TestUtils.isExternalNetworkAvailable;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -49,15 +49,6 @@ public class AddressResolverGroupTest extends HttpTest {
     private static final String EXAMPLE_URL = "https://www.example.com/";
 
     private HttpServer server;
-
-    private static boolean isExternalNetworkAvailable() {
-        try (Socket socket = new Socket()) {
-            socket.connect(new InetSocketAddress("www.google.com", 443), 3000);
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
-    }
 
     @BeforeEach
     public void start() throws Throwable {
@@ -143,6 +134,7 @@ public class AddressResolverGroupTest extends HttpTest {
         });
     }
 
+    @Tag("external")
     @RepeatedIfExceptionsTest(repeats = 5)
     public void resolveRealDomainWithDnsResolverGroup() throws Throwable {
         assumeTrue(isExternalNetworkAvailable(), "External network not available - skipping test");
@@ -159,6 +151,7 @@ public class AddressResolverGroupTest extends HttpTest {
         }
     }
 
+    @Tag("external")
     @RepeatedIfExceptionsTest(repeats = 5)
     public void resolveMultipleRealDomainsWithDnsResolverGroup() throws Throwable {
         assumeTrue(isExternalNetworkAvailable(), "External network not available - skipping test");

--- a/client/src/test/java/org/asynchttpclient/AsyncStreamHandlerTest.java
+++ b/client/src/test/java/org/asynchttpclient/AsyncStreamHandlerTest.java
@@ -429,19 +429,16 @@ public class AsyncStreamHandlerTest extends HttpTest {
                 }));
     }
 
-    // This test is flaky - see https://github.com/AsyncHttpClient/async-http-client/issues/1728#issuecomment-699962325
-    // For now, just run again if fails
     @RepeatedIfExceptionsTest(repeats = 5)
     public void asyncOptionsTest() throws Throwable {
         withClient().run(client ->
                 withServer(server).run(server -> {
+                    server.enqueueEcho();
 
                     final AtomicReference<HttpHeaders> responseHeaders = new AtomicReference<>();
 
-                    // Some responses contain the TRACE method, some do not - account for both
-                    final String[] expected = {"GET", "HEAD", "OPTIONS", "POST"};
-                    final String[] expectedWithTrace = {"GET", "HEAD", "OPTIONS", "POST", "TRACE"};
-                    Future<String> f = client.prepareOptions("https://www.google.com/").execute(new AsyncHandlerAdapter() {
+                    final String[] expected = {"GET", "HEAD", "OPTIONS", "POST", "TRACE"};
+                    Future<String> f = client.prepareOptions(getTargetUrl()).execute(new AsyncHandlerAdapter() {
 
                         @Override
                         public State onHeadersReceived(HttpHeaders headers) {
@@ -458,19 +455,11 @@ public class AsyncStreamHandlerTest extends HttpTest {
                     f.get(20, TimeUnit.SECONDS);
                     HttpHeaders h = responseHeaders.get();
                     assertNotNull(h);
-                    if (h.contains(ALLOW)) {
-                        String[] values = h.get(ALLOW).split(",|, ");
-                        assertNotNull(values);
-                        // Some responses contain the TRACE method, some do not - account for both
-                        assert values.length == expected.length || values.length == expectedWithTrace.length;
-                        Arrays.sort(values);
-                        // Some responses contain the TRACE method, some do not - account for both
-                        if (values.length == expected.length) {
-                            assertArrayEquals(values, expected);
-                        } else {
-                            assertArrayEquals(values, expectedWithTrace);
-                        }
-                    }
+                    assertTrue(h.contains(ALLOW));
+                    String[] values = h.get(ALLOW).split(",|, ");
+                    assertNotNull(values);
+                    Arrays.sort(values);
+                    assertArrayEquals(expected, values);
                 }));
     }
 

--- a/client/src/test/java/org/asynchttpclient/BasicHttpTest.java
+++ b/client/src/test/java/org/asynchttpclient/BasicHttpTest.java
@@ -579,7 +579,7 @@ public class BasicHttpTest extends HttpTest {
             withClient().run(client ->
                     withServer(server).run(server -> {
                         try {
-                            client.prepareGet("http://null.gatling.io").execute(new AsyncCompletionHandlerAdapter() {
+                            client.prepareGet("http://nonexistent.invalid").execute(new AsyncCompletionHandlerAdapter() {
                                 @Override
                                 public void onThrowable(Throwable t) {
                                 }

--- a/client/src/test/java/org/asynchttpclient/DefaultAsyncHttpClientTest.java
+++ b/client/src/test/java/org/asynchttpclient/DefaultAsyncHttpClientTest.java
@@ -27,6 +27,7 @@ import io.netty.util.Timer;
 import org.asynchttpclient.cookie.CookieEvictionTask;
 import org.asynchttpclient.cookie.CookieStore;
 import org.asynchttpclient.cookie.ThreadSafeCookieStore;
+import org.asynchttpclient.testserver.HttpServer;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
@@ -35,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.asynchttpclient.Dsl.asyncHttpClient;
 import static org.asynchttpclient.Dsl.config;
+import static org.asynchttpclient.test.TestUtils.createSslEngineFactory;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -52,31 +54,34 @@ public class DefaultAsyncHttpClientTest {
     @RepeatedIfExceptionsTest(repeats = 5)
     @EnabledOnOs(OS.LINUX)
     public void testNativeTransportWithEpollOnly() throws Exception {
-        AsyncHttpClientConfig config = config().setUseNativeTransport(true).setUseOnlyEpollNativeTransport(true).build();
-
-        try (DefaultAsyncHttpClient client = (DefaultAsyncHttpClient) asyncHttpClient(config)) {
-            assertDoesNotThrow(() -> client.prepareGet("https://www.google.com").execute().get());
-            assertInstanceOf(EpollEventLoopGroup.class, client.channelManager().getEventLoopGroup());
-        }
+        AsyncHttpClientConfig config = config().setUseNativeTransport(true).setUseOnlyEpollNativeTransport(true)
+                .setSslEngineFactory(createSslEngineFactory()).build();
+        assertRequestSucceedsAndEventLoopGroupIs(config, EpollEventLoopGroup.class);
     }
 
     @RepeatedIfExceptionsTest(repeats = 5)
     @EnabledOnOs(OS.LINUX)
     public void testNativeTransportWithoutEpollOnly() throws Exception {
-        AsyncHttpClientConfig config = config().setUseNativeTransport(true).setUseOnlyEpollNativeTransport(false).build();
-        try (DefaultAsyncHttpClient client = (DefaultAsyncHttpClient) asyncHttpClient(config)) {
-            assertDoesNotThrow(() -> client.prepareGet("https://www.google.com").execute().get());
-            assertInstanceOf(MultiThreadIoEventLoopGroup.class, client.channelManager().getEventLoopGroup());
-        }
+        AsyncHttpClientConfig config = config().setUseNativeTransport(true).setUseOnlyEpollNativeTransport(false)
+                .setSslEngineFactory(createSslEngineFactory()).build();
+        assertRequestSucceedsAndEventLoopGroupIs(config, MultiThreadIoEventLoopGroup.class);
     }
 
     @RepeatedIfExceptionsTest(repeats = 5)
     @EnabledOnOs(OS.MAC)
     public void testNativeTransportKQueueOnMacOs() throws Exception {
-        AsyncHttpClientConfig config = config().setUseNativeTransport(true).build();
-        try (DefaultAsyncHttpClient client = (DefaultAsyncHttpClient) asyncHttpClient(config)) {
-            assertDoesNotThrow(() -> client.prepareGet("https://www.google.com").execute().get());
-            assertInstanceOf(KQueueEventLoopGroup.class, client.channelManager().getEventLoopGroup());
+        AsyncHttpClientConfig config = config().setUseNativeTransport(true)
+                .setSslEngineFactory(createSslEngineFactory()).build();
+        assertRequestSucceedsAndEventLoopGroupIs(config, KQueueEventLoopGroup.class);
+    }
+
+    private static void assertRequestSucceedsAndEventLoopGroupIs(AsyncHttpClientConfig config, Class<?> expectedEventLoopGroupType) throws Exception {
+        try (HttpServer server = new HttpServer();
+             DefaultAsyncHttpClient client = (DefaultAsyncHttpClient) asyncHttpClient(config)) {
+            server.start();
+            server.enqueueOk();
+            assertDoesNotThrow(() -> client.prepareGet(server.getHttpsUrl()).execute().get());
+            assertInstanceOf(expectedEventLoopGroupType, client.channelManager().getEventLoopGroup());
         }
     }
 

--- a/client/src/test/java/org/asynchttpclient/FollowingThreadTest.java
+++ b/client/src/test/java/org/asynchttpclient/FollowingThreadTest.java
@@ -17,8 +17,14 @@ package org.asynchttpclient;
 
 import io.github.artsok.RepeatedIfExceptionsTest;
 import io.netty.handler.codec.http.HttpHeaders;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.junit.jupiter.api.Timeout;
 
+import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -50,7 +56,7 @@ public class FollowingThreadTest extends AbstractBasicTest {
                     public void run() {
                         final CountDownLatch l = new CountDownLatch(1);
                         try (AsyncHttpClient ahc = asyncHttpClient(config().setFollowRedirect(true))) {
-                            ahc.prepareGet("http://www.google.com/").execute(new AsyncHandler<Integer>() {
+                            ahc.prepareGet(getTargetUrl()).execute(new AsyncHandler<Integer>() {
 
                                 @Override
                                 public void onThrowable(Throwable t) {
@@ -94,6 +100,25 @@ public class FollowingThreadTest extends AbstractBasicTest {
             countDown.await();
         } finally {
             pool.shutdown();
+        }
+    }
+
+    @Override
+    public AbstractHandler configureHandler() {
+        return new RedirectHandler();
+    }
+
+    private static class RedirectHandler extends AbstractHandler {
+
+        @Override
+        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+            if (request.getRequestURI().endsWith("/landing")) {
+                response.setStatus(HttpServletResponse.SC_OK);
+            } else {
+                response.setStatus(HttpServletResponse.SC_FOUND);
+                response.setHeader("Location", request.getRequestURI() + "/landing");
+            }
+            baseRequest.setHandled(true);
         }
     }
 }

--- a/client/src/test/java/org/asynchttpclient/NoNullResponseTest.java
+++ b/client/src/test/java/org/asynchttpclient/NoNullResponseTest.java
@@ -16,22 +16,24 @@
  */
 package org.asynchttpclient;
 
+import org.asynchttpclient.testserver.HttpServer;
 import org.junit.jupiter.api.RepeatedTest;
 
 import java.time.Duration;
 
 import static org.asynchttpclient.Dsl.asyncHttpClient;
 import static org.asynchttpclient.Dsl.config;
+import static org.asynchttpclient.test.TestUtils.createSslEngineFactory;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class NoNullResponseTest extends AbstractBasicTest {
-    private static final String GOOGLE_HTTPS_URL = "https://www.google.com";
 
     @RepeatedTest(4)
     public void multipleSslRequestsWithDelayAndKeepAlive() throws Exception {
         AsyncHttpClientConfig config = config()
                 .setFollowRedirect(true)
                 .setKeepAlive(true)
+                .setSslEngineFactory(createSslEngineFactory())
                 .setConnectTimeout(Duration.ofSeconds(10))
                 .setPooledConnectionIdleTimeout(Duration.ofMinutes(1))
                 .setRequestTimeout(Duration.ofSeconds(10))
@@ -39,8 +41,13 @@ public class NoNullResponseTest extends AbstractBasicTest {
                 .setMaxConnections(-1)
                 .build();
 
-        try (AsyncHttpClient client = asyncHttpClient(config)) {
-            final BoundRequestBuilder builder = client.prepareGet(GOOGLE_HTTPS_URL);
+        try (HttpServer server = new HttpServer();
+             AsyncHttpClient client = asyncHttpClient(config)) {
+            server.start();
+            server.enqueueOk();
+            server.enqueueOk();
+
+            final BoundRequestBuilder builder = client.prepareGet(server.getHttpsUrl());
             final Response response1 = builder.execute().get();
             Thread.sleep(4000);
             final Response response2 = builder.execute().get();

--- a/client/src/test/java/org/asynchttpclient/PerRequestRelative302Test.java
+++ b/client/src/test/java/org/asynchttpclient/PerRequestRelative302Test.java
@@ -47,6 +47,8 @@ public class PerRequestRelative302Test extends AbstractBasicTest {
     // FIXME super NOT threadsafe!!!
     private static final AtomicBoolean isSet = new AtomicBoolean(false);
 
+    private int redirectTargetPort = -1;
+
     private static int getPort(Uri uri) {
         int port = uri.getPort();
         if (port == -1) {
@@ -60,10 +62,12 @@ public class PerRequestRelative302Test extends AbstractBasicTest {
     public void setUpGlobal() throws Exception {
         server = new Server();
         ServerConnector connector = addHttpConnector(server);
+        ServerConnector redirectTargetConnector = addHttpConnector(server);
 
         server.setHandler(new Relative302Handler());
         server.start();
         port1 = connector.getLocalPort();
+        redirectTargetPort = redirectTargetConnector.getLocalPort();
         logger.info("Local HTTP server started successfully");
         port2 = findFreePort();
     }
@@ -81,15 +85,15 @@ public class PerRequestRelative302Test extends AbstractBasicTest {
     public void redirected302Test() throws Exception {
         isSet.getAndSet(false);
         try (AsyncHttpClient c = asyncHttpClient()) {
-            Response response = c.prepareGet(getTargetUrl()).setFollowRedirect(true).setHeader("X-redirect", "https://www.google.com/").execute().get();
+            String redirectTarget = "http://localhost:" + redirectTargetPort + "/";
+            Response response = c.prepareGet(getTargetUrl()).setFollowRedirect(true).setHeader("X-redirect", redirectTarget).execute().get();
 
             assertNotNull(response);
             assertEquals(200, response.getStatusCode());
 
-            String anyGooglePage = "https://www.google.com[^:]*:443";
             String baseUrl = getBaseUrl(response.getUri());
 
-            assertTrue(baseUrl.matches(anyGooglePage), "response does not show redirection to " + anyGooglePage);
+            assertEquals("http://localhost:" + redirectTargetPort, baseUrl, "response does not show redirection to the local redirect target, got " + baseUrl);
         }
     }
 
@@ -97,7 +101,7 @@ public class PerRequestRelative302Test extends AbstractBasicTest {
     public void notRedirected302Test() throws Exception {
         isSet.getAndSet(false);
         try (AsyncHttpClient c = asyncHttpClient(config().setFollowRedirect(true))) {
-            Response response = c.prepareGet(getTargetUrl()).setFollowRedirect(false).setHeader("X-redirect", "http://www.microsoft.com/").execute().get();
+            Response response = c.prepareGet(getTargetUrl()).setFollowRedirect(false).setHeader("X-redirect", "http://localhost:" + redirectTargetPort + "/").execute().get();
             assertNotNull(response);
             assertEquals(response.getStatusCode(), 302);
         }

--- a/client/src/test/java/org/asynchttpclient/Relative302Test.java
+++ b/client/src/test/java/org/asynchttpclient/Relative302Test.java
@@ -46,6 +46,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class Relative302Test extends AbstractBasicTest {
     private static final AtomicBoolean isSet = new AtomicBoolean(false);
 
+    private int redirectTargetPort = -1;
+
     private static int getPort(Uri uri) {
         int port = uri.getPort();
         if (port == -1) {
@@ -59,9 +61,11 @@ public class Relative302Test extends AbstractBasicTest {
     public void setUpGlobal() throws Exception {
         server = new Server();
         ServerConnector connector = addHttpConnector(server);
+        ServerConnector redirectTargetConnector = addHttpConnector(server);
         server.setHandler(new Relative302Handler());
         server.start();
         port1 = connector.getLocalPort();
+        redirectTargetPort = redirectTargetConnector.getLocalPort();
         logger.info("Local HTTP server started successfully");
         port2 = findFreePort();
     }
@@ -79,12 +83,13 @@ public class Relative302Test extends AbstractBasicTest {
         isSet.getAndSet(false);
 
         try (AsyncHttpClient c = asyncHttpClient(config().setFollowRedirect(true))) {
-            Response response = c.prepareGet(getTargetUrl()).setHeader("X-redirect", "http://www.google.com/").execute().get();
+            String redirectTarget = "http://localhost:" + redirectTargetPort + "/";
+            Response response = c.prepareGet(getTargetUrl()).setHeader("X-redirect", redirectTarget).execute().get();
             assertNotNull(response);
             assertEquals(response.getStatusCode(), 200);
 
             String baseUrl = getBaseUrl(response.getUri());
-            assertTrue(baseUrl.startsWith("http://www.google."), "response does not show redirection to a google subdomain, got " + baseUrl);
+            assertEquals("http://localhost:" + redirectTargetPort, baseUrl, "response does not show redirection to the local redirect target, got " + baseUrl);
         }
     }
 

--- a/client/src/test/java/org/asynchttpclient/proxy/HttpsProxyTestcontainersIntegrationTest.java
+++ b/client/src/test/java/org/asynchttpclient/proxy/HttpsProxyTestcontainersIntegrationTest.java
@@ -21,6 +21,7 @@ import org.asynchttpclient.AsyncHttpClientConfig;
 import org.asynchttpclient.Response;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+@Tag("external")
 @Testcontainers
 public class HttpsProxyTestcontainersIntegrationTest {
 

--- a/client/src/test/java/org/asynchttpclient/proxy/SocksProxyTestcontainersIntegrationTest.java
+++ b/client/src/test/java/org/asynchttpclient/proxy/SocksProxyTestcontainersIntegrationTest.java
@@ -21,6 +21,7 @@ import org.asynchttpclient.AsyncHttpClientConfig;
 import org.asynchttpclient.Response;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +48,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * Integration tests for SOCKS proxy support using Dante SOCKS server in TestContainers.
  * This validates the fix for GitHub issue #1913.
  */
+@Tag("external")
 @Testcontainers
 public class SocksProxyTestcontainersIntegrationTest {
 

--- a/client/src/test/java/org/asynchttpclient/test/TestUtils.java
+++ b/client/src/test/java/org/asynchttpclient/test/TestUtils.java
@@ -54,7 +54,9 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.net.Socket;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -115,6 +117,20 @@ public final class TestUtils {
     public static synchronized int findFreePort() throws IOException {
         try (ServerSocket socket = ServerSocketFactory.getDefault().createServerSocket(0)) {
             return socket.getLocalPort();
+        }
+    }
+
+    /**
+     * Probes whether outbound internet (and DNS) is reachable. Tests that genuinely require a real
+     * public host should be annotated {@code @Tag("external")} (excluded from the default build) and
+     * may additionally guard with this so they skip cleanly when run on an isolated machine.
+     */
+    public static boolean isExternalNetworkAvailable() {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress("www.google.com", 443), 3000);
+            return true;
+        } catch (Exception e) {
+            return false;
         }
     }
 

--- a/client/src/test/java/org/asynchttpclient/ws/CloseCodeReasonMessageTest.java
+++ b/client/src/test/java/org/asynchttpclient/ws/CloseCodeReasonMessageTest.java
@@ -14,6 +14,9 @@ package org.asynchttpclient.ws;
 
 import io.github.artsok.RepeatedIfExceptionsTest;
 import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.testserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
@@ -28,6 +31,21 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CloseCodeReasonMessageTest extends AbstractBasicWebSocketTest {
+
+    private HttpServer plainServer;
+
+    @BeforeEach
+    public void startPlainServer() throws Exception {
+        plainServer = new HttpServer();
+        plainServer.start();
+    }
+
+    @AfterEach
+    public void stopPlainServer() throws Exception {
+        if (plainServer != null) {
+            plainServer.close();
+        }
+    }
 
     @RepeatedIfExceptionsTest(repeats = 5)
     @Timeout(unit = TimeUnit.MILLISECONDS, value = 60000)
@@ -64,8 +82,9 @@ public class CloseCodeReasonMessageTest extends AbstractBasicWebSocketTest {
     public void getWebSocketThrowsException() throws Throwable {
         final CountDownLatch latch = new CountDownLatch(1);
         try (AsyncHttpClient client = asyncHttpClient()) {
+            plainServer.enqueueOk();
             assertThrows(Exception.class, () -> {
-                client.prepareGet("http://apache.org").execute(new WebSocketUpgradeHandler.Builder().addWebSocketListener(new WebSocketListener() {
+                client.prepareGet(plainServer.getHttpUrl()).execute(new WebSocketUpgradeHandler.Builder().addWebSocketListener(new WebSocketListener() {
 
                     @Override
                     public void onOpen(WebSocket websocket) {
@@ -93,7 +112,8 @@ public class CloseCodeReasonMessageTest extends AbstractBasicWebSocketTest {
             final CountDownLatch latch = new CountDownLatch(1);
             final AtomicReference<Throwable> throwable = new AtomicReference<>();
 
-            client.prepareGet("ws://apache.org").execute(new WebSocketUpgradeHandler.Builder().addWebSocketListener(new WebSocketListener() {
+            plainServer.enqueueOk();
+            client.prepareGet("ws://localhost:" + plainServer.getHttpPort() + "/").execute(new WebSocketUpgradeHandler.Builder().addWebSocketListener(new WebSocketListener() {
 
                 @Override
                 public void onOpen(WebSocket websocket) {
@@ -122,7 +142,8 @@ public class CloseCodeReasonMessageTest extends AbstractBasicWebSocketTest {
             final CountDownLatch latch = new CountDownLatch(1);
             final AtomicReference<Throwable> throwable = new AtomicReference<>();
 
-            c.prepareGet("ws://www.google.com").execute(new WebSocketUpgradeHandler.Builder().addWebSocketListener(new WebSocketListener() {
+            plainServer.enqueueOk();
+            c.prepareGet("ws://localhost:" + plainServer.getHttpPort() + "/").execute(new WebSocketUpgradeHandler.Builder().addWebSocketListener(new WebSocketListener() {
 
                 @Override
                 public void onOpen(WebSocket websocket) {

--- a/client/src/test/java/org/asynchttpclient/ws/TextMessageTest.java
+++ b/client/src/test/java/org/asynchttpclient/ws/TextMessageTest.java
@@ -79,7 +79,7 @@ public class TextMessageTest extends AbstractBasicWebSocketTest {
     @Timeout(unit = TimeUnit.MILLISECONDS, value = 60000)
     public void onFailureTest() throws Throwable {
         try (AsyncHttpClient c = asyncHttpClient()) {
-            c.prepareGet("ws://abcdefg").execute(new WebSocketUpgradeHandler.Builder().build()).get();
+            c.prepareGet("ws://abcdefg.invalid").execute(new WebSocketUpgradeHandler.Builder().build()).get();
         } catch (ExecutionException e) {
             if (!(e.getCause() instanceof UnknownHostException || e.getCause() instanceof ConnectException)) {
                 fail("Exception is not UnknownHostException or ConnectException but rather: " + e);

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,10 @@
         <junit-bom.version>5.14.4</junit-bom.version>
         <errorprone.version>2.31.0</errorprone.version>
         <nullaway.version>0.12.6</nullaway.version>
+
+        <!-- JUnit tags excluded from the default build. "external" covers tests that reach real public
+             hosts/DNS; run them with -Dexternal.tests=true (see the run-external-tests profile). -->
+        <ahc.test.excludedGroups>external</ahc.test.excludedGroups>
     </properties>
 
     <developers>
@@ -349,6 +353,7 @@
                     <argLine>
                         @{argLine} --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
                     </argLine>
+                    <excludedGroups>${ahc.test.excludedGroups}</excludedGroups>
                 </configuration>
             </plugin>
 
@@ -518,6 +523,21 @@
     </build>
 
     <profiles>
+        <!-- Opt-in: also run tests tagged "external" (real public hosts/DNS). Enable with
+             -Dexternal.tests=true. Off by default so the standard build stays hermetic. -->
+        <profile>
+            <id>run-external-tests</id>
+            <activation>
+                <property>
+                    <name>external.tests</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <ahc.test.excludedGroups></ahc.test.excludedGroups>
+            </properties>
+        </profile>
+
         <!-- JDK 17+: use JUnit 6 (requires JDK 17+) -->
         <profile>
             <id>jdk17+</id>


### PR DESCRIPTION
Motivation:

CI jobs fail intermittently because a handful of tests execute real requests against public endpoints (google.com, apache.org, microsoft.com, gatling.io), so any outage, rate-limit, or runner without egress reds the whole 3-OS × 4-JDK matrix.

Modification:

Repoint those tests at the existing local Jetty test server (HTTP, HTTPS, redirect and WS-handshake-failure cases), switch unresolvable-host tests to RFC 6761 `.invalid`, and tag the irreducible real-DNS/proxy tests `@Tag("external")` — excluded from the default build and opt-in via `-Dexternal.tests=true` (run nightly).

Result:

The standard `mvn test` is now fully self-contained and deterministic with no behavioral coverage lost; real-network checks still run nightly behind the opt-in flag.