### PR TITLE
Skip empty channel pool partitions during reap

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/channel/DefaultChannelPool.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/DefaultChannelPool.java
@@ -362,6 +362,10 @@ public final class DefaultChannelPool implements ChannelPool {
                     totalCount += partition.size();
                 }
 
+                if (partition.isEmpty()) {
+                    continue;
+                }
+
                 closedCount += reapPartition(partition, start);
             }
 


### PR DESCRIPTION
## Summary
- skip idle-reaper scans for channel pool partition deques that are already empty
- keep existing debug accounting and non-empty partition reap behavior unchanged

## Verification
- ./mvnw -pl client -DskipTests compile
- ./mvnw -pl client -Dtest=DefaultChannelPoolTest test

## Attribution
Codex on behalf of Pavel Ptashyts