### PR TITLE
Fail fast on empty round-robin address resolution

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
@@ -89,6 +89,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
@@ -486,6 +487,13 @@ public final class NettyRequestSender {
         // new-connection path, before connecting.
         List<InetSocketAddress> roundRobinAddresses = future.getRoundRobinAddresses();
         if (roundRobinAddresses != null) {
+            // A misbehaving custom NameResolver can complete resolution successfully with an empty list; fail
+            // fast with a clear cause instead of throwing IndexOutOfBoundsException on get(0) below, which the
+            // resolve listener would swallow and leave the request hanging with no timeout scheduled.
+            if (roundRobinAddresses.isEmpty()) {
+                abort(null, future, new UnknownHostException("No addresses resolved for " + request.getUri().getHost()));
+                return future;
+            }
             scheduleRequestTimeout(future, roundRobinAddresses.get(0));
             connectWithAddresses(request, proxy, future, asyncHandler, roundRobinAddresses);
             return future;

--- a/client/src/test/java/org/asynchttpclient/RoundRobinSendTypeTest.java
+++ b/client/src/test/java/org/asynchttpclient/RoundRobinSendTypeTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.TestInstance;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -95,6 +96,21 @@ public class RoundRobinSendTypeTest {
             @Override
             protected void doResolveAll(String inetHost, Promise<List<InetAddress>> promise) {
                 promise.setSuccess(new ArrayList<>(addresses));
+            }
+        };
+    }
+
+    // A misbehaving resolver that reports success but yields no addresses.
+    private static NameResolver<InetAddress> emptyResolver() {
+        return new InetNameResolver(ImmediateEventExecutor.INSTANCE) {
+            @Override
+            protected void doResolve(String inetHost, Promise<InetAddress> promise) {
+                promise.setFailure(new UnknownHostException(inetHost));
+            }
+
+            @Override
+            protected void doResolveAll(String inetHost, Promise<List<InetAddress>> promise) {
+                promise.setSuccess(new ArrayList<>());
             }
         };
     }
@@ -289,6 +305,23 @@ public class RoundRobinSendTypeTest {
             }
         } finally {
             localServer.stop();
+        }
+    }
+
+    @Test
+    public void roundRobinEmptyResolutionFailsFast() throws Exception {
+        // Regression guard: a resolver that completes successfully but yields no addresses must make the
+        // round-robin request fail fast with UnknownHostException, not throw a swallowed
+        // IndexOutOfBoundsException on roundRobinAddresses.get(0) and hang with no timeout scheduled.
+        NameResolver<InetAddress> resolver = emptyResolver();
+        try (AsyncHttpClient client = asyncHttpClient(config()
+                .setLoadBalance(LoadBalance.ROUND_ROBIN)
+                .setMaxRequestRetry(0).build())) {
+            ExecutionException thrown = assertThrows(ExecutionException.class, () ->
+                    client.executeRequest(get("http://roundrobin.test:" + port + "/").setNameResolver(resolver))
+                            .get(TIMEOUT, SECONDS));
+            assertInstanceOf(UnknownHostException.class, thrown.getCause(),
+                    "empty round-robin resolution must fail fast with UnknownHostException; got " + thrown.getCause());
         }
     }
 


### PR DESCRIPTION
Motivation:

PR #2229 changed round-robin mode to schedule the request timeout only once. As part of that change, the new-connection path assumes a successful DNS resolution always returns at least one address and unconditionally accesses the first entry. If a custom `NameResolver` incorrectly reports success with an empty address list, this results in an `IndexOutOfBoundsException` that is swallowed by Netty, leaving the request future incomplete and no request timeout scheduled. The request then hangs until the caller's own timeout expires.

Modification:

Guard the round-robin new-connection path against an empty resolved address list. If resolution succeeds with no addresses, fail the request immediately with an `UnknownHostException` containing the requested host instead of indexing into the list. Add a test covering a custom resolver that returns an empty successful result and verify the request fails fast instead of hanging.

Result:

Round-robin requests now fail fast with a clear `UnknownHostException` when a resolver returns an empty address list, avoiding a swallowed exception and a hung request. Existing behavior for valid resolvers and `DEFAULT` mode is unchanged.
