### PR TITLE
Bind origin Kerberos/SPNEGO token to the origin service, not the proxy

### DIFF
--- a/client/src/main/java/org/asynchttpclient/util/AuthenticatorUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/AuthenticatorUtils.java
@@ -596,14 +596,11 @@ public final class AuthenticatorUtils {
                     break;
                 case KERBEROS:
                 case SPNEGO:
-                    String host;
-                    if (proxyServer != null) {
-                        host = proxyServer.getHost();
-                    } else if (request.getVirtualHost() != null) {
-                        host = request.getVirtualHost();
-                    } else {
-                        host = request.getUri().getHost();
-                    }
+                    // The origin realm's Negotiate token must target the origin service even when a proxy
+                    // is configured. Minting it against the proxy host produced a service ticket for the
+                    // proxy's SPN: a confused deputy where the origin credential is delivered to, and only
+                    // usable by, the proxy, while origin authentication fails.
+                    String host = request.getVirtualHost() != null ? request.getVirtualHost() : request.getUri().getHost();
 
                     try {
                         authorizationHeader = NEGOTIATE + ' ' + SpnegoEngine.instance(


### PR DESCRIPTION
Motivation

When a proxy is configured, `perConnectionAuthorizationHeader` incorrectly builds the origin Kerberos/SPNEGO token using the proxy host instead of the origin host. This generates a service ticket for the proxy's SPN, causing origin authentication to fail and misdirecting the credential.

Modification

Always build the origin token using the origin host (`request.getVirtualHost()` when set, otherwise `request.getUri().getHost()`). Proxy authentication remains unchanged and continues to use `perConnectionProxyAuthorizationHeader`.

Result

Origin Kerberos/SPNEGO authentication now targets the correct SPN even when requests are sent through a proxy. Proxy authentication and direct (non-proxy) behavior remain unchanged.
