### PR TITLE
Avoid rebuilding clean query strings

### DIFF
--- a/client/src/main/java/org/asynchttpclient/util/UriEncoder.java
+++ b/client/src/main/java/org/asynchttpclient/util/UriEncoder.java
@@ -62,9 +62,7 @@ public enum UriEncoder {
         @Override
         protected String withQueryWithoutParams(final String query) {
             // encode query
-            StringBuilder sb = StringBuilderPool.DEFAULT.stringBuilder();
-            encodeAndAppendQuery(sb, query);
-            return sb.toString();
+            return Utf8UrlEncoder.encodeQuery(query);
         }
 
         @Override

--- a/client/src/main/java/org/asynchttpclient/util/Utf8UrlEncoder.java
+++ b/client/src/main/java/org/asynchttpclient/util/Utf8UrlEncoder.java
@@ -129,6 +129,11 @@ public final class Utf8UrlEncoder {
         return sb == null ? input : sb.toString();
     }
 
+    public static String encodeQuery(String input) {
+        StringBuilder sb = lazyAppendEncoded(null, input, BUILT_QUERY_UNTOUCHED_CHARS, false);
+        return sb == null ? input : sb.toString();
+    }
+
     public static StringBuilder encodeAndAppendQuery(StringBuilder sb, String query) {
         return appendEncoded(sb, query, BUILT_QUERY_UNTOUCHED_CHARS, false);
     }

--- a/client/src/main/java/org/asynchttpclient/util/Utf8UrlEncoder.java
+++ b/client/src/main/java/org/asynchttpclient/util/Utf8UrlEncoder.java
@@ -129,7 +129,7 @@ public final class Utf8UrlEncoder {
         return sb == null ? input : sb.toString();
     }
 
-    public static String encodeQuery(String input) {
+    static String encodeQuery(String input) {
         StringBuilder sb = lazyAppendEncoded(null, input, BUILT_QUERY_UNTOUCHED_CHARS, false);
         return sb == null ? input : sb.toString();
     }

--- a/client/src/main/java/org/asynchttpclient/util/Utf8UrlEncoder.java
+++ b/client/src/main/java/org/asynchttpclient/util/Utf8UrlEncoder.java
@@ -129,6 +129,7 @@ public final class Utf8UrlEncoder {
         return sb == null ? input : sb.toString();
     }
 
+    // package-private: only UriEncoder (same package) needs this; keep API surface minimal
     static String encodeQuery(String input) {
         StringBuilder sb = lazyAppendEncoded(null, input, BUILT_QUERY_UNTOUCHED_CHARS, false);
         return sb == null ? input : sb.toString();

--- a/client/src/test/java/org/asynchttpclient/util/Utf8UrlEncoderTest.java
+++ b/client/src/test/java/org/asynchttpclient/util/Utf8UrlEncoderTest.java
@@ -44,6 +44,7 @@ public class Utf8UrlEncoderTest {
 
         assertNotSame(query, encoded);
         assertEquals("a=one%20two", encoded);
+        assertEquals("a=%C3%A9", Utf8UrlEncoder.encodeQuery("a=\u00e9"));
     }
 
     @RepeatedIfExceptionsTest(repeats = 5)

--- a/client/src/test/java/org/asynchttpclient/util/Utf8UrlEncoderTest.java
+++ b/client/src/test/java/org/asynchttpclient/util/Utf8UrlEncoderTest.java
@@ -15,7 +15,7 @@
  */
 package org.asynchttpclient.util;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -30,14 +30,14 @@ public class Utf8UrlEncoderTest {
         assertEquals("a%2Bb", Utf8UrlEncoder.encodeQueryElement("a+b"));
     }
 
-    @RepeatedIfExceptionsTest(repeats = 5)
+    @Test
     public void encodeQueryReusesInputWhenNothingNeedsEscaping() {
         String query = "a=1&b=/two?c%20d";
 
         assertSame(query, Utf8UrlEncoder.encodeQuery(query));
     }
 
-    @RepeatedIfExceptionsTest(repeats = 5)
+    @Test
     public void encodeQueryEscapesWhenNeeded() {
         String query = "a=one two";
         String encoded = Utf8UrlEncoder.encodeQuery(query);

--- a/client/src/test/java/org/asynchttpclient/util/Utf8UrlEncoderTest.java
+++ b/client/src/test/java/org/asynchttpclient/util/Utf8UrlEncoderTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class Utf8UrlEncoderTest {
 
-    @RepeatedIfExceptionsTest(repeats = 5)
+    @Test
     public void testBasics() {
         assertEquals("foobar", Utf8UrlEncoder.encodeQueryElement("foobar"));
         assertEquals("a%26b", Utf8UrlEncoder.encodeQueryElement("a&b"));

--- a/client/src/test/java/org/asynchttpclient/util/Utf8UrlEncoderTest.java
+++ b/client/src/test/java/org/asynchttpclient/util/Utf8UrlEncoderTest.java
@@ -47,7 +47,7 @@ public class Utf8UrlEncoderTest {
         assertEquals("a=%C3%A9", Utf8UrlEncoder.encodeQuery("a=\u00e9"));
     }
 
-    @RepeatedIfExceptionsTest(repeats = 5)
+    @Test
     public void testPercentageEncoding() {
         assertEquals("foobar", Utf8UrlEncoder.percentEncodeQueryElement("foobar"));
         assertEquals("foo%2Abar", Utf8UrlEncoder.percentEncodeQueryElement("foo*bar"));

--- a/client/src/test/java/org/asynchttpclient/util/Utf8UrlEncoderTest.java
+++ b/client/src/test/java/org/asynchttpclient/util/Utf8UrlEncoderTest.java
@@ -18,6 +18,8 @@ package org.asynchttpclient.util;
 import io.github.artsok.RepeatedIfExceptionsTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class Utf8UrlEncoderTest {
 
@@ -26,6 +28,22 @@ public class Utf8UrlEncoderTest {
         assertEquals("foobar", Utf8UrlEncoder.encodeQueryElement("foobar"));
         assertEquals("a%26b", Utf8UrlEncoder.encodeQueryElement("a&b"));
         assertEquals("a%2Bb", Utf8UrlEncoder.encodeQueryElement("a+b"));
+    }
+
+    @RepeatedIfExceptionsTest(repeats = 5)
+    public void encodeQueryReusesInputWhenNothingNeedsEscaping() {
+        String query = "a=1&b=/two?c%20d";
+
+        assertSame(query, Utf8UrlEncoder.encodeQuery(query));
+    }
+
+    @RepeatedIfExceptionsTest(repeats = 5)
+    public void encodeQueryEscapesWhenNeeded() {
+        String query = "a=one two";
+        String encoded = Utf8UrlEncoder.encodeQuery(query);
+
+        assertNotSame(query, encoded);
+        assertEquals("a=one%20two", encoded);
     }
 
     @RepeatedIfExceptionsTest(repeats = 5)


### PR DESCRIPTION
## Summary
- add a lazy query-string encoder that reuses the input String when no escaping is needed
- use that fast path for existing queries without additional query params
- add tests for no-op query identity and query escaping

## Rationale
UriEncoder already reuses the original Uri when encoding produces equal path and query values, but the existing query path still allocated a StringBuilder and replacement String for clean queries. The new helper mirrors the path encoder's lazy behavior and avoids that temporary allocation in the common already-encoded REST query case.

## Validation
- ./mvnw -pl client -Dtest=Utf8UrlEncoderTest,UriEncoderTest test
- ./mvnw -pl client -DskipTests compile
- ./mvnw -pl client -Dtest=UriTest,QueryParametersTest,PostWithQueryStringTest test

## Attribution
Codex on behalf of Pavel Ptashyts