### PR TITLE
Short-circuit empty cookie store lookups

### DIFF
--- a/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
+++ b/client/src/main/java/org/asynchttpclient/cookie/ThreadSafeCookieStore.java
@@ -63,6 +63,10 @@ public final class ThreadSafeCookieStore implements CookieStore {
 
     @Override
     public List<Cookie> get(Uri uri) {
+        requireNonNull(uri, "uri");
+        if (cookieJar.isEmpty()) {
+            return Collections.emptyList();
+        }
         return get(requestDomain(uri), requestPath(uri), uri.isSecured());
     }
 

--- a/client/src/test/java/org/asynchttpclient/cookie/ThreadSafeCookieStoreGetTest.java
+++ b/client/src/test/java/org/asynchttpclient/cookie/ThreadSafeCookieStoreGetTest.java
@@ -113,6 +113,13 @@ public class ThreadSafeCookieStoreGetTest {
     }
 
     @Test
+    public void returnsEmptyForEmptyStore() {
+        ThreadSafeCookieStore store = new ThreadSafeCookieStore();
+
+        assertTrue(store.get(Uri.create("http://www.foo.com/")).isEmpty());
+    }
+
+    @Test
     public void perDomainCookieCountIsCappedUnderFlood() {
         ThreadSafeCookieStore store = new ThreadSafeCookieStore();
         Uri uri = Uri.create("http://www.foo.com/");


### PR DESCRIPTION
### Summary
- Return an empty cookie list immediately when `ThreadSafeCookieStore` has no retained cookies.
- Keep null handling explicit with `requireNonNull(uri, "uri")` before the shortcut.
- Add coverage for `get(Uri)` on an empty store.

### Motivation
The default cookie store is consulted for each request. When no cookies have been stored, the lookup does not need to normalize the request host, derive the request path, or scan subdomains.

### Validation
- `/opt/maven/bin/mvn -pl client -DskipTests compile`
- `/opt/maven/bin/mvn -pl client -Dtest=ThreadSafeCookieStoreGetTest test`