### PR TITLE
Enable HTTPS endpoint identification in JsseSslEngineFactory

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/ssl/JsseSslEngineFactory.java
+++ b/client/src/main/java/org/asynchttpclient/netty/ssl/JsseSslEngineFactory.java
@@ -19,6 +19,7 @@ import org.asynchttpclient.AsyncHttpClientConfig;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
 
 public class JsseSslEngineFactory extends SslEngineFactoryBase {
 
@@ -31,6 +32,14 @@ public class JsseSslEngineFactory extends SslEngineFactoryBase {
     @Override
     public SSLEngine newSslEngine(AsyncHttpClientConfig config, String peerHost, int peerPort) {
         SSLEngine sslEngine = sslContext.createSSLEngine(domain(peerHost), peerPort);
+        // A JDK SSLEngine does not verify the peer hostname unless the endpoint identification algorithm
+        // is set, so without this a certificate valid for any host would be accepted. Enable it to match
+        // DefaultSslEngineFactory, honoring disableHttpsEndpointIdentificationAlgorithm.
+        if (!config.isDisableHttpsEndpointIdentificationAlgorithm()) {
+            SSLParameters params = sslEngine.getSSLParameters();
+            params.setEndpointIdentificationAlgorithm("HTTPS");
+            sslEngine.setSSLParameters(params);
+        }
         configureSslEngine(sslEngine, config);
         return sslEngine;
     }


### PR DESCRIPTION
Motivation

`JsseSslEngineFactory` creates the `SSLEngine` using `sslContext.createSSLEngine(host, port)` but only enables client mode via `setUseClientMode(true)`. It never configures endpoint identification, so a JDK `SSLEngine` does not verify the server hostname during the TLS handshake. As a result, any certificate signed by a trusted CA is accepted regardless of the requested hostname, leaving the connection vulnerable to man-in-the-middle attacks. `DefaultSslEngineFactory` correctly enables hostname verification. 

This regression was introduced in #2104, which removed the shared `setEndpointIdentificationAlgorithm("HTTPS")` call from `configureSslEngine()` and restored it only in `DefaultSslEngineFactory`, unintentionally leaving the pure JSSE path (used with a user-supplied JDK `SSLContext`) without hostname verification.

Modification

Update `JsseSslEngineFactory.newSslEngine()` to configure the engine's `SSLParameters` with `setEndpointIdentificationAlgorithm("HTTPS")`, unless `config.isDisableHttpsEndpointIdentificationAlgorithm()` is enabled. This matches the behavior of `DefaultSslEngineFactory` while preserving the documented opt-out.

Result

Connections created through `JsseSslEngineFactory` with a custom JDK `SSLContext` now perform hostname verification during the TLS handshake, matching the default implementation. Existing opt-out behavior remains unchanged, and the `DefaultSslEngineFactory` path is unaffected.