### PR TITLE
Support HTTP/2 after proxy CONNECT

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
@@ -122,6 +122,7 @@ public class ChannelManager {
     public static final String HTTP2_FRAME_CODEC = "http2-frame-codec";
     public static final String HTTP2_MULTIPLEX = "http2-multiplex";
     public static final String AHC_HTTP2_HANDLER = "ahc-http2";
+    private static final String TARGET_SSL_HANDLER = "target-ssl";
     private static final Logger LOGGER = LoggerFactory.getLogger(ChannelManager.class);
     // Guards the one-time WARN emitted when a native transport was requested but is unavailable and we
     // fall back to NIO. Logged once per JVM to avoid spamming logs when many clients are created.
@@ -630,10 +631,6 @@ public class ChannelManager {
     }
 
     public Future<Channel> updatePipelineForHttpTunneling(ChannelPipeline pipeline, Uri requestUri) {
-        return updatePipelineForHttpTunneling(pipeline, requestUri, null);
-    }
-
-    public Future<Channel> updatePipelineForHttpTunneling(ChannelPipeline pipeline, Uri requestUri, Object partitionKey) {
         Future<Channel> whenHandshaked = null;
 
         if (pipeline.get(HTTP_CLIENT_CODEC) != null) {
@@ -651,7 +648,6 @@ public class ChannelManager {
             whenHandshaked = sslHandler.handshakeFuture();
             pipeline.addBefore(INFLATER_HANDLER, SSL_HANDLER, sslHandler);
             pipeline.addAfter(SSL_HANDLER, HTTP_CLIENT_CODEC, newHttpClientCodec());
-            upgradePipelineToHttp2AfterHandshake(whenHandshaked, sslHandler, pipeline, requestUri, partitionKey);
 
         } else {
             // For HTTP targets, remove any existing SSL handler (from HTTPS proxy) since target is not secured
@@ -674,11 +670,6 @@ public class ChannelManager {
     }
 
     public Future<Channel> updatePipelineForHttpsTunneling(ChannelPipeline pipeline, Uri requestUri, ProxyServer proxyServer) {
-        return updatePipelineForHttpsTunneling(pipeline, requestUri, proxyServer, null);
-    }
-
-    public Future<Channel> updatePipelineForHttpsTunneling(ChannelPipeline pipeline, Uri requestUri, ProxyServer proxyServer,
-                                                           Object partitionKey) {
         Future<Channel> whenHandshaked = null;
 
         // Remove HTTP codec as tunnel is established
@@ -698,14 +689,13 @@ public class ChannelManager {
             // This creates a nested SSL setup: Target SSL -> Proxy SSL -> Network
             if (isSslHandlerConfigured(pipeline)) {
                 // Insert target SSL handler after the proxy SSL handler
-                pipeline.addAfter(SSL_HANDLER, "target-ssl", sslHandler);
+                pipeline.addAfter(SSL_HANDLER, TARGET_SSL_HANDLER, sslHandler);
             } else {
                 // This shouldn't happen for HTTPS proxy, but fallback
                 pipeline.addBefore(INFLATER_HANDLER, SSL_HANDLER, sslHandler);
             }
             
-            pipeline.addAfter("target-ssl", HTTP_CLIENT_CODEC, newHttpClientCodec());
-            upgradePipelineToHttp2AfterHandshake(whenHandshaked, sslHandler, pipeline, requestUri, partitionKey);
+            pipeline.addAfter(TARGET_SSL_HANDLER, HTTP_CLIENT_CODEC, newHttpClientCodec());
 
         } else {
             // For HTTPS proxy to HTTP target, just add HTTP codec
@@ -724,25 +714,6 @@ public class ChannelManager {
         }
         
         return whenHandshaked;
-    }
-
-    private void upgradePipelineToHttp2AfterHandshake(Future<Channel> whenHandshaked,
-                                                       SslHandler sslHandler,
-                                                       ChannelPipeline pipeline,
-                                                       Uri requestUri,
-                                                       Object partitionKey) {
-        if (!config.isHttp2Enabled() || requestUri.isWebSocket()) {
-            return;
-        }
-
-        whenHandshaked.addListener(f -> {
-            if (f.isSuccess() && ApplicationProtocolNames.HTTP_2.equals(sslHandler.applicationProtocol())) {
-                upgradePipelineToHttp2(pipeline);
-                if (partitionKey != null) {
-                    registerHttp2Connection(partitionKey, pipeline.channel());
-                }
-            }
-        });
     }
 
     public SslHandler addSslHandler(ChannelPipeline pipeline, Uri uri, String virtualHost, boolean hasSocksProxyHandler) {
@@ -993,6 +964,23 @@ public class ChannelManager {
         if (pingIntervalMs > 0) {
             pipeline.addLast("http2-idle-state", new IdleStateHandler(0, 0, pingIntervalMs, TimeUnit.MILLISECONDS));
             pipeline.addLast("http2-ping", new Http2PingHandler());
+        }
+    }
+
+    /**
+     * Upgrades and registers a proxy tunnel when the target TLS handshake negotiated HTTP/2.
+     * The caller controls when this runs so the upgrade can happen immediately before the
+     * tunneled request is sent.
+     */
+    public void upgradePipelineToHttp2AfterProxyConnect(ChannelPipeline pipeline, Object partitionKey) {
+        SslHandler targetSslHandler = (SslHandler) pipeline.get(TARGET_SSL_HANDLER);
+        if (targetSslHandler == null) {
+            targetSslHandler = (SslHandler) pipeline.get(SSL_HANDLER);
+        }
+        if (targetSslHandler != null
+                && ApplicationProtocolNames.HTTP_2.equals(targetSslHandler.applicationProtocol())) {
+            upgradePipelineToHttp2(pipeline);
+            registerHttp2Connection(partitionKey, pipeline.channel());
         }
     }
 

--- a/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/ChannelManager.java
@@ -51,6 +51,7 @@ import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.proxy.ProxyHandler;
 import io.netty.handler.proxy.Socks4ProxyHandler;
 import io.netty.handler.proxy.Socks5ProxyHandler;
+import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.IdleStateHandler;
@@ -629,6 +630,10 @@ public class ChannelManager {
     }
 
     public Future<Channel> updatePipelineForHttpTunneling(ChannelPipeline pipeline, Uri requestUri) {
+        return updatePipelineForHttpTunneling(pipeline, requestUri, null);
+    }
+
+    public Future<Channel> updatePipelineForHttpTunneling(ChannelPipeline pipeline, Uri requestUri, Object partitionKey) {
         Future<Channel> whenHandshaked = null;
 
         if (pipeline.get(HTTP_CLIENT_CODEC) != null) {
@@ -646,6 +651,7 @@ public class ChannelManager {
             whenHandshaked = sslHandler.handshakeFuture();
             pipeline.addBefore(INFLATER_HANDLER, SSL_HANDLER, sslHandler);
             pipeline.addAfter(SSL_HANDLER, HTTP_CLIENT_CODEC, newHttpClientCodec());
+            upgradePipelineToHttp2AfterHandshake(whenHandshaked, sslHandler, pipeline, requestUri, partitionKey);
 
         } else {
             // For HTTP targets, remove any existing SSL handler (from HTTPS proxy) since target is not secured
@@ -668,6 +674,11 @@ public class ChannelManager {
     }
 
     public Future<Channel> updatePipelineForHttpsTunneling(ChannelPipeline pipeline, Uri requestUri, ProxyServer proxyServer) {
+        return updatePipelineForHttpsTunneling(pipeline, requestUri, proxyServer, null);
+    }
+
+    public Future<Channel> updatePipelineForHttpsTunneling(ChannelPipeline pipeline, Uri requestUri, ProxyServer proxyServer,
+                                                           Object partitionKey) {
         Future<Channel> whenHandshaked = null;
 
         // Remove HTTP codec as tunnel is established
@@ -694,6 +705,7 @@ public class ChannelManager {
             }
             
             pipeline.addAfter("target-ssl", HTTP_CLIENT_CODEC, newHttpClientCodec());
+            upgradePipelineToHttp2AfterHandshake(whenHandshaked, sslHandler, pipeline, requestUri, partitionKey);
 
         } else {
             // For HTTPS proxy to HTTP target, just add HTTP codec
@@ -712,6 +724,25 @@ public class ChannelManager {
         }
         
         return whenHandshaked;
+    }
+
+    private void upgradePipelineToHttp2AfterHandshake(Future<Channel> whenHandshaked,
+                                                       SslHandler sslHandler,
+                                                       ChannelPipeline pipeline,
+                                                       Uri requestUri,
+                                                       Object partitionKey) {
+        if (!config.isHttp2Enabled() || requestUri.isWebSocket()) {
+            return;
+        }
+
+        whenHandshaked.addListener(f -> {
+            if (f.isSuccess() && ApplicationProtocolNames.HTTP_2.equals(sslHandler.applicationProtocol())) {
+                upgradePipelineToHttp2(pipeline);
+                if (partitionKey != null) {
+                    registerHttp2Connection(partitionKey, pipeline.channel());
+                }
+            }
+        });
     }
 
     public SslHandler addSslHandler(ChannelPipeline pipeline, Uri uri, String virtualHost, boolean hasSocksProxyHandler) {

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ConnectSuccessInterceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ConnectSuccessInterceptor.java
@@ -55,16 +55,14 @@ public class ConnectSuccessInterceptor {
         LOGGER.debug("Connecting to proxy {} for scheme {}", proxyServer, requestUri.getScheme());
         
         final Future<Channel> whenHandshaked;
-        Object partitionKey = future.getPartitionKey();
         
         // Special handling for HTTPS proxy tunneling
         if (proxyServer != null && ProxyType.HTTPS.equals(proxyServer.getProxyType())) {
             // For HTTPS proxy, we need special tunnel pipeline management
-            whenHandshaked = channelManager.updatePipelineForHttpsTunneling(channel.pipeline(), requestUri, proxyServer,
-                    partitionKey);
+            whenHandshaked = channelManager.updatePipelineForHttpsTunneling(channel.pipeline(), requestUri, proxyServer);
         } else {
             // Standard HTTP proxy or SOCKS proxy tunneling
-            whenHandshaked = channelManager.updatePipelineForHttpTunneling(channel.pipeline(), requestUri, partitionKey);
+            whenHandshaked = channelManager.updatePipelineForHttpTunneling(channel.pipeline(), requestUri);
         }
         
         future.setReuseChannel(true);

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ConnectSuccessInterceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/ConnectSuccessInterceptor.java
@@ -55,14 +55,16 @@ public class ConnectSuccessInterceptor {
         LOGGER.debug("Connecting to proxy {} for scheme {}", proxyServer, requestUri.getScheme());
         
         final Future<Channel> whenHandshaked;
+        Object partitionKey = future.getPartitionKey();
         
         // Special handling for HTTPS proxy tunneling
         if (proxyServer != null && ProxyType.HTTPS.equals(proxyServer.getProxyType())) {
             // For HTTPS proxy, we need special tunnel pipeline management
-            whenHandshaked = channelManager.updatePipelineForHttpsTunneling(channel.pipeline(), requestUri, proxyServer);
+            whenHandshaked = channelManager.updatePipelineForHttpsTunneling(channel.pipeline(), requestUri, proxyServer,
+                    partitionKey);
         } else {
             // Standard HTTP proxy or SOCKS proxy tunneling
-            whenHandshaked = channelManager.updatePipelineForHttpTunneling(channel.pipeline(), requestUri);
+            whenHandshaked = channelManager.updatePipelineForHttpTunneling(channel.pipeline(), requestUri, partitionKey);
         }
         
         future.setReuseChannel(true);

--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
@@ -1289,6 +1289,10 @@ public final class NettyRequestSender {
             public void call() {
                 whenHandshaked.addListener(f -> {
                             if (f.isSuccess()) {
+                                if (!nextRequest.getUri().isWebSocket()) {
+                                    channelManager.upgradePipelineToHttp2AfterProxyConnect(
+                                            channel.pipeline(), future.getPartitionKey());
+                                }
                                 sendNextRequest(nextRequest, future);
                             } else {
                                 future.abort(f.cause());

--- a/client/src/test/java/org/asynchttpclient/BasicHttp2Test.java
+++ b/client/src/test/java/org/asynchttpclient/BasicHttp2Test.java
@@ -48,6 +48,8 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.pkitesting.CertificateBuilder;
 import io.netty.pkitesting.X509Bundle;
 import io.netty.util.concurrent.GlobalEventExecutor;
+import org.asynchttpclient.proxy.ProxyServer;
+import org.asynchttpclient.proxy.ProxyType;
 import org.asynchttpclient.test.EventCollectingHandler;
 import org.eclipse.jetty.proxy.ConnectHandler;
 import org.eclipse.jetty.server.Server;
@@ -86,6 +88,7 @@ import static org.asynchttpclient.Dsl.config;
 import static org.asynchttpclient.Dsl.proxyServer;
 import static org.asynchttpclient.test.TestUtils.AsyncCompletionHandlerAdapter;
 import static org.asynchttpclient.test.TestUtils.addHttpConnector;
+import static org.asynchttpclient.test.TestUtils.addHttpsConnector;
 import static org.asynchttpclient.util.DateUtils.unpreciseMillisTime;
 import static org.asynchttpclient.util.ThrowableUtil.unknownStackTrace;
 import static org.junit.jupiter.api.Assertions.*;
@@ -436,21 +439,44 @@ public class BasicHttp2Test {
     }
 
     @Test
-    public void httpsRequestThroughHttpProxyNegotiatesHttp2AfterConnect() throws Exception {
+    public void httpsRequestsThroughHttpProxyNegotiateAndReuseHttp2AfterConnect() throws Exception {
+        assertHttpsRequestsThroughProxyNegotiateAndReuseHttp2AfterConnect(false);
+    }
+
+    @Test
+    public void httpsRequestsThroughHttpsProxyNegotiateAndReuseHttp2AfterConnect() throws Exception {
+        assertHttpsRequestsThroughProxyNegotiateAndReuseHttp2AfterConnect(true);
+    }
+
+    private void assertHttpsRequestsThroughProxyNegotiateAndReuseHttp2AfterConnect(boolean secureProxy) throws Exception {
         Server proxy = new Server();
-        ServerConnector proxyConnector = addHttpConnector(proxy);
+        ServerConnector proxyConnector = secureProxy ? addHttpsConnector(proxy) : addHttpConnector(proxy);
         proxy.setHandler(new ConnectHandler());
         proxy.start();
 
         try (AsyncHttpClient client = http2Client()) {
-            Response response = client.prepareGet(httpsUrl("/hello"))
-                    .setProxyServer(proxyServer("127.0.0.1", proxyConnector.getLocalPort()).build())
+            ProxyServer.Builder proxyBuilder = proxyServer("127.0.0.1", proxyConnector.getLocalPort());
+            if (secureProxy) {
+                proxyBuilder.setProxyType(ProxyType.HTTPS);
+            }
+            ProxyServer proxyServer = proxyBuilder.build();
+            Response firstResponse = client.prepareGet(httpsUrl("/hello"))
+                    .setProxyServer(proxyServer)
+                    .execute()
+                    .get(30, SECONDS);
+            Response secondResponse = client.prepareGet(httpsUrl("/hello"))
+                    .setProxyServer(proxyServer)
                     .execute()
                     .get(30, SECONDS);
 
-            assertNotNull(response);
-            assertEquals(200, response.getStatusCode());
-            assertEquals(HttpProtocol.HTTP_2, response.getProtocol());
+            assertNotNull(firstResponse);
+            assertEquals(200, firstResponse.getStatusCode());
+            assertEquals(HttpProtocol.HTTP_2, firstResponse.getProtocol());
+            assertNotNull(secondResponse);
+            assertEquals(200, secondResponse.getStatusCode());
+            assertEquals(HttpProtocol.HTTP_2, secondResponse.getProtocol());
+            assertEquals(1, serverChildChannels.size(),
+                    "the HTTP/2 tunnel connection should be registered and reused");
         } finally {
             proxy.stop();
         }

--- a/client/src/test/java/org/asynchttpclient/BasicHttp2Test.java
+++ b/client/src/test/java/org/asynchttpclient/BasicHttp2Test.java
@@ -49,6 +49,9 @@ import io.netty.pkitesting.CertificateBuilder;
 import io.netty.pkitesting.X509Bundle;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import org.asynchttpclient.test.EventCollectingHandler;
+import org.eclipse.jetty.proxy.ConnectHandler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -80,7 +83,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.asynchttpclient.Dsl.asyncHttpClient;
 import static org.asynchttpclient.Dsl.config;
+import static org.asynchttpclient.Dsl.proxyServer;
 import static org.asynchttpclient.test.TestUtils.AsyncCompletionHandlerAdapter;
+import static org.asynchttpclient.test.TestUtils.addHttpConnector;
 import static org.asynchttpclient.util.DateUtils.unpreciseMillisTime;
 import static org.asynchttpclient.util.ThrowableUtil.unknownStackTrace;
 import static org.junit.jupiter.api.Assertions.*;
@@ -428,6 +433,27 @@ public class BasicHttp2Test {
                 .setHttp2Enabled(true);
         customizer.accept(builder);
         return asyncHttpClient(builder);
+    }
+
+    @Test
+    public void httpsRequestThroughHttpProxyNegotiatesHttp2AfterConnect() throws Exception {
+        Server proxy = new Server();
+        ServerConnector proxyConnector = addHttpConnector(proxy);
+        proxy.setHandler(new ConnectHandler());
+        proxy.start();
+
+        try (AsyncHttpClient client = http2Client()) {
+            Response response = client.prepareGet(httpsUrl("/hello"))
+                    .setProxyServer(proxyServer("127.0.0.1", proxyConnector.getLocalPort()).build())
+                    .execute()
+                    .get(30, SECONDS);
+
+            assertNotNull(response);
+            assertEquals(200, response.getStatusCode());
+            assertEquals(HttpProtocol.HTTP_2, response.getProtocol());
+        } finally {
+            proxy.stop();
+        }
     }
 
     /**

--- a/client/src/test/java/org/asynchttpclient/BasicHttp2Test.java
+++ b/client/src/test/java/org/asynchttpclient/BasicHttp2Test.java
@@ -452,31 +452,33 @@ public class BasicHttp2Test {
         Server proxy = new Server();
         ServerConnector proxyConnector = secureProxy ? addHttpsConnector(proxy) : addHttpConnector(proxy);
         proxy.setHandler(new ConnectHandler());
-        proxy.start();
 
-        try (AsyncHttpClient client = http2Client()) {
-            ProxyServer.Builder proxyBuilder = proxyServer("127.0.0.1", proxyConnector.getLocalPort());
-            if (secureProxy) {
-                proxyBuilder.setProxyType(ProxyType.HTTPS);
+        try {
+            proxy.start();
+            try (AsyncHttpClient client = http2Client()) {
+                ProxyServer.Builder proxyBuilder = proxyServer("127.0.0.1", proxyConnector.getLocalPort());
+                if (secureProxy) {
+                    proxyBuilder.setProxyType(ProxyType.HTTPS);
+                }
+                ProxyServer proxyServer = proxyBuilder.build();
+                Response firstResponse = client.prepareGet(httpsUrl("/hello"))
+                        .setProxyServer(proxyServer)
+                        .execute()
+                        .get(30, SECONDS);
+                Response secondResponse = client.prepareGet(httpsUrl("/hello"))
+                        .setProxyServer(proxyServer)
+                        .execute()
+                        .get(30, SECONDS);
+
+                assertNotNull(firstResponse);
+                assertEquals(200, firstResponse.getStatusCode());
+                assertEquals(HttpProtocol.HTTP_2, firstResponse.getProtocol());
+                assertNotNull(secondResponse);
+                assertEquals(200, secondResponse.getStatusCode());
+                assertEquals(HttpProtocol.HTTP_2, secondResponse.getProtocol());
+                assertEquals(1, serverChildChannels.size(),
+                        "the HTTP/2 tunnel connection should be registered and reused");
             }
-            ProxyServer proxyServer = proxyBuilder.build();
-            Response firstResponse = client.prepareGet(httpsUrl("/hello"))
-                    .setProxyServer(proxyServer)
-                    .execute()
-                    .get(30, SECONDS);
-            Response secondResponse = client.prepareGet(httpsUrl("/hello"))
-                    .setProxyServer(proxyServer)
-                    .execute()
-                    .get(30, SECONDS);
-
-            assertNotNull(firstResponse);
-            assertEquals(200, firstResponse.getStatusCode());
-            assertEquals(HttpProtocol.HTTP_2, firstResponse.getProtocol());
-            assertNotNull(secondResponse);
-            assertEquals(200, secondResponse.getStatusCode());
-            assertEquals(HttpProtocol.HTTP_2, secondResponse.getProtocol());
-            assertEquals(1, serverChildChannels.size(),
-                    "the HTTP/2 tunnel connection should be registered and reused");
         } finally {
             proxy.stop();
         }

--- a/client/src/test/java/org/asynchttpclient/proxy/HttpsProxyTestcontainersIntegrationTest.java
+++ b/client/src/test/java/org/asynchttpclient/proxy/HttpsProxyTestcontainersIntegrationTest.java
@@ -146,8 +146,6 @@ public class HttpsProxyTestcontainersIntegrationTest {
                         .setProxyType(ProxyType.HTTP)
                         .build())
                 .setUseInsecureTrustManager(true)
-                // HTTP/2 ALPN upgrade after proxy CONNECT tunnel is not yet supported
-                .setHttp2Enabled(false)
                 .setConnectTimeout(Duration.ofMillis(10000))
                 .setRequestTimeout(Duration.ofMillis(30000))
                 .build();
@@ -169,8 +167,6 @@ public class HttpsProxyTestcontainersIntegrationTest {
                         .setProxyType(ProxyType.HTTPS)
                         .build())
                 .setUseInsecureTrustManager(true)
-                // HTTP/2 ALPN upgrade after proxy CONNECT tunnel is not yet supported
-                .setHttp2Enabled(false)
                 .setConnectTimeout(Duration.ofMillis(10000))
                 .setRequestTimeout(Duration.ofMillis(30000))
                 .build();


### PR DESCRIPTION
## Motivation

When an HTTPS request uses an HTTP proxy, AHC establishes a `CONNECT` tunnel and then performs TLS with the target. If ALPN selects `h2`, the tunnel path currently leaves the HTTP/1.1 codec in place. The target then receives HTTP/1.1 bytes on a connection that negotiated HTTP/2 and closes it.

## Modification

- Check the negotiated ALPN protocol after the target TLS handshake in both proxy tunnel paths.
- When ALPN selects `h2`, upgrade the existing channel pipeline to HTTP/2 and register the physical tunnel connection with its existing pool partition key.
- Preserve the existing HTTP/1.1 fallback and WebSocket behavior.
- Add regression tests using local HTTP and HTTPS `CONNECT` proxies with a TLS HTTP/2 target.
- Verify that the upgraded tunnel is registered and reused for a second request.
- Preserve the existing public tunneling method signatures for binary compatibility.

## Result

HTTPS requests through HTTP and HTTPS `CONNECT` proxies now send HTTP/2 frames when the target negotiates `h2`. The regression tests verify successful HTTP/2 responses and reuse of a single physical target connection.

## Testing

- `./mvnw -pl client -Dtest=BasicHttp2Test,HttpsProxyTest test` — 60 tests passed.
- Full client test suite passed as part of `verify`; the local run then stopped at artifact signing because `gpg` is not installed.
- `./mvnw -pl client -DskipTests -Dgpg.skip=true verify` — packaging and API compatibility checks passed.

Fixes #2241 
