### PR TITLE
Mirror Netty option-failure semantics in applyChannelOptions

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
@@ -300,12 +300,24 @@ public class ChannelManager {
      * Applies the pre-resolved channel options to a freshly created channel. Invoked from the channel initializer
      * (once per connection, on the channel's event loop, before the channel is connected), mirroring what
      * {@link Bootstrap#option} would otherwise do but without the shared, synchronized options map.
+     * <p>
+     * The per-option handling mirrors Netty's {@code AbstractBootstrap#setChannelOption}: an unknown option is
+     * warned about and skipped, and a failure to set an option is warned about and rethrown so the channel is
+     * closed rather than connecting with a half-applied configuration.
      */
     @SuppressWarnings("unchecked")
     private void applyChannelOptions(Channel channel) {
         ChannelConfig channelConfig = channel.config();
         for (Map.Entry<ChannelOption<?>, Object> option : channelOptions) {
-            channelConfig.setOption((ChannelOption<Object>) option.getKey(), option.getValue());
+            ChannelOption<Object> key = (ChannelOption<Object>) option.getKey();
+            try {
+                if (!channelConfig.setOption(key, option.getValue())) {
+                    LOGGER.warn("Unknown channel option '{}' for channel '{}'", key, channel);
+                }
+            } catch (Throwable t) {
+                LOGGER.warn("Failed to set channel option '{}' with value '{}' for channel '{}'", key, option.getValue(), channel, t);
+                throw t;
+            }
         }
     }
 


### PR DESCRIPTION
Motivation

After #2219, channel options are applied per-channel in ChannelManager.applyChannelOptions via Channel.config().setOption(...) instead of Bootstrap#option. The direct call dropped the error handling that Netty's AbstractBootstrap#setChannelOption provided: an unknown option key is now silently ignored (previously logged Unknown channel option), and an option whose setOption throws now propagates out of initChannel as a generic channel-init failure that closes the channel with a masked cause, instead of being logged with the offending option and value.

Modification

In applyChannelOptions, mirror Netty's AbstractBootstrap#setChannelOption: warn and skip when setOption returns false (unknown option), and warn (naming the option and value) then rethrow on failure, preserving Netty's close-on-failure semantics so a channel never connects with a partially-applied configuration.

Result

Channel-option error handling and diagnostics match the pre-#2219 Bootstrap behavior again. Happy-path behavior is unchanged, and only user-supplied config.getChannelOptions() can reach these branches since the built-in defaults are guarded to valid ranges.