### PR TITLE
Avoid unused promise allocation in address resolution

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
@@ -564,7 +564,6 @@ public final class NettyRequestSender {
     private <T> Future<List<InetSocketAddress>> resolveAddresses(Request request, ProxyServer proxy, NettyResponseFuture<T> future,
                                                                  AsyncHandler<T> asyncHandler, boolean scheduleTimeout) {
         Uri uri = request.getUri();
-        final Promise<List<InetSocketAddress>> promise = ImmediateEventExecutor.INSTANCE.newPromise();
 
         if (proxy != null && !proxy.isIgnoredForHost(uri.getHost()) && proxy.getProxyType().isHttp()) {
             int port = ProxyType.HTTPS.equals(proxy.getProxyType()) || uri.isSecured() ? proxy.getSecuredPort() : proxy.getPort();
@@ -584,6 +583,7 @@ public final class NettyRequestSender {
             if (request.getAddress() != null) {
                 // bypass resolution
                 InetSocketAddress inetSocketAddress = new InetSocketAddress(request.getAddress(), port);
+                Promise<List<InetSocketAddress>> promise = ImmediateEventExecutor.INSTANCE.newPromise();
                 return promise.setSuccess(singletonList(inetSocketAddress));
             }
             return resolveHostname(request, unresolvedRemoteAddress, asyncHandler);


### PR DESCRIPTION
### Summary
- Move promise creation in `NettyRequestSender.resolveAddresses` into the explicit-address bypass branch.
- Avoid allocating a completed promise on hostname and proxy resolution paths that return `resolveHostname(...)` instead.

### Motivation
Most requests resolve by hostname and do not use the local `Promise` created at the start of `resolveAddresses`. Deferring the allocation keeps the explicit-address behavior unchanged while reducing per-request allocation on the common path.

### Validation
- `./mvnw -pl client -DskipTests compile`
- `./mvnw -pl client -Dtest=CustomRemoteAddressTest test`

## Attribution
Codex on behalf of Pavel Ptashyts