### PR TITLE
Round robin issue (#2214) 

### DIFF
--- a/client/src/main/java/org/asynchttpclient/LoadBalance.java
+++ b/client/src/main/java/org/asynchttpclient/LoadBalance.java
@@ -49,20 +49,25 @@ public enum LoadBalance {
      *       with an explicit {@link Request#getAddress() address}, or requests routed through a
      *       proxy (HTTP or SOCKS) — the socket is established to the proxy, not directly to the
      *       rotated target IPs. (Round-robin still applies when the proxy is bypassed for the host.)</li>
-     *   <li>Connection limits ({@code maxConnectionsPerHost}) remain per host, not per IP.</li>
-     *   <li>For HTTP/2 this mode deliberately opens more than one connection to the same host and port
-     *       — one per resolved IP — so streams can be spread across the host's backends. That is a
-     *       conscious deviation from RFC 9113 (and RFC 7540) Section 9.1, which recommends that clients
-     *       SHOULD NOT open more than one HTTP/2 connection to a given host and port pair.
-     *       {@link #DEFAULT} mode preserves the standard single-connection-per-origin behavior.</li>
-     *   <li>With HTTP/2 and a finite {@code maxConnectionsPerHost} smaller than the number of resolved
-     *       IPs, a request pinned to an IP that cannot acquire a per-host connection permit does not open
-     *       a new connection; instead it multiplexes onto an active HTTP/2 connection already open to a
-     *       sibling IP of the same host, if one exists (multiplexing onto an existing connection takes no
-     *       permit). Only if no such connection exists does it fail with
-     *       {@code TooManyConnectionsPerHostException}. The default {@code maxConnectionsPerHost} is
-     *       unlimited, so this only affects clients that set a finite per-host limit below the
-     *       resolved-IP count.</li>
+     *   <li>Connection limits ({@code maxConnectionsPerHost}) are enforced per host, not per IP: at most
+     *       that many HTTP/2 connections are kept open to a host at once, spread across that many of its
+     *       resolved IPs (see the cap note below).</li>
+     *   <li>For HTTP/2 this mode deliberately opens more than one connection to the same host and port —
+     *       up to one per resolved IP, bounded by {@code maxConnectionsPerHost} — so streams can be spread
+     *       across the host's backends. That is a conscious deviation from RFC 9113 (and RFC 7540)
+     *       Section 9.1, which recommends that clients SHOULD NOT open more than one HTTP/2 connection to a
+     *       given host and port pair. {@link #DEFAULT} mode preserves the standard
+     *       single-connection-per-origin behavior.</li>
+     *   <li>When {@code maxConnectionsPerHost} (call it K) is smaller than the number of resolved IPs, the
+     *       cap wins over full spreading: at most K HTTP/2 connections are opened, to the first K rotated
+     *       IPs, and a request pinned to any further IP cannot acquire a per-host permit — it multiplexes
+     *       onto one of those K sibling connections (multiplexing onto an existing connection takes no
+     *       permit) instead of opening another, failing with {@code TooManyConnectionsPerHostException}
+     *       only if none is available. Those K connections are held open (kept alive by HTTP/2 PING), so
+     *       they stay pinned to their K IPs rather than rotating across all of them; set
+     *       {@code maxConnectionsPerHost} at least as large as the resolved-IP count for full per-IP
+     *       spreading. The default is unlimited, so this bound only applies when a finite per-host limit is
+     *       configured.</li>
      *   <li>The address order comes straight from the configured
      *       {@link io.netty.resolver.InetNameResolver}; this mode does not re-sort it. For the
      *       rotation to map consistently across requests, use a resolver that returns the addresses

--- a/client/src/main/java/org/asynchttpclient/LoadBalance.java
+++ b/client/src/main/java/org/asynchttpclient/LoadBalance.java
@@ -56,12 +56,13 @@ public enum LoadBalance {
      *       SHOULD NOT open more than one HTTP/2 connection to a given host and port pair.
      *       {@link #DEFAULT} mode preserves the standard single-connection-per-origin behavior.</li>
      *   <li>With HTTP/2 and a finite {@code maxConnectionsPerHost} smaller than the number of resolved
-     *       IPs, a request pinned to an IP that cannot acquire a per-host connection permit will not
-     *       multiplex onto a sibling connection already open to a different IP (HTTP/2 connections are
-     *       pooled per IP in this mode); it fails with {@code TooManyConnectionsPerHostException}
-     *       instead. The default {@code maxConnectionsPerHost} is unlimited, so this only affects
-     *       clients that set a finite per-host limit below the resolved-IP count; {@link #DEFAULT} mode
-     *       would multiplex onto the shared per-host connection.</li>
+     *       IPs, a request pinned to an IP that cannot acquire a per-host connection permit does not open
+     *       a new connection; instead it multiplexes onto an active HTTP/2 connection already open to a
+     *       sibling IP of the same host, if one exists (multiplexing onto an existing connection takes no
+     *       permit). Only if no such connection exists does it fail with
+     *       {@code TooManyConnectionsPerHostException}. The default {@code maxConnectionsPerHost} is
+     *       unlimited, so this only affects clients that set a finite per-host limit below the
+     *       resolved-IP count.</li>
      *   <li>The address order comes straight from the configured
      *       {@link io.netty.resolver.InetNameResolver}; this mode does not re-sort it. For the
      *       rotation to map consistently across requests, use a resolver that returns the addresses

--- a/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
@@ -134,7 +134,11 @@ public class ChannelManager {
 
     private final ChannelPool channelPool;
     private final ChannelGroup openChannels;
-    private final ConcurrentHashMap<Object, Channel> http2Connections = new ConcurrentHashMap<>();
+    // HTTP/2 registry, grouped by per-host base key so a permit-starved round-robin request can find a
+    // sibling-IP connection (issue #2214). Outer key: the per-host base partition key. Inner key: the full
+    // partition key actually registered — the per-IP RoundRobinPartitionKey in LoadBalance.ROUND_ROBIN
+    // mode, or the plain base key otherwise (then the inner map holds a single entry under that key).
+    private final ConcurrentHashMap<Object, ConcurrentHashMap<Object, Channel>> http2Connections = new ConcurrentHashMap<>();
 
     private AsyncHttpClientHandler wsHandler;
     private Http2Handler http2Handler;
@@ -363,6 +367,17 @@ public class ChannelManager {
     }
 
     /**
+     * The per-host base partition key under which an HTTP/2 connection registered with {@code partitionKey}
+     * is grouped. For a {@link RoundRobinPartitionKey} that is its base (without the pinned IP); for any
+     * other key the key is already the base.
+     */
+    private static Object baseKeyOf(Object partitionKey) {
+        return partitionKey instanceof RoundRobinPartitionKey
+                ? ((RoundRobinPartitionKey) partitionKey).getBaseKey()
+                : partitionKey;
+    }
+
+    /**
      * Registers an HTTP/2 connection in the registry for the given partition key.
      * The connection stays in the registry (not the regular pool) to allow multiplexing —
      * multiple requests can share the same connection concurrently.
@@ -377,17 +392,31 @@ public class ChannelManager {
         // so it serves only its own opening request and then closes (its stream's closeFuture listener
         // closes the parent once activeStreams hits 0) instead of lingering open and unregistered. A dead
         // registered entry is replaced.
-        Channel existing = http2Connections.putIfAbsent(partitionKey, channel);
-        if (existing != null && existing != channel) {
-            boolean replacedDead = !existing.isActive() && http2Connections.replace(partitionKey, existing, channel);
-            if (!replacedDead && state != null) {
-                state.markRedundant();
+        //
+        // The whole coalescing mutation runs inside compute() on the outer base-key bucket so it is atomic
+        // against removeHttp2Connection() pruning an emptied inner map — both hold the same bucket lock,
+        // which closes the race where a prune could orphan a connection inserted into a detached inner map.
+        http2Connections.compute(baseKeyOf(partitionKey), (k, byKey) -> {
+            if (byKey == null) {
+                byKey = new ConcurrentHashMap<>();
             }
-        }
+            Channel existing = byKey.putIfAbsent(partitionKey, channel);
+            if (existing != null && existing != channel) {
+                boolean replacedDead = !existing.isActive() && byKey.replace(partitionKey, existing, channel);
+                if (!replacedDead && state != null) {
+                    state.markRedundant();
+                }
+            }
+            return byKey;
+        });
         // When the connection closes, remove it from the registry AND fail any requests still queued
         // for a stream slot. Without the latter, requests sitting in pendingOpeners when the parent
         // connection drops have no stream channel (so no channelInactive is ever delivered for them)
         // and would survive only until the request timeout fires — the silent-timeout bug of #2160.
+        //
+        // This listener MUST stay outside the compute() lambda above: a channel already closed at
+        // registration time fires it synchronously on this thread, and re-entering computeIfPresent() on
+        // the same outer bucket from within compute() would self-deadlock. Here compute() has returned.
         channel.closeFuture().addListener(future -> {
             removeHttp2Connection(partitionKey, channel);
             if (state != null) {
@@ -412,10 +441,15 @@ public class ChannelManager {
 
     /**
      * Removes an HTTP/2 connection from the registry, but only if it's the currently registered
-     * connection for that partition key (avoids removing a replacement connection).
+     * connection for that partition key (avoids removing a replacement connection). The emptied per-host
+     * inner map is pruned atomically — computeIfPresent serializes with registerHttp2Connection's
+     * compute() on the same outer bucket, so a concurrent insert cannot be lost to the prune.
      */
     public void removeHttp2Connection(Object partitionKey, Channel channel) {
-        http2Connections.remove(partitionKey, channel);
+        http2Connections.computeIfPresent(baseKeyOf(partitionKey), (k, byKey) -> {
+            byKey.remove(partitionKey, channel);
+            return byKey.isEmpty() ? null : byKey;
+        });
     }
 
     /**
@@ -424,12 +458,16 @@ public class ChannelManager {
      * concurrent multiplexed requests.
      */
     public Channel pollHttp2Connection(Object partitionKey) {
-        Channel channel = http2Connections.get(partitionKey);
+        ConcurrentHashMap<Object, Channel> byKey = http2Connections.get(baseKeyOf(partitionKey));
+        if (byKey == null) {
+            return null;
+        }
+        Channel channel = byKey.get(partitionKey);
         if (channel == null) {
             return null;
         }
         if (!channel.isActive()) {
-            http2Connections.remove(partitionKey, channel);
+            removeHttp2Connection(partitionKey, channel);
             return null;
         }
         Http2ConnectionState state = channel.attr(Http2ConnectionState.HTTP2_STATE_KEY).get();
@@ -437,6 +475,32 @@ public class ChannelManager {
             return null;
         }
         return channel;
+    }
+
+    /**
+     * Round-robin permit-starved fallback (issue #2214): returns an active, non-draining HTTP/2 connection
+     * open to ANY IP of the host identified by {@code baseKey}, or {@code null} if none qualifies. Used only
+     * by {@link org.asynchttpclient.netty.request.NettyRequestSender} when a request pinned to one IP cannot
+     * acquire a per-host connection permit ({@code maxConnectionsPerHost}) and its own per-IP connection does
+     * not exist — it may then multiplex onto a sibling-IP connection instead of failing. NOT used on the
+     * happy path, which polls the exact per-IP key so load keeps spreading across IPs.
+     *
+     * <p>Iterates only the inner map for this host (bounded by the host's resolved-IP count). Per-key
+     * validation and dead-entry eviction are delegated to {@link #pollHttp2Connection}; redundant
+     * coalescing-losers are never stored, so they are never returned.
+     */
+    public Channel pollHttp2SiblingConnection(Object baseKey) {
+        ConcurrentHashMap<Object, Channel> byKey = http2Connections.get(baseKey);
+        if (byKey == null) {
+            return null;
+        }
+        for (Object key : byKey.keySet()) {
+            Channel channel = pollHttp2Connection(key);
+            if (channel != null) {
+                return channel;
+            }
+        }
+        return null;
     }
 
     /**

--- a/client/src/main/java/org/asynchttpclient/netty/channel/NettyConnectListener.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/NettyConnectListener.java
@@ -215,8 +215,7 @@ public final class NettyConnectListener<T> {
                     }
                     if (http2Negotiated && !uri.isWebSocket()) {
                         channelManager.upgradePipelineToHttp2(channel.pipeline());
-                        registerHttp2AndReleaseSemaphore(channel);
-                        releaseSemaphoreImmediately(partitionKeyLock);
+                        registerHttp2AndManageSemaphore(channel, partitionKeyLock);
                     } else {
                         attachSemaphoreToChannelClose(channel, partitionKeyLock);
                     }
@@ -241,8 +240,7 @@ public final class NettyConnectListener<T> {
             // excluded for the same RFC 8441 reason as the TLS path above — it stays on HTTP/1.1.
             if (!uri.isSecured() && channelManager.isHttp2CleartextEnabled() && !uri.isWebSocket()) {
                 channelManager.upgradePipelineToHttp2(channel.pipeline());
-                registerHttp2AndReleaseSemaphore(channel);
-                releaseSemaphoreImmediately(partitionKeyLock);
+                registerHttp2AndManageSemaphore(channel, partitionKeyLock);
             } else {
                 attachSemaphoreToChannelClose(channel, partitionKeyLock);
             }
@@ -272,12 +270,26 @@ public final class NettyConnectListener<T> {
     }
 
     /**
-     * Registers the HTTP/2 connection in the channel manager's H2 registry.
+     * Registers the HTTP/2 connection in the channel manager's H2 registry, then decides how long to hold
+     * the per-host connection permit.
+     *
+     * <p>{@link org.asynchttpclient.LoadBalance#DEFAULT} multiplexes a host onto a single connection, so the
+     * permit is released immediately — holding it would needlessly block concurrent requests that all share
+     * that one connection. {@link org.asynchttpclient.LoadBalance#ROUND_ROBIN} instead keeps one connection
+     * per resolved IP, so the per-host permit is what bounds the number of live connections: it is held for
+     * the connection's lifetime (as HTTP/1.1 does). Once {@code maxConnectionsPerHost} connections are live,
+     * a further request fails to acquire a permit and multiplexes onto a sibling-IP connection via
+     * {@link ChannelManager#pollHttp2SiblingConnection(Object)} rather than opening another (issue #2214).
      */
-    private void registerHttp2AndReleaseSemaphore(Channel channel) {
+    private void registerHttp2AndManageSemaphore(Channel channel, Object partitionKeyLock) {
         // Register under the future's partition key so the H2 connection is found by the same key the
         // pool is polled with — including the IP-aware key used by LoadBalance.ROUND_ROBIN.
         channelManager.registerHttp2Connection(future.getPartitionKey(), channel);
+        if (future.getPartitionKey() instanceof RoundRobinPartitionKey) {
+            attachSemaphoreToChannelClose(channel, partitionKeyLock);
+        } else {
+            releaseSemaphoreImmediately(partitionKeyLock);
+        }
     }
 
     public void onFailure(Channel channel, Throwable cause) {

--- a/client/src/main/java/org/asynchttpclient/netty/channel/RoundRobinPartitionKey.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/RoundRobinPartitionKey.java
@@ -37,6 +37,14 @@ public final class RoundRobinPartitionKey {
     }
 
     /**
+     * @return the per-host base partition key (without the pinned IP). Lets the HTTP/2 registry group
+     * sibling per-IP connections for the same host so a permit-starved request can reuse one (issue #2214).
+     */
+    public Object getBaseKey() {
+        return baseKey;
+    }
+
+    /**
      * @return a key with the same base but a different IP, used to re-pin to the IP actually connected
      * to when the connector fails over from the initially selected IP
      */

--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
@@ -1102,17 +1102,18 @@ public final class NettyRequestSender {
      * acquire a connection permit can still multiplex onto an HTTP/2 connection another thread is
      * establishing to the same origin.
      *
-     * <p><b>{@link org.asynchttpclient.LoadBalance#ROUND_ROBIN} limitation.</b> The HTTP/2 registry is an
-     * exact-key map, and in round-robin mode each connection is registered under its per-IP key
+     * <p>In {@link org.asynchttpclient.LoadBalance#ROUND_ROBIN} mode the registry is keyed per IP
      * ({@code RoundRobinPartitionKey(base, IP)}; see {@link org.asynchttpclient.netty.channel.NettyConnectListener}).
-     * A request pinned to {@code IP_B} therefore polls only {@code (base, IP_B)} and never discovers a
-     * sibling HTTP/2 connection already open on {@code IP_A}. The connection permit, however, is per host
-     * ({@code maxConnectionsPerHost}), so once the host is at its cap such a request can neither open a new
-     * connection nor reuse the sibling one: off the event loop it spins here for the full
-     * {@code connectTimeout} and then fails with the original permit exception. This only bites when
-     * {@code maxConnectionsPerHost} is configured (the default is unlimited). Note that falling back to a
-     * poll on the per-host base key would be a no-op — nothing is ever registered under it — so reusing a
-     * sibling-IP connection requires indexing the registry by base key (tracked in issue #2214).
+     * This path first polls the request's own pinned-IP key and, if that misses, falls back to ANY active,
+     * non-draining HTTP/2 connection to the same host on a sibling IP (see
+     * {@link org.asynchttpclient.netty.channel.ChannelManager#pollHttp2SiblingConnection(Object)}). That lets
+     * a request fail the per-host {@code maxConnectionsPerHost} permit yet still multiplex onto a connection
+     * already open to a different IP of the host — multiplexing onto an existing HTTP/2 connection takes no
+     * permit — instead of stalling for {@code connectTimeout} and then failing with the original permit
+     * exception (issue #2214). The sibling fallback is confined to this permit-failure path; the normal
+     * pooled-reuse path stays strictly per IP so load keeps spreading. If no sibling qualifies, the original
+     * permit failure stands. This only matters when {@code maxConnectionsPerHost} is configured below the
+     * host's resolved-IP count (the default is unlimited).
      */
     private Channel waitForHttp2Connection(Request request, ProxyServer proxy, NettyResponseFuture<?> future) {
         Uri uri = request.getUri();
@@ -1155,9 +1156,18 @@ public final class NettyRequestSender {
     }
 
     // Polls the HTTP/2 registry, using the IP-aware key in round-robin mode and the regular key otherwise.
+    // In round-robin mode the exact per-IP key is tried first (keeping reuse pinned to this request's IP);
+    // only if that misses do we fall back to a sibling-IP connection for the same host, so a permit-starved
+    // request can still multiplex instead of failing (issue #2214). The sibling fallback is confined to this
+    // permit-failure path — the happy path (pollPooledChannel) deliberately does not use it, so steady-state
+    // reuse keeps spreading across IPs.
     private Channel pollHttp2(Object override, Uri uri, String virtualHost, ProxyServer proxy, Request request) {
         if (override != null) {
-            return channelManager.pollHttp2Connection(override);
+            Channel h2Channel = channelManager.pollHttp2Connection(override);
+            if (h2Channel == null && override instanceof RoundRobinPartitionKey) {
+                h2Channel = channelManager.pollHttp2SiblingConnection(((RoundRobinPartitionKey) override).getBaseKey());
+            }
+            return h2Channel;
         }
         return channelManager.pollHttp2(uri, virtualHost, proxy, request.getChannelPoolPartitioning());
     }

--- a/client/src/test/java/org/asynchttpclient/BasicHttp2Test.java
+++ b/client/src/test/java/org/asynchttpclient/BasicHttp2Test.java
@@ -484,6 +484,110 @@ public class BasicHttp2Test {
     }
 
     /**
+     * A fixed multi-IP resolver for a single hostname (mirrors the inline resolver used above):
+     * {@code doResolve} returns the first IP, {@code doResolveAll} returns the full list.
+     */
+    private static io.netty.resolver.NameResolver<java.net.InetAddress> multiIpResolver(String... ips) throws Exception {
+        final List<java.net.InetAddress> addresses = new ArrayList<>();
+        for (String ip : ips) {
+            addresses.add(java.net.InetAddress.getByName(ip));
+        }
+        return new io.netty.resolver.InetNameResolver(io.netty.util.concurrent.ImmediateEventExecutor.INSTANCE) {
+            @Override
+            protected void doResolve(String inetHost, io.netty.util.concurrent.Promise<java.net.InetAddress> promise) {
+                promise.setSuccess(addresses.get(0));
+            }
+
+            @Override
+            protected void doResolveAll(String inetHost, io.netty.util.concurrent.Promise<List<java.net.InetAddress>> promise) {
+                promise.setSuccess(new ArrayList<>(addresses));
+            }
+        };
+    }
+
+    /**
+     * Regression guard for the round-robin sibling-reuse fix (issue #2214): when {@code maxConnectionsPerHost}
+     * is at least the number of resolved IPs, no request is ever permit-starved, so the sibling-reuse fallback
+     * must NOT engage and round-robin must still open one connection per IP. If sibling reuse leaked onto the
+     * happy path it would collapse all requests onto a single connection and this would fail.
+     */
+    @Test
+    public void http2RoundRobinStillSpreadsWhenPermitsAbundant() throws Exception {
+        io.netty.resolver.NameResolver<java.net.InetAddress> resolver = multiIpResolver("127.0.0.1", "127.0.0.2", "127.0.0.3");
+        java.util.Set<String> attemptedIps = java.util.concurrent.ConcurrentHashMap.newKeySet();
+        try (AsyncHttpClient client = http2ClientWithConfig(b -> b.setLoadBalance(LoadBalance.ROUND_ROBIN)
+                .setMaxConnectionsPerHost(3).setMaxRequestRetry(0))) {
+            for (int i = 0; i < 12; i++) {
+                Response response = client.executeRequest(
+                        org.asynchttpclient.Dsl.get(httpsUrl("/ok")).setNameResolver(resolver),
+                        new AsyncCompletionHandler<Response>() {
+                            @Override
+                            public void onTcpConnectAttempt(java.net.InetSocketAddress remoteAddress) {
+                                if (remoteAddress.getAddress() != null) {
+                                    attemptedIps.add(remoteAddress.getAddress().getHostAddress());
+                                }
+                            }
+
+                            @Override
+                            public Response onCompleted(Response response) {
+                                return response;
+                            }
+                        }).get(30, SECONDS);
+                assertEquals(200, response.getStatusCode());
+            }
+        }
+        assertEquals(java.util.Set.of("127.0.0.1", "127.0.0.2", "127.0.0.3"), attemptedIps,
+                "with enough permits the sibling fallback must not engage — round-robin still targets every IP");
+    }
+
+    /**
+     * Issue #2214: round-robin pins each request to one of the host's IPs, but the connection permit is per
+     * host. With {@code maxConnectionsPerHost=1} and a multi-IP host, a request pinned to an IP whose
+     * connection is not open and that cannot acquire the per-host permit must multiplex onto an HTTP/2
+     * connection already open to a sibling IP, instead of stalling for {@code connectTimeout} and failing
+     * with {@code TooManyConnectionsPerHostException}. We fire a burst of concurrent requests so several are
+     * permit-starved while the first connection is being established; with the fix they all complete by
+     * reusing the sibling connection. {@code connectTimeout} is kept short so a regression surfaces as a fast
+     * failure rather than a long hang.
+     */
+    @Test
+    public void http2RoundRobinPermitStarvedReusesSiblingConnection() throws Exception {
+        io.netty.resolver.NameResolver<java.net.InetAddress> resolver = multiIpResolver("127.0.0.1", "127.0.0.2");
+        int concurrentRequests = 8;
+        CountDownLatch latch = new CountDownLatch(concurrentRequests);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicReference<Throwable> firstError = new AtomicReference<>();
+        try (AsyncHttpClient client = http2ClientWithConfig(b -> b.setLoadBalance(LoadBalance.ROUND_ROBIN)
+                .setMaxConnectionsPerHost(1).setMaxRequestRetry(0).setConnectTimeout(Duration.ofSeconds(2)))) {
+            for (int i = 0; i < concurrentRequests; i++) {
+                client.executeRequest(
+                        org.asynchttpclient.Dsl.get(httpsUrl("/delay/300")).setNameResolver(resolver),
+                        new AsyncCompletionHandlerBase() {
+                            @Override
+                            public Response onCompleted(Response response) {
+                                if (response.getStatusCode() == 200) {
+                                    successCount.incrementAndGet();
+                                }
+                                latch.countDown();
+                                return response;
+                            }
+
+                            @Override
+                            public void onThrowable(Throwable t) {
+                                firstError.compareAndSet(null, t);
+                                latch.countDown();
+                            }
+                        });
+            }
+            assertTrue(latch.await(30, SECONDS), "all round-robin requests should complete");
+            assertNull(firstError.get(),
+                    "permit-starved requests must reuse a sibling-IP HTTP/2 connection, not fail; got: " + firstError.get());
+            assertEquals(concurrentRequests, successCount.get(),
+                    "all requests should succeed via sibling-IP HTTP/2 reuse under maxConnectionsPerHost=1");
+        }
+    }
+
+    /**
      * Creates an AHC client with a specific request timeout.
      */
     private AsyncHttpClient http2ClientWithTimeout(int requestTimeoutMs) {

--- a/client/src/test/java/org/asynchttpclient/BasicHttp2Test.java
+++ b/client/src/test/java/org/asynchttpclient/BasicHttp2Test.java
@@ -588,6 +588,33 @@ public class BasicHttp2Test {
     }
 
     /**
+     * In round-robin mode the per-host connection permit is held for the HTTP/2 connection's lifetime, so
+     * {@code maxConnectionsPerHost} actually caps the number of live connections to a host. With a host of
+     * three IPs and a cap of two, round-robin would otherwise open three connections (one per IP); the cap
+     * must hold it to at most two, with requests pinned to the third IP multiplexing onto a sibling
+     * connection (issue #2214). All requests still succeed.
+     */
+    @Test
+    public void http2RoundRobinCapsLiveConnectionsAtMaxConnectionsPerHost() throws Exception {
+        io.netty.resolver.NameResolver<java.net.InetAddress> resolver = multiIpResolver("127.0.0.1", "127.0.0.2", "127.0.0.3");
+        int maxPerHost = 2;
+        try (AsyncHttpClient client = http2ClientWithConfig(b -> b.setLoadBalance(LoadBalance.ROUND_ROBIN)
+                .setMaxConnectionsPerHost(maxPerHost).setMaxRequestRetry(0))) {
+            for (int i = 0; i < 12; i++) {
+                Response response = client.executeRequest(
+                        org.asynchttpclient.Dsl.get(httpsUrl("/ok")).setNameResolver(resolver)).get(30, SECONDS);
+                assertEquals(200, response.getStatusCode());
+            }
+            // serverChildChannels tracks accepted TCP (HTTP/2) connections; a DefaultChannelGroup auto-removes
+            // closed ones. Without holding the permit for the connection lifetime, round-robin opens one
+            // connection per resolved IP (3 > cap); the cap must hold live connections to at most maxPerHost.
+            assertTrue(serverChildChannels.size() <= maxPerHost,
+                    "maxConnectionsPerHost must cap live HTTP/2 connections; expected <= " + maxPerHost
+                            + ", got " + serverChildChannels.size());
+        }
+    }
+
+    /**
      * Creates an AHC client with a specific request timeout.
      */
     private AsyncHttpClient http2ClientWithTimeout(int requestTimeoutMs) {

--- a/client/src/test/java/org/asynchttpclient/Http2ResidualFixesRegressionTest.java
+++ b/client/src/test/java/org/asynchttpclient/Http2ResidualFixesRegressionTest.java
@@ -222,7 +222,11 @@ public class Http2ResidualFixesRegressionTest {
         ChannelManager cm = ((DefaultAsyncHttpClient) client).channelManager();
         java.lang.reflect.Field f = ChannelManager.class.getDeclaredField("http2Connections");
         f.setAccessible(true);
-        return ((java.util.Map<Object, Channel>) f.get(cm)).values();
+        // The registry is grouped by per-host base key (issue #2214): Map<baseKey, Map<fullKey, Channel>>.
+        // Flatten the inner maps to recover the flat collection of connections this test expects.
+        return ((java.util.Map<Object, ? extends java.util.Map<Object, Channel>>) f.get(cm)).values().stream()
+                .flatMap(inner -> inner.values().stream())
+                .collect(java.util.stream.Collectors.toList());
     }
 
     private static int activeStreams(AsyncHttpClient client) throws Exception {

--- a/client/src/test/java/org/asynchttpclient/Http2ReviewFixesRegressionTest.java
+++ b/client/src/test/java/org/asynchttpclient/Http2ReviewFixesRegressionTest.java
@@ -222,7 +222,11 @@ public class Http2ReviewFixesRegressionTest {
         ChannelManager cm = ((DefaultAsyncHttpClient) client).channelManager();
         java.lang.reflect.Field f = ChannelManager.class.getDeclaredField("http2Connections");
         f.setAccessible(true);
-        return ((java.util.Map<Object, Channel>) f.get(cm)).values();
+        // The registry is grouped by per-host base key (issue #2214): Map<baseKey, Map<fullKey, Channel>>.
+        // Flatten the inner maps to recover the flat collection of connections this test expects.
+        return ((java.util.Map<Object, ? extends java.util.Map<Object, Channel>>) f.get(cm)).values().stream()
+                .flatMap(inner -> inner.values().stream())
+                .collect(java.util.stream.Collectors.toList());
     }
 
     private static Channel singleHttp2Connection(AsyncHttpClient client) throws Exception {

--- a/client/src/test/java/org/asynchttpclient/netty/channel/ChannelManagerHttp2SiblingLookupTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/channel/ChannelManagerHttp2SiblingLookupTest.java
@@ -1,0 +1,164 @@
+/*
+ *    Copyright (c) 2026 AsyncHttpClient Project. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.asynchttpclient.netty.channel;
+
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.HashedWheelTimer;
+import io.netty.util.Timer;
+import org.asynchttpclient.AsyncHttpClientConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.net.InetAddress;
+import java.util.Map;
+
+import static org.asynchttpclient.Dsl.config;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the base-key-grouped HTTP/2 registry and the sibling-connection lookup that backs the
+ * round-robin permit-starved reuse path (issue #2214). These exercise
+ * {@link ChannelManager#pollHttp2SiblingConnection(Object)}, the exact-key {@link ChannelManager#pollHttp2Connection(Object)}
+ * over the nested map, and the empty-inner-map pruning, without any network I/O.
+ */
+class ChannelManagerHttp2SiblingLookupTest {
+
+    private static final String BASE = "https://host:443";
+
+    private ChannelManager channelManager;
+    private Timer timer;
+
+    @BeforeEach
+    void setUp() {
+        AsyncHttpClientConfig cfg = config().build();
+        timer = new HashedWheelTimer();
+        channelManager = new ChannelManager(cfg, timer);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (channelManager != null) {
+            channelManager.close();
+        }
+        if (timer != null) {
+            timer.stop();
+        }
+    }
+
+    private static RoundRobinPartitionKey rrKey(String base, String ip) throws Exception {
+        return new RoundRobinPartitionKey(base, InetAddress.getByName(ip));
+    }
+
+    /** Registers an active EmbeddedChannel under the given key, attaching a (optionally draining) H2 state. */
+    private EmbeddedChannel register(Object partitionKey, boolean draining) {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        Http2ConnectionState state = new Http2ConnectionState();
+        if (draining) {
+            state.setDraining(0);
+        }
+        channel.attr(Http2ConnectionState.HTTP2_STATE_KEY).set(state);
+        channelManager.registerHttp2Connection(partitionKey, channel);
+        return channel;
+    }
+
+    @Test
+    void siblingLookupReturnsConnectionForSameBaseDifferentIp() throws Exception {
+        EmbeddedChannel chA = register(rrKey(BASE, "127.0.0.1"), false);
+
+        // A request pinned to a different IP misses the exact key but must find the sibling on IP_A.
+        assertNull(channelManager.pollHttp2Connection(rrKey(BASE, "127.0.0.2")), "exact per-IP poll must miss");
+        assertSame(chA, channelManager.pollHttp2SiblingConnection(BASE), "sibling lookup must find the IP_A connection");
+    }
+
+    @Test
+    void exactPollStillResolvesOverNestedMap() throws Exception {
+        EmbeddedChannel chA = register(rrKey(BASE, "127.0.0.1"), false);
+        assertSame(chA, channelManager.pollHttp2Connection(rrKey(BASE, "127.0.0.1")), "exact per-IP poll must hit");
+    }
+
+    @Test
+    void defaultModePlainKeyStillResolves() {
+        // DEFAULT mode registers under the plain base key; baseKeyOf returns it unchanged, so the inner
+        // map holds a single entry and the exact poll behaves exactly as the old flat map did.
+        EmbeddedChannel ch = register(BASE, false);
+        assertSame(ch, channelManager.pollHttp2Connection(BASE), "plain-key exact poll must hit");
+    }
+
+    @Test
+    void siblingLookupSkipsDrainingConnection() throws Exception {
+        register(rrKey(BASE, "127.0.0.1"), true);
+        assertNull(channelManager.pollHttp2SiblingConnection(BASE), "a draining sibling must not be handed out");
+    }
+
+    @Test
+    void siblingLookupReturnsHealthyAmongDraining() throws Exception {
+        register(rrKey(BASE, "127.0.0.1"), true);
+        EmbeddedChannel healthy = register(rrKey(BASE, "127.0.0.2"), false);
+        assertSame(healthy, channelManager.pollHttp2SiblingConnection(BASE),
+                "lookup must skip the draining sibling and return the healthy one");
+    }
+
+    @Test
+    void siblingLookupSkipsClosedConnection() throws Exception {
+        EmbeddedChannel chA = register(rrKey(BASE, "127.0.0.1"), false);
+        chA.close().sync();
+        assertNull(channelManager.pollHttp2SiblingConnection(BASE), "a closed sibling must not be handed out");
+    }
+
+    @Test
+    void siblingLookupIgnoresDifferentBase() throws Exception {
+        register(rrKey(BASE, "127.0.0.1"), false);
+        assertNull(channelManager.pollHttp2SiblingConnection("https://other:443"),
+                "lookup must not cross base-key (host) boundaries");
+    }
+
+    @Test
+    void siblingLookupReturnsNullForUnknownBase() {
+        assertNull(channelManager.pollHttp2SiblingConnection(BASE), "no connections registered yet");
+    }
+
+    @Test
+    void emptyInnerMapIsPrunedOnRemoval() throws Exception {
+        RoundRobinPartitionKey keyA = rrKey(BASE, "127.0.0.1");
+        RoundRobinPartitionKey keyB = rrKey(BASE, "127.0.0.2");
+        EmbeddedChannel chA = register(keyA, false);
+        EmbeddedChannel chB = register(keyB, false);
+        assertTrue(outerMapContainsBase(BASE), "base entry present after registering two siblings");
+
+        // Removing one sibling keeps the inner map (still has the other).
+        channelManager.removeHttp2Connection(keyA, chA);
+        assertTrue(outerMapContainsBase(BASE), "base entry kept while a sibling remains");
+        assertSame(chB, channelManager.pollHttp2SiblingConnection(BASE), "remaining sibling still found");
+
+        // Removing the last sibling prunes the empty inner map from the outer registry.
+        channelManager.removeHttp2Connection(keyB, chB);
+        assertFalse(outerMapContainsBase(BASE), "emptied inner map must be pruned from the outer registry");
+        assertNull(channelManager.pollHttp2SiblingConnection(BASE), "no sibling after the last is removed");
+    }
+
+    @SuppressWarnings("unchecked")
+    private boolean outerMapContainsBase(Object baseKey) throws Exception {
+        Field f = ChannelManager.class.getDeclaredField("http2Connections");
+        f.setAccessible(true);
+        return ((Map<Object, ?>) f.get(channelManager)).containsKey(baseKey);
+    }
+}

--- a/client/src/test/java/org/asynchttpclient/netty/channel/RoundRobinPartitionKeyTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/channel/RoundRobinPartitionKeyTest.java
@@ -21,6 +21,7 @@ import java.net.InetAddress;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 class RoundRobinPartitionKeyTest {
 
@@ -54,5 +55,15 @@ class RoundRobinPartitionKeyTest {
         RoundRobinPartitionKey repinned = original.withAddress(InetAddress.getByName("127.0.0.2"));
         assertEquals(new RoundRobinPartitionKey("base", InetAddress.getByName("127.0.0.2")), repinned);
         assertNotEquals(original, repinned);
+    }
+
+    @Test
+    void getBaseKeyReturnsConstructorBase() throws Exception {
+        Object base = "base";
+        RoundRobinPartitionKey key = new RoundRobinPartitionKey(base, InetAddress.getByName("127.0.0.1"));
+        // Same reference, so the HTTP/2 registry groups sibling per-IP keys under the exact base it was built with.
+        assertSame(base, key.getBaseKey());
+        // withAddress preserves the base key (used to re-pin on failover, issue #2214).
+        assertSame(base, key.withAddress(InetAddress.getByName("127.0.0.2")).getBaseKey());
     }
 }


### PR DESCRIPTION
Fixes https://github.com/AsyncHttpClient/async-http-client/issues/2214.
Two HTTP/2 robustness fixes for `LoadBalance.ROUND_ROBIN`, on top of the feature
branch (`requests-round-robin-per-host`):

1. A permit-starved request now reuses a sibling-IP HTTP/2 connection instead of
   stalling for `connectTimeout` and then failing (#2214).
2. `maxConnectionsPerHost` is now actually *enforced* as a per-host connection cap
   in round-robin mode (it previously only throttled connection establishment).

Two commits:
- `Fix #2214: reuse a sibling-IP HTTP/2 connection when permit-starved`
- `Enforce maxConnectionsPerHost for round-robin HTTP/2`

## 1. Reuse a sibling-IP HTTP/2 connection when permit-starved (#2214)

In round-robin mode each request is pinned to a resolved IP via
`RoundRobinPartitionKey(base, IP)`, but the connection permit is per host. With a
finite `maxConnectionsPerHost`, a request pinned to `IP_B` that couldn't acquire a
permit polled only its own per-IP key in the HTTP/2 registry, never found a
connection already open on `IP_A`, and — off the event loop — spun the full
`connectTimeout` before failing with the permit exception.

- The HTTP/2 registry (`ChannelManager.http2Connections`) changes from a flat
  exact-key map into a **base-keyed nested map** (`base host → per-IP key →
  channel`): single source of truth, O(1) exact lookup, sibling lookup scoped to
  the host. Register runs inside `compute(baseKey, …)` and removal inside
  `computeIfPresent(baseKey, …)` on the same outer bucket, so a concurrent
  insert/prune can't orphan an entry.
- On the permit-starved path, `waitForHttp2Connection` falls back to
  `pollHttp2SiblingConnection(baseKey)` — any active, non-draining connection to
  the same host on a sibling IP — and multiplexes onto it. Multiplexing onto an
  existing HTTP/2 connection takes no permit, so this is safe. The fallback is
  confined to the permit-starved path; the happy path stays strictly per IP, so
  round-robin spreading is unaffected.

## 2. Enforce `maxConnectionsPerHost` for round-robin HTTP/2

The per-host permit was released immediately after ALPN (as in `DEFAULT` mode), so
it only throttled connection *establishment*. Because each request pins to a
different IP and opens its own connection, a host could accumulate up to one
connection per resolved IP regardless of the cap — it wasn't enforced.

- In round-robin mode the permit is now held for the HTTP/2 connection's lifetime
  (as HTTP/1.1 already does). The per-host semaphore then bounds live connections:
  at most `maxConnectionsPerHost` (K) connections, spread across K of the IPs; a
  request pinned to a further IP fails to acquire a permit and multiplexes onto a
  sibling (via the fix above) rather than opening another. `DEFAULT` mode is
  unchanged (one connection per host, released post-ALPN so concurrent requests
  multiplex onto it).

## Behavior & compatibility

- `DEFAULT` mode is unchanged.
- `maxConnectionsPerHost` now caps live HTTP/2 connections per host in round-robin
  mode. When it's `< #resolved IPs`, the cap wins over full spreading: K
  connections are held open (kept alive by PING) and stay pinned to K IPs. Set it
  `≥ #IPs` for full per-IP spreading. The default is unlimited, so this only
  affects clients that configure a finite per-host cap.
- A live round-robin HTTP/2 connection now also occupies a global `maxConnections`
  slot for its lifetime.

## Testing

- `ChannelManagerHttp2SiblingLookupTest` (new) — nested registry + sibling lookup:
  active hit, draining/dead/closed skipped, base mismatch ignored, empty-inner-map
  pruning.
- `RoundRobinPartitionKeyTest` — `getBaseKey` coverage.
- `BasicHttp2Test`:
  - permit-starved sibling reuse (concurrent burst, `maxConnectionsPerHost=1`,
    multi-IP) — completes by multiplexing instead of stalling;
  - spreading regression guard (cap ≥ #IPs → every IP still attempted);
  - cap enforcement (3 IPs, cap=2 → ≤ 2 live connections, all requests succeed).
- Existing HTTP/2 multiplex / orphan / conformance regression suites and
  `RoundRobinSendTypeTest` pass; the two reflective `http2Connections()` test
  helpers were updated to flatten the nested map.

Both fixes were adversarially verified: reverting the change makes the sibling
reuse test stall-then-fail, and the cap test report `expected <= 2, got 3`.

## Out of scope

- Active health checks / authoritative failed-IP handling remain the resolver/DNS
  layer's responsibility (round-robin's IP cooldown is only a short-lived dampener).