### PR TITLE
ignore a Set-Cookie scoped to a bare TLD

### DIFF
--- a/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
@@ -181,6 +181,17 @@ public final class ThreadSafeCookieStore implements CookieStore {
         String keyDomain = pair.getKey();
         boolean hostOnly = pair.getValue();
 
+        // rfc6265#section-5.3 step 5: a Domain attribute that is a public suffix must not scope a
+        // cookie to that suffix, otherwise any host under it can plant cookies for every sibling.
+        // Approximated without a public suffix list by treating a single-label domain (a TLD such
+        // as "com") as one: accepted only when it is the request host itself, and then as host-only.
+        if (!hostOnly && DomainUtils.getSubDomain(keyDomain) == null) {
+            if (!keyDomain.equals(requestDomain)) {
+                return;
+            }
+            hostOnly = true;
+        }
+
         // rfc6265#section-5.3 step 6: ignore a cookie whose Domain attribute is not
         // domain-matched by the request host, otherwise a host can plant cookies for
         // unrelated domains (cookie tossing).

--- a/client/src/test/java/org/asynchttpclient/cookie/ThreadSafeCookieStoreGetTest.java
+++ b/client/src/test/java/org/asynchttpclient/cookie/ThreadSafeCookieStoreGetTest.java
@@ -113,6 +113,28 @@ public class ThreadSafeCookieStoreGetTest {
     }
 
     @Test
+    public void ignoresCookieScopedToATld() {
+        ThreadSafeCookieStore store = new ThreadSafeCookieStore();
+        // evil.com scopes a cookie to the whole "com" TLD.
+        store.add(Uri.create("http://evil.com/"),
+                ClientCookieDecoder.LAX.decode("SESSIONID=attacker; Domain=com; Path=/"));
+
+        assertTrue(store.get(Uri.create("http://bank.com/")).isEmpty(), "a TLD cookie must not reach a sibling host");
+        assertTrue(store.get(Uri.create("http://evil.com/")).isEmpty(), "a TLD cookie must not be stored at all");
+    }
+
+    @Test
+    public void keepsSingleLabelDomainCookieAsHostOnly() {
+        ThreadSafeCookieStore store = new ThreadSafeCookieStore();
+        // Domain equal to the request host stays usable, but only for that exact host.
+        store.add(Uri.create("http://localhost/"),
+                ClientCookieDecoder.LAX.decode("ALPHA=VALUE1; Domain=localhost; Path=/"));
+
+        assertEquals(setOf("ALPHA=VALUE1"), namesValues(store.get(Uri.create("http://localhost/"))));
+        assertTrue(store.get(Uri.create("http://sub.localhost/")).isEmpty(), "host-only cookie must not reach a sub-domain");
+    }
+
+    @Test
     public void returnsEmptyForUnknownDomain() {
         ThreadSafeCookieStore store = new ThreadSafeCookieStore();
         store.add(Uri.create("http://www.foo.com/"),


### PR DESCRIPTION
ThreadSafeCookieStore.add only applies rfc6265 section 5.3 step 6, so a Domain attribute that is a bare public suffix survives: domainsMatch("com", "evil.com") is true because evil.com ends with ".com". A response from evil.com carrying `Set-Cookie: SESSIONID=attacker; Domain=com; Path=/` (cookies arrive here from Interceptors.java:107) is stored under key domain "com" with hostOnly false. get() then walks the request host's parent labels through DomainUtils.getSubDomain, so a later request to bank.com resolves "bank.com", then "com", and picks the cookie up. Any host can plant a session cookie on every sibling under its TLD.

Step 5 is the missing rule, so the guard goes next to the existing step 6 check in add() rather than in get(): the walk is only reachable because the entry was accepted in the first place, and keying the jar correctly keeps the read path untouched. Without a public suffix list the approximation is a single-label domain, matching the embedded-dot requirement java.net.HttpCookie already enforces. Domain=localhost on a localhost request keeps working and becomes host-only, which is what it already resolved to in practice. Multi-label suffixes like co.uk still need a real list and are out of reach here. Two regression tests in ThreadSafeCookieStoreGetTest fail without the guard.