### PR TITLE
Avoid boxed redirect status lookup

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Interceptors.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Interceptors.java
@@ -125,7 +125,7 @@ public class Interceptors {
             return continue100Interceptor.exitAfterHandling100(channel, future);
         }
 
-        if (Redirect30xInterceptor.REDIRECT_STATUSES.contains(statusCode)) {
+        if (Redirect30xInterceptor.isRedirectStatus(statusCode)) {
             return redirect30xInterceptor.exitAfterHandlingRedirect(channel, future, response, request, statusCode, realm);
         }
 

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Redirect30xInterceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Redirect30xInterceptor.java
@@ -35,9 +35,6 @@ import org.asynchttpclient.uri.Uri;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import static io.netty.handler.codec.http.HttpHeaderNames.AUTHORIZATION;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
@@ -59,16 +56,7 @@ import static org.asynchttpclient.util.ThrowableUtil.unknownStackTrace;
 
 public class Redirect30xInterceptor {
 
-    public static final Set<Integer> REDIRECT_STATUSES = new HashSet<>();
     private static final Logger LOGGER = LoggerFactory.getLogger(Redirect30xInterceptor.class);
-
-    static {
-        REDIRECT_STATUSES.add(MOVED_PERMANENTLY_301);
-        REDIRECT_STATUSES.add(FOUND_302);
-        REDIRECT_STATUSES.add(SEE_OTHER_303);
-        REDIRECT_STATUSES.add(TEMPORARY_REDIRECT_307);
-        REDIRECT_STATUSES.add(PERMANENT_REDIRECT_308);
-    }
 
     private final ChannelManager channelManager;
     private final AsyncHttpClientConfig config;
@@ -201,6 +189,14 @@ public class Redirect30xInterceptor {
             }
         }
         return false;
+    }
+
+    static boolean isRedirectStatus(int statusCode) {
+        return statusCode == MOVED_PERMANENTLY_301 ||
+                statusCode == FOUND_302 ||
+                statusCode == SEE_OTHER_303 ||
+                statusCode == TEMPORARY_REDIRECT_307 ||
+                statusCode == PERMANENT_REDIRECT_308;
     }
 
     private static HttpHeaders propagatedHeaders(Request request, Realm realm, boolean keepBody, boolean stripAuthorization) {

--- a/client/src/test/java/org/asynchttpclient/netty/handler/intercept/Redirect30xInterceptorTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/handler/intercept/Redirect30xInterceptorTest.java
@@ -1,0 +1,35 @@
+/*
+ *    Copyright (c) 2026 AsyncHttpClient Project. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.asynchttpclient.netty.handler.intercept;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Redirect30xInterceptorTest {
+
+    @Test
+    public void primitiveRedirectStatusCheckMatchesRedirectStatuses() {
+        for (int statusCode : new int[]{301, 302, 303, 307, 308}) {
+            assertTrue(Redirect30xInterceptor.isRedirectStatus(statusCode), "status " + statusCode);
+        }
+
+        for (int statusCode : new int[]{100, 200, 300, 304, 305, 306, 309, 400, 500}) {
+            assertFalse(Redirect30xInterceptor.isRedirectStatus(statusCode), "status " + statusCode);
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- Replace the redirect status `Set<Integer>` lookup with a primitive status-code helper.
- Remove `Redirect30xInterceptor.REDIRECT_STATUSES`.
- Use the helper from the response interceptor hot path before redirect handling.
- Add unit coverage for redirect and non-redirect status codes.

### Motivation
The response interceptor checks redirect status codes for every response. The previous `Set<Integer>` lookup boxed each response status code before lookup. A primitive comparison helper keeps the redirect behavior unchanged while avoiding that allocation.

### Validation
- `/opt/maven/bin/mvn -pl client -DskipTests compile`
- `/opt/maven/bin/mvn -pl client -Dtest=Redirect30xInterceptorTest,Relative302Test test`