### PR TITLE
reject backslash in the parsed URI authority

### DIFF
--- a/client/src/main/java/org/asynchttpclient/uri/UriParser.java
+++ b/client/src/main/java/org/asynchttpclient/uri/UriParser.java
@@ -334,6 +334,15 @@ final class UriParser {
             currentIndex += 2;
 
             String nonNullAuthority = computeAuthority();
+
+            // A backslash is not allowed in the authority (RFC 3986). Left as an ordinary character it
+            // slips past the '@' userinfo split below, so "https://trusted.com\@evil.com/" resolves the
+            // host to evil.com here while java.net.URI rejects it and a WHATWG parser reads trusted.com.
+            // Reject it so the host we connect to cannot disagree with a host the caller already checked.
+            if (nonNullAuthority.indexOf('\\') != -1) {
+                throw new IllegalArgumentException("Invalid authority field: " + nonNullAuthority);
+            }
+
             computeUserInfo(nonNullAuthority);
 
             if (host != null) {

--- a/client/src/test/java/org/asynchttpclient/uri/UriTest.java
+++ b/client/src/test/java/org/asynchttpclient/uri/UriTest.java
@@ -296,6 +296,24 @@ public class UriTest {
     }
 
     @RepeatedIfExceptionsTest(repeats = 5)
+    public void creatingUriWithBackslashInAuthorityThrowsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> Uri.create("https://trusted.com\\@evil.com/"));
+    }
+
+    @RepeatedIfExceptionsTest(repeats = 5)
+    public void creatingUriWithBackslashInSchemeRelativeAuthorityThrows() {
+        Uri context = Uri.create("https://trusted.com/app");
+        assertThrows(IllegalArgumentException.class, () -> Uri.create(context, "//trusted.com\\@evil.com/"));
+    }
+
+    @RepeatedIfExceptionsTest(repeats = 5)
+    public void backslashInPathIsPreserved() {
+        Uri uri = Uri.create("https://trusted.com/a\\b");
+        assertEquals("trusted.com", uri.getHost());
+        assertEquals("/a\\b", uri.getPath());
+    }
+
+    @RepeatedIfExceptionsTest(repeats = 5)
     public void testGetAuthority() {
         Uri uri = Uri.create("http://stackoverflow.com/questions/17814461/jacoco-maven-testng-0-test-coverage");
         assertEquals("stackoverflow.com:80", uri.getAuthority(), "Incorrect authority returned from getAuthority");


### PR DESCRIPTION
UriParser.parseAuthority never rejects a backslash in the authority, so it slips past the '@' userinfo split and Uri.create("https://trusted.com\@evil.com/") resolves the connect host to evil.com, while java.net.URI rejects that string and a WHATWG parser reads trusted.com. An app that allowlists the host before handing the raw URL, or a server-supplied redirect Location, to the client then connects to a host it never checked. This rejects a backslash in the parsed authority per RFC 3986, which does not permit it there, and leaves a backslash in the path untouched.