### PR TITLE
escape quoted-string params in Digest Authorization header

### DIFF
--- a/client/src/main/java/org/asynchttpclient/util/AuthenticatorUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/AuthenticatorUtils.java
@@ -491,11 +491,31 @@ public final class AuthenticatorUtils {
     private static void append(StringBuilder builder, String name, @Nullable String value, boolean quoted) {
         builder.append(name).append('=');
         if (quoted) {
-            builder.append('"').append(value).append('"');
+            builder.append('"');
+            appendQuotedStringContent(builder, value);
+            builder.append('"');
         } else {
             builder.append(value);
         }
         builder.append(", ");
+    }
+
+    // RFC 7616 params like realm/nonce/opaque are echoed back from the server challenge into the
+    // quoted-string values of the Authorization header. Backslash-escape " and \ (RFC 7230 quoted-string)
+    // so a server-supplied value carrying a bare quote cannot close the value early and inject extra
+    // auth-params into the credentials the client emits.
+    private static void appendQuotedStringContent(StringBuilder builder, @Nullable String value) {
+        if (value == null) {
+            builder.append((String) null);
+            return;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == '"' || c == '\\') {
+                builder.append('\\');
+            }
+            builder.append(c);
+        }
     }
 
     public static @Nullable String perConnectionProxyAuthorizationHeader(Request request, @Nullable Realm proxyRealm) {

--- a/client/src/test/java/org/asynchttpclient/util/AuthenticatorUtilsTest.java
+++ b/client/src/test/java/org/asynchttpclient/util/AuthenticatorUtilsTest.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -491,5 +492,30 @@ public class AuthenticatorUtilsTest {
         String rspauth = AuthenticatorUtils.computeRspAuth(realm);
         assertNotNull(rspauth);
         assertEquals(32, rspauth.length()); // MD5 hex is 32 chars
+    }
+
+    // A server-controlled challenge value (nonce/realm/opaque) must be backslash-escaped when echoed
+    // into the quoted-string params of the outgoing Authorization header, so a bare " cannot close the
+    // value early and inject extra auth-params.
+    @Test
+    void digestChallengeValuesEscapedInAuthorizationHeader() {
+        Realm realm = new Realm.Builder("user", "pass")
+                .setScheme(Realm.AuthScheme.DIGEST)
+                .setUsePreemptiveAuth(true)
+                .setRealmName("testrealm")
+                .setNonce("abc\"x")
+                .setOpaque("op\\aque")
+                .setAlgorithm("MD5")
+                .build();
+        Request request = new RequestBuilder("GET")
+                .setUrl("http://example.com/secret")
+                .build();
+
+        String header = AuthenticatorUtils.perRequestAuthorizationHeader(request, realm);
+
+        assertNotNull(header);
+        assertTrue(header.contains("nonce=\"abc\\\"x\""), header);
+        assertTrue(header.contains("opaque=\"op\\\\aque\""), header);
+        assertFalse(header.contains("nonce=\"abc\"x\""), header);
     }
 }


### PR DESCRIPTION
computeDigestAuthentication echoes the realm, nonce and opaque values from the server's Digest challenge into the quoted-string params of the outgoing Authorization header via append(), which wrapped them in quotes without escaping. matchParam returns an unquoted challenge value up to the next comma or space, so a bare double quote survives, and a server sending nonce=abc"x makes that quote close the value early and inject stray auth-params into the credentials the client emits toward any proxy or gateway on the path. append() now backslash-escapes double-quote and backslash per the RFC 7230/7616 quoted-string rules, covering both the origin and proxy Digest paths since they share this helper. Base64/hex nonces are unaffected; AuthenticatorUtilsTest gets a case that fails without the escaping.