### PR TITLE
Document that BodyState.STOP may carry the final bytes

### DIFF
--- a/client/src/main/java/org/asynchttpclient/request/body/Body.java
+++ b/client/src/main/java/org/asynchttpclient/request/body/Body.java
@@ -31,6 +31,10 @@ public interface Body extends Closeable {
 
     /**
      * Reads the next chunk of bytes from the body.
+     * <p>
+     * A {@link BodyState#STOP} result may be returned by the same call that writes the body's last bytes, so
+     * {@code target} can still hold unread bytes on STOP. Consumers must drain {@code target} before honouring
+     * STOP, otherwise the final chunk is lost.
      *
      * @param target The buffer to store the chunk in, must not be {@code null}.
      * @return The state.
@@ -51,7 +55,8 @@ public interface Body extends Closeable {
         SUSPEND,
 
         /**
-         * There's nothing to read and input has to stop
+         * Input has to stop. This is the last chunk; {@code target} may still carry unread bytes that the
+         * consumer must send before stopping (see {@link Body#transferTo(ByteBuf)}).
          */
         STOP
     }

--- a/client/src/main/java/org/asynchttpclient/util/AuthenticatorUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/AuthenticatorUtils.java
@@ -464,6 +464,8 @@ public final class AuthenticatorUtils {
 
         try (Body body = gen.createBody()) {
             Body.BodyState state;
+            // Safe only because ByteArrayBodyGenerator returns STOP on an empty call; a body that returns
+            // STOP carrying its last bytes (e.g. MultipartBody) would be truncated here. See Body#transferTo.
             while ((state = body.transferTo(tmp)) != Body.BodyState.STOP) {
                 if (state == Body.BodyState.SUSPEND) {
                     continue;               // nothing new yet


### PR DESCRIPTION
Motivation:

PR #2232 changed `MultipartBody.transferTo()` to return `STOP` on the same call that writes the body's final bytes, meaning `STOP` may still be accompanied by unread data in the target buffer. However, `BodyState.STOP` is currently documented as meaning "nothing to read," and `AuthenticatorUtils`'s `auth-int` loop assumes this behavior, which would truncate such a body (currently unreachable because multipart bodies do not use this path).

Modification:

Update the `Body.transferTo()` and `BodyState.STOP` documentation to clarify that `STOP` may accompany the final bytes and that consumers must drain the target buffer before stopping. Add a comment in the `auth-int` loop documenting its assumption.

Result:

The `STOP`-with-data contract is explicitly documented, and the existing assumption in `AuthenticatorUtils` is clearly identified. Documentation only; no behavioral changes.