### PR TITLE
stop config realm leaking to a cross-origin redirect target

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Interceptors.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Interceptors.java
@@ -87,7 +87,12 @@ public class Interceptors {
         ProxyServer proxyServer = future.getProxyServer();
         int statusCode = response.status().code();
         Request request = future.getCurrentRequest();
-        Realm realm = request.getRealm() != null ? request.getRealm() : config.getRealm();
+        // Use the realm the future is carrying (seeded from the request or client config when the
+        // exchange started, and reset to null by Redirect30xInterceptor on a cross-origin or
+        // scheme-downgrade redirect). Re-deriving from config.getRealm() here re-attaches the
+        // client-wide credentials to a redirect target whose auth was just stripped, leaking them
+        // to a different origin that answers 401.
+        Realm realm = future.getRealm();
 
         // This MUST BE called before Redirect30xInterceptor because latter assumes cookie store is already updated
         CookieStore cookieStore = config.getCookieStore();

--- a/client/src/test/java/org/asynchttpclient/RedirectCredentialSecurityTest.java
+++ b/client/src/test/java/org/asynchttpclient/RedirectCredentialSecurityTest.java
@@ -70,6 +70,7 @@ public class RedirectCredentialSecurityTest {
     private static final AtomicReference<String> cookieOnBounceBack = new AtomicReference<>();
     private static final AtomicReference<String> authAfterHttpsDowngrade = new AtomicReference<>();
     private static final AtomicReference<String> cookieAfterHttpsDowngrade = new AtomicReference<>();
+    private static final AtomicReference<String> authOn401Target = new AtomicReference<>();
 
     @BeforeAll
     public static void startServers() throws Exception {
@@ -191,6 +192,24 @@ public class RedirectCredentialSecurityTest {
             cookieAfterHttpsDowngrade.set(exchange.getRequestHeaders().getFirst("Cookie"));
             exchange.sendResponseHeaders(200, 0);
             exchange.getResponseBody().close();
+            exchange.close();
+        });
+
+        // Cross-domain redirect to a target that answers 401: the target must never receive
+        // credentials, even those configured client-wide via config.setRealm(...).
+        serverA.createContext("/redirect-to-b-401", exchange -> {
+            exchange.getResponseHeaders().add("Location", "http://127.0.0.1:" + portB + "/target-401");
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+        });
+
+        serverB.createContext("/target-401", exchange -> {
+            String auth = exchange.getRequestHeaders().getFirst("Authorization");
+            if (auth != null) {
+                authOn401Target.set(auth);
+            }
+            exchange.getResponseHeaders().add("WWW-Authenticate", "Basic realm=\"target\"");
+            exchange.sendResponseHeaders(401, -1);
             exchange.close();
         });
 
@@ -697,6 +716,29 @@ public class RedirectCredentialSecurityTest {
                     "Authorization must be stripped when only the port differs (origin includes port)");
             assertNull(lastCookieHeaderOnB.get(),
                     "Cookie must be stripped when only the port differs (origin includes port)");
+        }
+    }
+
+    /**
+     * Client-wide credentials set via {@code config.setRealm(...)} must not be sent to a
+     * cross-domain redirect target, even when that target answers 401 to solicit them. The
+     * redirect clears the request/future realm, but the config realm must not be re-applied.
+     */
+    @Test
+    void crossDomainRedirectTo401TargetDoesNotLeakConfigRealm() throws Exception {
+        DefaultAsyncHttpClientConfig config = new DefaultAsyncHttpClientConfig.Builder()
+                .setFollowRedirect(true)
+                .setRealm(basicAuthRealm("user", "password").build())
+                .build();
+        try (DefaultAsyncHttpClient client = new DefaultAsyncHttpClient(config)) {
+            authOn401Target.set(null);
+
+            client.prepareGet("http://127.0.0.1:" + portA + "/redirect-to-b-401")
+                    .execute()
+                    .get(5, TimeUnit.SECONDS);
+
+            assertNull(authOn401Target.get(),
+                    "client-wide config Realm must not be sent to a cross-domain 401 target after redirect");
         }
     }
 


### PR DESCRIPTION
Cross-origin and https-to-http redirects strip the request realm, but exitAfterIntercept re-derived it from config.getRealm(), reattaching a client-wide realm to the redirect target:
- the target answers 401 and then receives the configured credentials, leaking them to a different origin
- Redirect30xInterceptor already clears future.getRealm() on the strip, so read the realm from the future instead of falling back to config
Added a cross-origin 401 case to RedirectCredentialSecurityTest that fails without the change.