### PR TITLE
Upgrade Netty 4.1.136.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -462,7 +462,7 @@
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
     <source.property>1.8</source.property>
     <target.property>1.8</target.property>
-    <netty.version>4.1.133.Final</netty.version>
+    <netty.version>4.1.136.Final</netty.version>
     <slf4j.version>1.7.36</slf4j.version>
     <reactive-streams.version>1.0.4</reactive-streams.version>
     <activation.version>1.2.2</activation.version>


### PR DESCRIPTION
Netty 4.1.133.Final is affected by GHSA-hvcg-qmg6-jm4c (netty-codec-http: HttpObjectDecoder skips arbitrary initial control characters) and GHSA-3qp7-7mw8-wx86 (netty-handler: IPv6 subnet filter bypass), both fixed in 4.1.135.Final. The main branch already moved to the fixed 4.2.15.Final; this brings the 2.x line to the current 4.1.x patch level.