### PR TITLE
normalize the scheme case in the Uri constructor

### DIFF
--- a/client/src/main/java/org/asynchttpclient/uri/Uri.java
+++ b/client/src/main/java/org/asynchttpclient/uri/Uri.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Locale;
 
 import static org.asynchttpclient.util.Assertions.assertNotEmpty;
 import static org.asynchttpclient.util.MiscUtils.isEmpty;
@@ -43,15 +44,18 @@ public class Uri {
     private final boolean webSocket;
 
     public Uri(String scheme, @Nullable String userInfo, String host, int port, String path, @Nullable String query, @Nullable String fragment) {
-        this.scheme = assertNotEmpty(scheme, "scheme");
+        // rfc3986#section-3.1: schemes are case-insensitive, and validateSupportedScheme accepts any
+        // case. UriParser lowercases the schemes it parses; normalizing here keeps the constructor and
+        // withNewScheme consistent with it, so secured can't come out false for an "HTTPS" Uri.
+        this.scheme = assertNotEmpty(scheme, "scheme").toLowerCase(Locale.ROOT);
         this.userInfo = userInfo;
         this.host = assertNotEmpty(host, "host");
         this.port = port;
         this.path = path;
         this.query = query;
         this.fragment = fragment;
-        secured = HTTPS.equals(scheme) || WSS.equals(scheme);
-        webSocket = WS.equals(scheme) || WSS.equalsIgnoreCase(scheme);
+        secured = HTTPS.equals(this.scheme) || WSS.equals(this.scheme);
+        webSocket = WS.equals(this.scheme) || WSS.equals(this.scheme);
     }
 
     public static Uri create(String originalUrl) {

--- a/client/src/test/java/org/asynchttpclient/uri/UriTest.java
+++ b/client/src/test/java/org/asynchttpclient/uri/UriTest.java
@@ -182,6 +182,28 @@ public class UriTest {
     }
 
     @RepeatedIfExceptionsTest(repeats = 5)
+    public void testUpperCaseSchemeIsSecured() {
+        Uri uri = new Uri("HTTPS", null, "example.com", -1, "/", null, null);
+        Uri.validateSupportedScheme(uri);
+        assertTrue(uri.isSecured(), "HTTPS must be secured");
+        assertEquals(443, uri.getSchemeDefaultPort());
+        assertEquals(443, uri.getExplicitPort());
+
+        Uri wss = new Uri("WSS", null, "example.com", -1, "/", null, null);
+        assertTrue(wss.isSecured(), "WSS must be secured");
+        assertTrue(wss.isWebSocket());
+    }
+
+    @RepeatedIfExceptionsTest(repeats = 5)
+    public void testMixedCaseSchemeIsNormalized() {
+        Uri uri = new Uri("HtTp", "user", "example.com", 44, "/path", "query=4", null);
+        assertEquals("http", uri.getScheme());
+        assertEquals("http://user@example.com:44/path?query=4", uri.toUrl());
+        assertEquals(uri, new Uri("http", "user", "example.com", 44, "/path", "query=4", null));
+        assertTrue(uri.withNewScheme("HTTPS").isSecured());
+    }
+
+    @RepeatedIfExceptionsTest(repeats = 5)
     public void testWithNewQuery() {
         Uri uri = new Uri("http", "user", "example.com", 44, "/path/path2", "query=4", null);
         Uri newUri = uri.withNewQuery("query2=10&query3=20");


### PR DESCRIPTION
validateSupportedScheme accepts a scheme equal ignoring case to http/https/ws/wss, but the constructor derived secured with a case-sensitive compare, so a Uri built through the public constructor or withNewScheme with "HTTPS" passes validation and still reports isSecured() false, with getSchemeDefaultPort() then returning 80. That gates the TLS and credential decisions downstream: no SslHandler is installed, Proxy-Authorization goes out in the clear, Secure cookies are released, and the schemeDowngrade check on redirect never fires. UriParser already lowercases the schemes it parses, so only the direct-constructor path disagrees; normalizing in the constructor lines the two up (the adjacent webSocket line was already using equalsIgnoreCase for WSS).