### PR TITLE
Mark the round-robin RotatedView RandomAccess and cover its bounds check

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/channel/RoundRobinAddressSelector.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/RoundRobinAddressSelector.java
@@ -18,6 +18,7 @@ package org.asynchttpclient.netty.channel;
 import java.net.InetSocketAddress;
 import java.util.AbstractList;
 import java.util.List;
+import java.util.RandomAccess;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -89,7 +90,8 @@ public final class RoundRobinAddressSelector {
         return new RotatedView(resolved, index);
     }
 
-    private static final class RotatedView extends AbstractList<InetSocketAddress> {
+    // RandomAccess: get(i) is O(1), like the ArrayList this view replaces.
+    private static final class RotatedView extends AbstractList<InetSocketAddress> implements RandomAccess {
 
         private final List<InetSocketAddress> resolved;
         private final int index;

--- a/client/src/test/java/org/asynchttpclient/netty/channel/RoundRobinAddressSelectorTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/channel/RoundRobinAddressSelectorTest.java
@@ -105,6 +105,16 @@ class RoundRobinAddressSelectorTest {
     }
 
     @Test
+    void rotatedViewRejectsOutOfBoundsAccess() {
+        RoundRobinAddressSelector selector = new RoundRobinAddressSelector();
+        List<InetSocketAddress> input = Arrays.asList(addr("127.0.0.1"), addr("127.0.0.2"), addr("127.0.0.3"));
+        selector.rotate("h", input);                          // index 0, returns input as-is
+        List<InetSocketAddress> rotated = selector.rotate("h", input); // index 1, a real rotation
+        assertThrows(IndexOutOfBoundsException.class, () -> rotated.get(input.size()));
+        assertThrows(IndexOutOfBoundsException.class, () -> rotated.get(-1));
+    }
+
+    @Test
     void singleAddressReturnedUnchanged() {
         RoundRobinAddressSelector selector = new RoundRobinAddressSelector();
         List<InetSocketAddress> input = Collections.singletonList(addr("127.0.0.1"));


### PR DESCRIPTION
Motivation:

#2230 replaced the per-request rotation copy in `RoundRobinAddressSelector` with a lightweight read-only `RotatedView`. Two follow-ups remained: the new view no longer implemented `RandomAccess`, causing consumers that optimize for indexed access to fall back to iterator-based traversal, and its bounds-checking behavior was not covered by tests.

Modification:

Make `RotatedView` implement `RandomAccess` and add a `rotatedViewRejectsOutOfBoundsAccess` test to verify that `get(size)` and `get(-1)` throw `IndexOutOfBoundsException`.

Result:

`RotatedView` now preserves the `RandomAccess` contract of the `ArrayList` it replaced, allowing consumers to retain indexed fast paths, and its bounds-checking behavior is protected by regression tests.
