### PR TITLE
Batch HTTP/2 upload flushes and prevent duplicate endStream

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/request/body/Http2BodyWriter.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/body/Http2BodyWriter.java
@@ -124,6 +124,11 @@ final class Http2BodyWriter {
     private ByteBuf pending;
     private boolean done;
 
+    // flush() can synchronously fire channelWritabilityChanged. Prevent that callback from re-entering the
+    // pump, and prevent later callbacks from writing a second endStream frame before the first one completes.
+    private boolean pumping;
+    private boolean terminalWritePending;
+
     // Transient handler that resumes the pump when the channel becomes writable again. Added lazily the
     // first time the pump parks, removed by finish().
     private WritabilityResumeHandler resumeHandler;
@@ -181,9 +186,10 @@ final class Http2BodyWriter {
      * event loop. Any written frames are flushed before the pump parks or completes.
      */
     private void pump() {
-        if (done) {
+        if (done || pumping || terminalWritePending) {
             return;
         }
+        pumping = true;
         try {
             while (true) {
                 if (done) {
@@ -211,6 +217,7 @@ final class Http2BodyWriter {
                     ByteBuf terminal = last != null ? last
                             // Empty body — preserve existing behaviour: a single empty DATA frame ends the stream.
                             : channel.alloc().buffer(0);
+                    terminalWritePending = true;
                     writeLastFrame(terminal);
                     channel.flush();
                     return;
@@ -238,6 +245,8 @@ final class Http2BodyWriter {
             }
         } catch (Throwable t) {
             finish(t);
+        } finally {
+            pumping = false;
         }
     }
 
@@ -314,7 +323,7 @@ final class Http2BodyWriter {
     private final class WritabilityResumeHandler extends ChannelInboundHandlerAdapter {
         @Override
         public void channelWritabilityChanged(ChannelHandlerContext ctx) {
-            if (!done && ctx.channel().isWritable()) {
+            if (!done && !terminalWritePending && ctx.channel().isWritable()) {
                 pump();
             }
             ctx.fireChannelWritabilityChanged();

--- a/client/src/main/java/org/asynchttpclient/netty/request/body/Http2BodyWriter.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/body/Http2BodyWriter.java
@@ -38,8 +38,9 @@ import java.io.IOException;
  * <p>
  * This writer is a one-chunk-at-a-time pump driven entirely on the stream channel's event loop:
  * <ul>
- *   <li>It produces and writes exactly one chunk, then flushes, so frames actually leave the process
- *       instead of accumulating.</li>
+ *   <li>It writes chunks while the stream remains writable, flushing when the pump yields for flow control,
+ *       a source suspension, or the terminal DATA frame, so frames leave the process without one flush per
+ *       chunk.</li>
  *   <li>It only produces the next chunk while {@link Http2StreamChannel#isWritable()} is {@code true}.
  *       A stream child channel becomes unwritable when the HTTP/2 flow-control window is exhausted or
  *       the local high-water mark is reached (child writes go through {@code incrementPendingOutboundBytes}).
@@ -176,7 +177,8 @@ final class Http2BodyWriter {
 
     /**
      * Produces and writes chunks until the channel goes unwritable (then parks for
-     * {@code channelWritabilityChanged}) or the body is exhausted. Always runs on the event loop.
+     * {@code channelWritabilityChanged}), the source suspends, or the body is exhausted. Always runs on the
+     * event loop. Any written frames are flushed before the pump parks or completes.
      */
     private void pump() {
         if (done) {
@@ -196,6 +198,7 @@ final class Http2BodyWriter {
                     // No data available yet but the body is not finished (feedable body). Park until the
                     // source signals more via the onResume callback. Any already-buffered `pending` chunk is
                     // retained (O(1)); we deliberately do not flush an early endStream.
+                    channel.flush();
                     suspended = true;
                     return;
                 }
@@ -219,9 +222,12 @@ final class Http2BodyWriter {
                 pending = next;
                 if (toWrite != null) {
                     writeFrame(toWrite, false);
-                    channel.flush();
 
                     if (!channel.isWritable()) {
+                        channel.flush();
+                        if (channel.isWritable()) {
+                            continue;
+                        }
                         // Flow-control window exhausted / high-water mark reached: stop producing and resume
                         // from channelWritabilityChanged. `pending` (one chunk) is retained until then.
                         ensureResumeHandler();

--- a/client/src/main/java/org/asynchttpclient/netty/request/body/Http2BodyWriter.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/body/Http2BodyWriter.java
@@ -50,8 +50,8 @@ import java.io.IOException;
  *       an empty body still sends a single empty DATA frame with {@code endStream=true}.</li>
  *   <li>This writer holds at most one buffered "pending" chunk across a writability wait. Production stops
  *       once the channel goes unwritable, so total in-flight heap is bounded by the channel's write
- *       high-water mark (the already-written chunks the channel's outbound buffer still owns) plus that one
- *       pending chunk — not by the size of the whole body.</li>
+ *       high-water mark (64 KiB by default; the already-written chunks the channel's outbound buffer still
+ *       owns) plus that one pending chunk, rather than by the size of the whole body.</li>
  * </ul>
  * <p>
  * <strong>Lifecycle / cleanup.</strong> Because the pump completes asynchronously (after {@code writeHttp2}
@@ -125,9 +125,10 @@ final class Http2BodyWriter {
     private boolean done;
 
     // flush() can synchronously fire channelWritabilityChanged. Prevent that callback from re-entering the
-    // pump, and prevent later callbacks from writing a second endStream frame before the first one completes.
+    // pump, and remember permanently once the terminal frame has been emitted so later callbacks cannot write
+    // a second endStream frame before its write completes.
     private boolean pumping;
-    private boolean terminalWritePending;
+    private boolean terminalWritten;
 
     // Transient handler that resumes the pump when the channel becomes writable again. Added lazily the
     // first time the pump parks, removed by finish().
@@ -186,7 +187,7 @@ final class Http2BodyWriter {
      * event loop. Any written frames are flushed before the pump parks or completes.
      */
     private void pump() {
-        if (done || pumping || terminalWritePending) {
+        if (done || pumping || terminalWritten) {
             return;
         }
         pumping = true;
@@ -204,8 +205,13 @@ final class Http2BodyWriter {
                     // No data available yet but the body is not finished (feedable body). Park until the
                     // source signals more via the onResume callback. Any already-buffered `pending` chunk is
                     // retained (O(1)); we deliberately do not flush an early endStream.
-                    channel.flush();
                     suspended = true;
+                    channel.flush();
+                    if (!suspended) {
+                        // A synchronous flush callback resumed the source while pump() was guarded against
+                        // re-entry. Consume that resume here instead of parking indefinitely.
+                        continue;
+                    }
                     return;
                 }
 
@@ -217,7 +223,7 @@ final class Http2BodyWriter {
                     ByteBuf terminal = last != null ? last
                             // Empty body — preserve existing behaviour: a single empty DATA frame ends the stream.
                             : channel.alloc().buffer(0);
-                    terminalWritePending = true;
+                    terminalWritten = true;
                     writeLastFrame(terminal);
                     channel.flush();
                     return;
@@ -323,7 +329,7 @@ final class Http2BodyWriter {
     private final class WritabilityResumeHandler extends ChannelInboundHandlerAdapter {
         @Override
         public void channelWritabilityChanged(ChannelHandlerContext ctx) {
-            if (!done && !terminalWritePending && ctx.channel().isWritable()) {
+            if (!done && !terminalWritten && ctx.channel().isWritable()) {
                 pump();
             }
             ctx.fireChannelWritabilityChanged();

--- a/client/src/test/java/org/asynchttpclient/netty/request/body/Http2BodyWriterTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/request/body/Http2BodyWriterTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2014-2026 AsyncHttpClient Project. All rights reserved.
+ *    Copyright (c) 2026 AsyncHttpClient Project. All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,6 +19,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http2.DefaultHttp2DataFrame;
@@ -28,8 +31,10 @@ import io.netty.util.concurrent.ImmediateEventExecutor;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -68,6 +73,76 @@ public class Http2BodyWriterTest {
         verify(channel, times(1)).flush();
     }
 
+    @Test
+    public void sourceSuspensionFlushesBeforeParking() {
+        Http2StreamChannel channel = mock(Http2StreamChannel.class);
+        EventLoop eventLoop = mock(EventLoop.class);
+        when(eventLoop.inEventLoop()).thenReturn(true);
+        when(channel.eventLoop()).thenReturn(eventLoop);
+        when(channel.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
+        when(channel.isWritable()).thenReturn(true);
+        when(channel.closeFuture()).thenReturn(new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE));
+        when(channel.write(any())).thenAnswer(invocation -> {
+            ReferenceCountUtil.release(invocation.getArgument(0));
+            return succeededFuture(channel);
+        });
+
+        SuspendingChunkSource source = new SuspendingChunkSource();
+        Http2BodyWriter.start(channel, source);
+
+        assertEquals(0, source.closed);
+        verify(channel, times(1)).write(any(DefaultHttp2DataFrame.class));
+        verify(channel, times(1)).flush();
+
+        source.finish();
+
+        assertEquals(1, source.closed);
+        verify(channel, times(2)).write(any(DefaultHttp2DataFrame.class));
+        verify(channel, times(2)).flush();
+    }
+
+    @Test
+    public void unwritableChannelFlushesAndResumesWhenWritable() throws Exception {
+        Http2StreamChannel channel = mock(Http2StreamChannel.class);
+        EventLoop eventLoop = mock(EventLoop.class);
+        ChannelPipeline pipeline = mock(ChannelPipeline.class);
+        ChannelHandlerContext pipelineContext = mock(ChannelHandlerContext.class);
+        AtomicReference<ChannelHandler> resumeHandler = new AtomicReference<>();
+        when(eventLoop.inEventLoop()).thenReturn(true);
+        when(channel.eventLoop()).thenReturn(eventLoop);
+        when(channel.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
+        when(channel.isWritable()).thenReturn(false, false, true);
+        when(channel.closeFuture()).thenReturn(new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE));
+        when(channel.pipeline()).thenReturn(pipeline);
+        when(pipeline.addLast(any(ChannelHandler.class))).thenAnswer(invocation -> {
+            resumeHandler.set(invocation.getArgument(0));
+            return pipeline;
+        });
+        when(pipeline.context(any(ChannelHandler.class))).thenReturn(pipelineContext);
+        when(channel.write(any())).thenAnswer(invocation -> {
+            ReferenceCountUtil.release(invocation.getArgument(0));
+            return succeededFuture(channel);
+        });
+
+        FixedChunkSource source = new FixedChunkSource(3);
+        Http2BodyWriter.start(channel, source);
+
+        assertEquals(0, source.closed);
+        assertNotNull(resumeHandler.get());
+        verify(channel, times(1)).write(any(DefaultHttp2DataFrame.class));
+        verify(channel, times(1)).flush();
+
+        ChannelHandlerContext eventContext = mock(ChannelHandlerContext.class);
+        when(eventContext.channel()).thenReturn(channel);
+        ((io.netty.channel.ChannelInboundHandlerAdapter) resumeHandler.get())
+                .channelWritabilityChanged(eventContext);
+
+        assertEquals(1, source.closed);
+        verify(channel, times(3)).write(any(DefaultHttp2DataFrame.class));
+        verify(channel, times(2)).flush();
+        verify(pipeline).remove(resumeHandler.get());
+    }
+
     private static ChannelFuture succeededFuture(Http2StreamChannel channel) {
         return new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE).setSuccess();
     }
@@ -87,6 +162,36 @@ public class Http2BodyWriterTest {
             }
             chunks--;
             return alloc.buffer(1).writeByte(chunks);
+        }
+
+        @Override
+        public void close() {
+            closed++;
+        }
+    }
+
+    private static final class SuspendingChunkSource implements Http2BodyWriter.ChunkSource {
+        private int state;
+        private int closed;
+        private Runnable resume;
+
+        @Override
+        public ByteBuf nextChunk(ByteBufAllocator alloc) {
+            if (state < 2) {
+                state++;
+                return alloc.buffer(1).writeByte(state);
+            }
+            return state == 2 ? Http2BodyWriter.SUSPEND : null;
+        }
+
+        @Override
+        public void onResume(Runnable resume) {
+            this.resume = resume;
+        }
+
+        void finish() {
+            state = 3;
+            resume.run();
         }
 
         @Override

--- a/client/src/test/java/org/asynchttpclient/netty/request/body/Http2BodyWriterTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/request/body/Http2BodyWriterTest.java
@@ -1,0 +1,97 @@
+/*
+ *    Copyright (c) 2014-2026 AsyncHttpClient Project. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.asynchttpclient.netty.request.body;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.EventLoop;
+import io.netty.handler.codec.http2.DefaultHttp2DataFrame;
+import io.netty.handler.codec.http2.Http2StreamChannel;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class Http2BodyWriterTest {
+
+    @Test
+    public void multiChunkBodyBatchesFlushUntilTerminalFrame() {
+        Http2StreamChannel channel = mock(Http2StreamChannel.class);
+        EventLoop eventLoop = mock(EventLoop.class);
+        when(eventLoop.inEventLoop()).thenReturn(true);
+        when(channel.eventLoop()).thenReturn(eventLoop);
+        when(channel.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
+        when(channel.isWritable()).thenReturn(true);
+        when(channel.closeFuture()).thenReturn(new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE));
+
+        AtomicInteger terminalFrames = new AtomicInteger();
+        when(channel.write(any())).thenAnswer(invocation -> {
+            Object msg = invocation.getArgument(0);
+            if (((DefaultHttp2DataFrame) msg).isEndStream()) {
+                terminalFrames.incrementAndGet();
+            }
+            ReferenceCountUtil.release(msg);
+            return succeededFuture(channel);
+        });
+
+        FixedChunkSource source = new FixedChunkSource(4);
+
+        Http2BodyWriter.start(channel, source);
+
+        assertEquals(1, source.closed);
+        assertEquals(1, terminalFrames.get());
+        verify(channel, times(4)).write(any(DefaultHttp2DataFrame.class));
+        verify(channel, times(1)).flush();
+    }
+
+    private static ChannelFuture succeededFuture(Http2StreamChannel channel) {
+        return new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE).setSuccess();
+    }
+
+    private static final class FixedChunkSource implements Http2BodyWriter.ChunkSource {
+        private int chunks;
+        private int closed;
+
+        FixedChunkSource(int chunks) {
+            this.chunks = chunks;
+        }
+
+        @Override
+        public ByteBuf nextChunk(ByteBufAllocator alloc) {
+            if (chunks == 0) {
+                return null;
+            }
+            chunks--;
+            return alloc.buffer(1).writeByte(chunks);
+        }
+
+        @Override
+        public void close() {
+            closed++;
+        }
+    }
+}

--- a/client/src/test/java/org/asynchttpclient/netty/request/body/Http2BodyWriterTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/request/body/Http2BodyWriterTest.java
@@ -30,6 +30,7 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -102,12 +103,16 @@ public class Http2BodyWriterTest {
     }
 
     @Test
-    public void unwritableChannelFlushesAndResumesWhenWritable() throws Exception {
+    public void unwritableChannelResumesWithoutReentrantTerminalWrite() throws Exception {
         Http2StreamChannel channel = mock(Http2StreamChannel.class);
         EventLoop eventLoop = mock(EventLoop.class);
         ChannelPipeline pipeline = mock(ChannelPipeline.class);
         ChannelHandlerContext pipelineContext = mock(ChannelHandlerContext.class);
+        ChannelHandlerContext eventContext = mock(ChannelHandlerContext.class);
         AtomicReference<ChannelHandler> resumeHandler = new AtomicReference<>();
+        AtomicBoolean nestedWritabilityCallbackFired = new AtomicBoolean();
+        AtomicInteger terminalFrames = new AtomicInteger();
+        DefaultChannelPromise terminalWrite = new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE);
         when(eventLoop.inEventLoop()).thenReturn(true);
         when(channel.eventLoop()).thenReturn(eventLoop);
         when(channel.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
@@ -119,9 +124,25 @@ public class Http2BodyWriterTest {
             return pipeline;
         });
         when(pipeline.context(any(ChannelHandler.class))).thenReturn(pipelineContext);
+        when(eventContext.channel()).thenReturn(channel);
         when(channel.write(any())).thenAnswer(invocation -> {
-            ReferenceCountUtil.release(invocation.getArgument(0));
+            DefaultHttp2DataFrame frame = invocation.getArgument(0);
+            if (frame.isEndStream()) {
+                terminalFrames.incrementAndGet();
+                ReferenceCountUtil.release(frame);
+                return terminalWrite;
+            }
+            ReferenceCountUtil.release(frame);
             return succeededFuture(channel);
+        });
+        when(channel.flush()).thenAnswer(invocation -> {
+            ChannelHandler handler = resumeHandler.get();
+            if (handler != null
+                    && terminalFrames.get() != 0
+                    && nestedWritabilityCallbackFired.compareAndSet(false, true)) {
+                ((io.netty.channel.ChannelInboundHandlerAdapter) handler).channelWritabilityChanged(eventContext);
+            }
+            return channel;
         });
 
         FixedChunkSource source = new FixedChunkSource(3);
@@ -132,10 +153,12 @@ public class Http2BodyWriterTest {
         verify(channel, times(1)).write(any(DefaultHttp2DataFrame.class));
         verify(channel, times(1)).flush();
 
-        ChannelHandlerContext eventContext = mock(ChannelHandlerContext.class);
-        when(eventContext.channel()).thenReturn(channel);
         ((io.netty.channel.ChannelInboundHandlerAdapter) resumeHandler.get())
                 .channelWritabilityChanged(eventContext);
+
+        assertEquals(0, source.closed);
+        assertEquals(1, terminalFrames.get());
+        terminalWrite.setSuccess();
 
         assertEquals(1, source.closed);
         verify(channel, times(3)).write(any(DefaultHttp2DataFrame.class));

--- a/client/src/test/java/org/asynchttpclient/netty/request/body/Http2BodyWriterTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/request/body/Http2BodyWriterTest.java
@@ -226,7 +226,7 @@ public class Http2BodyWriterTest {
             if (handler != null
                     && terminalFrames.get() != 0
                     && nestedWritabilityCallbackFired.compareAndSet(false, true)) {
-                ((io.netty.channel.ChannelInboundHandlerAdapter) handler).channelWritabilityChanged(eventContext);
+                ((ChannelInboundHandlerAdapter) handler).channelWritabilityChanged(eventContext);
             }
             return channel;
         });

--- a/client/src/test/java/org/asynchttpclient/netty/request/body/Http2BodyWriterTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/request/body/Http2BodyWriterTest.java
@@ -240,8 +240,7 @@ public class Http2BodyWriterTest {
         verify(channel, times(1)).flush();
 
         writable.set(true);
-        ((io.netty.channel.ChannelInboundHandlerAdapter) resumeHandler.get())
-                .channelWritabilityChanged(eventContext);
+        ((ChannelInboundHandlerAdapter) resumeHandler.get()).channelWritabilityChanged(eventContext);
 
         assertEquals(0, source.closed);
         assertEquals(1, terminalFrames.get());

--- a/client/src/test/java/org/asynchttpclient/netty/request/body/Http2BodyWriterTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/request/body/Http2BodyWriterTest.java
@@ -21,11 +21,22 @@ import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.EventLoop;
+import io.netty.channel.WriteBufferWaterMark;
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http2.DefaultHttp2DataFrame;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.DefaultHttp2HeadersFrame;
+import io.netty.handler.codec.http2.Http2DataFrame;
+import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
+import io.netty.handler.codec.http2.Http2MultiplexHandler;
 import io.netty.handler.codec.http2.Http2StreamChannel;
+import io.netty.handler.codec.http2.Http2StreamChannelBootstrap;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import org.junit.jupiter.api.Test;
@@ -36,6 +47,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -83,23 +95,96 @@ public class Http2BodyWriterTest {
         when(channel.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
         when(channel.isWritable()).thenReturn(true);
         when(channel.closeFuture()).thenReturn(new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE));
+        AtomicInteger flushes = new AtomicInteger();
         when(channel.write(any())).thenAnswer(invocation -> {
             ReferenceCountUtil.release(invocation.getArgument(0));
             return succeededFuture(channel);
         });
+        when(channel.flush()).thenAnswer(invocation -> {
+            flushes.incrementAndGet();
+            return channel;
+        });
 
-        SuspendingChunkSource source = new SuspendingChunkSource();
+        SuspendingChunkSource source = new SuspendingChunkSource(flushes);
         Http2BodyWriter.start(channel, source);
 
         assertEquals(0, source.closed);
+        assertEquals(0, source.flushesBeforeSuspend);
+        assertEquals(1, flushes.get());
         verify(channel, times(1)).write(any(DefaultHttp2DataFrame.class));
-        verify(channel, times(1)).flush();
 
         source.finish();
 
         assertEquals(1, source.closed);
         verify(channel, times(2)).write(any(DefaultHttp2DataFrame.class));
-        verify(channel, times(2)).flush();
+        assertEquals(2, flushes.get());
+    }
+
+    @Test
+    public void synchronousResumeDuringSuspensionFlushIsNotLost() {
+        Http2StreamChannel channel = mock(Http2StreamChannel.class);
+        EventLoop eventLoop = mock(EventLoop.class);
+        when(eventLoop.inEventLoop()).thenReturn(true);
+        when(channel.eventLoop()).thenReturn(eventLoop);
+        when(channel.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
+        when(channel.isWritable()).thenReturn(true);
+        when(channel.closeFuture()).thenReturn(new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE));
+        when(channel.write(any())).thenAnswer(invocation -> {
+            ReferenceCountUtil.release(invocation.getArgument(0));
+            return succeededFuture(channel);
+        });
+        AtomicInteger flushes = new AtomicInteger();
+        SuspendingChunkSource source = new SuspendingChunkSource(flushes);
+        when(channel.flush()).thenAnswer(invocation -> {
+            if (flushes.incrementAndGet() == 1) {
+                source.finish();
+            }
+            return channel;
+        });
+
+        Http2BodyWriter.start(channel, source);
+
+        assertEquals(1, source.closed);
+        assertEquals(2, flushes.get());
+        verify(channel, times(2)).write(any(DefaultHttp2DataFrame.class));
+    }
+
+    @Test
+    public void realStreamBoundsUnflushedBytesByWaterMark() {
+        UnflushedBytesTracker tracker = new UnflushedBytesTracker();
+        EmbeddedChannel parent = new EmbeddedChannel(
+                Http2FrameCodecBuilder.forClient().build(),
+                new Http2MultiplexHandler(new ChannelInboundHandlerAdapter()));
+        Http2StreamChannel stream = new Http2StreamChannelBootstrap(parent)
+                .handler(tracker)
+                .open()
+                .syncUninterruptibly()
+                .getNow();
+        int chunkSize = 1024;
+        int highWaterMark = 8 * 1024;
+        stream.config().setWriteBufferWaterMark(new WriteBufferWaterMark(highWaterMark / 2, highWaterMark));
+        FixedChunkSource source = new FixedChunkSource(highWaterMark / chunkSize * 2, chunkSize);
+
+        try {
+            stream.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers()
+                    .method("POST")
+                    .scheme("https")
+                    .authority("localhost")
+                    .path("/"))).syncUninterruptibly();
+
+            Http2BodyWriter.start(stream, source);
+            parent.runPendingTasks();
+
+            assertEquals(1, source.closed);
+            assertTrue(tracker.peakUnflushedBytes >= highWaterMark,
+                    "the real stream must reach its configured high-water mark");
+            assertTrue(tracker.peakUnflushedBytes <= highWaterMark + chunkSize,
+                    "unflushed DATA must stay within the high-water mark plus one chunk");
+        } finally {
+            stream.close().syncUninterruptibly();
+            parent.runPendingTasks();
+            parent.finishAndReleaseAll();
+        }
     }
 
     @Test
@@ -116,7 +201,8 @@ public class Http2BodyWriterTest {
         when(eventLoop.inEventLoop()).thenReturn(true);
         when(channel.eventLoop()).thenReturn(eventLoop);
         when(channel.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
-        when(channel.isWritable()).thenReturn(false, false, true);
+        AtomicBoolean writable = new AtomicBoolean();
+        when(channel.isWritable()).thenAnswer(invocation -> writable.get());
         when(channel.closeFuture()).thenReturn(new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE));
         when(channel.pipeline()).thenReturn(pipeline);
         when(pipeline.addLast(any(ChannelHandler.class))).thenAnswer(invocation -> {
@@ -153,6 +239,7 @@ public class Http2BodyWriterTest {
         verify(channel, times(1)).write(any(DefaultHttp2DataFrame.class));
         verify(channel, times(1)).flush();
 
+        writable.set(true);
         ((io.netty.channel.ChannelInboundHandlerAdapter) resumeHandler.get())
                 .channelWritabilityChanged(eventContext);
 
@@ -172,10 +259,16 @@ public class Http2BodyWriterTest {
 
     private static final class FixedChunkSource implements Http2BodyWriter.ChunkSource {
         private int chunks;
+        private final int chunkSize;
         private int closed;
 
         FixedChunkSource(int chunks) {
+            this(chunks, 1);
+        }
+
+        FixedChunkSource(int chunks, int chunkSize) {
             this.chunks = chunks;
+            this.chunkSize = chunkSize;
         }
 
         @Override
@@ -184,7 +277,7 @@ public class Http2BodyWriterTest {
                 return null;
             }
             chunks--;
-            return alloc.buffer(1).writeByte(chunks);
+            return alloc.buffer(chunkSize).writeZero(chunkSize);
         }
 
         @Override
@@ -194,9 +287,15 @@ public class Http2BodyWriterTest {
     }
 
     private static final class SuspendingChunkSource implements Http2BodyWriter.ChunkSource {
+        private final AtomicInteger flushes;
         private int state;
         private int closed;
+        private int flushesBeforeSuspend;
         private Runnable resume;
+
+        SuspendingChunkSource(AtomicInteger flushes) {
+            this.flushes = flushes;
+        }
 
         @Override
         public ByteBuf nextChunk(ByteBufAllocator alloc) {
@@ -204,7 +303,11 @@ public class Http2BodyWriterTest {
                 state++;
                 return alloc.buffer(1).writeByte(state);
             }
-            return state == 2 ? Http2BodyWriter.SUSPEND : null;
+            if (state == 2) {
+                flushesBeforeSuspend = flushes.get();
+                return Http2BodyWriter.SUSPEND;
+            }
+            return null;
         }
 
         @Override
@@ -220,6 +323,26 @@ public class Http2BodyWriterTest {
         @Override
         public void close() {
             closed++;
+        }
+    }
+
+    private static final class UnflushedBytesTracker extends ChannelOutboundHandlerAdapter {
+        private int unflushedBytes;
+        private int peakUnflushedBytes;
+
+        @Override
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+            if (msg instanceof Http2DataFrame) {
+                unflushedBytes += ((Http2DataFrame) msg).content().readableBytes();
+                peakUnflushedBytes = Math.max(peakUnflushedBytes, unflushedBytes);
+            }
+            ctx.write(msg, promise);
+        }
+
+        @Override
+        public void flush(ChannelHandlerContext ctx) {
+            unflushedBytes = 0;
+            ctx.flush();
         }
     }
 }


### PR DESCRIPTION
## Summary
- batch HTTP/2 upload DATA frame flushes while the stream remains writable
- flush only when the body pump yields for source suspension/backpressure or writes the terminal DATA frame
- prevent synchronous writability callbacks from re-entering the pump
- keep the pump parked while the terminal DATA write is pending, preventing duplicate `endStream` frames
- cover multi-chunk batching, suspension, backpressure resume, re-entry, and cleanup timing in `Http2BodyWriterTest`

## Rationale
The HTTP/2 upload body pump previously flushed after every intermediate DATA chunk. That kept writes moving, but it also forced one flush per chunk even when the stream child channel stayed writable. Batching until a yield point preserves bounded in-flight data while reducing flush overhead for multi-chunk uploads.

Netty may synchronously fire `channelWritabilityChanged` from `flush()`. Explicit pumping and terminal-write states prevent that callback from mutating pump state recursively or emitting a second terminal frame before the first write completes.

## Validation
- `./mvnw -pl client -Dtest='org.asynchttpclient.netty.request.body.Http2BodyWriterTest' test` (3 tests)
- `./mvnw -pl client -DskipTests compile`
- `./mvnw -pl client -Dtest=Http2StreamingBodyFlowControlTest test`
- `./mvnw -pl client -Dtest=BasicHttp2Test test`

## Attribution
Codex on behalf of Pavel Ptashyts