### PR TITLE
Cache Basic auth header on Realm

### DIFF
--- a/client/src/main/java/org/asynchttpclient/Realm.java
+++ b/client/src/main/java/org/asynchttpclient/Realm.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
+import java.util.Base64;
 import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
@@ -70,6 +71,7 @@ public class Realm {
     private final boolean userhash;
     private final @Nullable String sid;
     private final int maxIterationCount;
+    private @Nullable String basicAuthHeader;
 
     private Realm(@Nullable AuthScheme scheme,
                   @Nullable String principal,
@@ -243,6 +245,21 @@ public class Realm {
 
     public int getMaxIterationCount() {
         return maxIterationCount;
+    }
+
+    /**
+     * Returns the HTTP Basic authorization header for this immutable realm.
+     *
+     * @return the Basic authorization header
+     */
+    public String getBasicAuthHeader() {
+        String header = basicAuthHeader;
+        if (header == null) {
+            String s = principal + ':' + password;
+            header = "Basic " + Base64.getEncoder().encodeToString(s.getBytes(charset));
+            basicAuthHeader = header;
+        }
+        return header;
     }
 
     @Override

--- a/client/src/main/java/org/asynchttpclient/Realm.java
+++ b/client/src/main/java/org/asynchttpclient/Realm.java
@@ -248,9 +248,11 @@ public class Realm {
     }
 
     /**
-     * Returns the HTTP Basic authorization header for this immutable realm.
+     * Returns the lazily computed and cached HTTP Basic authorization header for this immutable realm.
+     * Concurrent first calls may compute the same value more than once.
      *
      * @return the Basic authorization header
+     * @since 3.0.12
      */
     public String getBasicAuthHeader() {
         String header = basicAuthHeader;

--- a/client/src/main/java/org/asynchttpclient/util/AuthenticatorUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/AuthenticatorUtils.java
@@ -32,7 +32,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.MessageDigest;
-import java.util.Base64;
 import java.util.List;
 import java.util.Set;
 
@@ -87,12 +86,7 @@ public final class AuthenticatorUtils {
     }
 
     private static @Nullable String computeBasicAuthentication(@Nullable Realm realm) {
-        return realm != null ? computeBasicAuthentication(realm.getPrincipal(), realm.getPassword(), realm.getCharset()) : null;
-    }
-
-    private static String computeBasicAuthentication(@Nullable String principal, @Nullable String password, Charset charset) {
-        String s = principal + ':' + password;
-        return "Basic " + Base64.getEncoder().encodeToString(s.getBytes(charset));
+        return realm != null ? realm.getBasicAuthHeader() : null;
     }
 
     public static String computeRealmURI(Uri uri, boolean useAbsoluteURI, boolean omitQuery) {

--- a/client/src/test/java/org/asynchttpclient/util/AuthenticatorUtilsTest.java
+++ b/client/src/test/java/org/asynchttpclient/util/AuthenticatorUtilsTest.java
@@ -59,9 +59,11 @@ public class AuthenticatorUtilsTest {
 
         String first = AuthenticatorUtils.perRequestAuthorizationHeader(request, realm);
         String second = AuthenticatorUtils.perRequestAuthorizationHeader(request, realm);
+        String proxy = AuthenticatorUtils.perRequestProxyAuthorizationHeader(request, realm);
 
         assertEquals("Basic dXNlcjpwYXNz", first);
         assertSame(first, second);
+        assertSame(first, proxy);
     }
 
     @Test

--- a/client/src/test/java/org/asynchttpclient/util/AuthenticatorUtilsTest.java
+++ b/client/src/test/java/org/asynchttpclient/util/AuthenticatorUtilsTest.java
@@ -40,12 +40,30 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class AuthenticatorUtilsTest {
+    @Test
+    void preemptiveBasicAuthorizationHeaderIsMemoizedOnRealm() {
+        Request request = new RequestBuilder("GET")
+                .setUrl("http://example.com/api/users")
+                .build();
+        Realm realm = new Realm.Builder("user", "pass")
+                .setScheme(Realm.AuthScheme.BASIC)
+                .setUsePreemptiveAuth(true)
+                .build();
+
+        String first = AuthenticatorUtils.perRequestAuthorizationHeader(request, realm);
+        String second = AuthenticatorUtils.perRequestAuthorizationHeader(request, realm);
+
+        assertEquals("Basic dXNlcjpwYXNz", first);
+        assertSame(first, second);
+    }
+
     @Test
     void computeBodyHashEmptyBody() throws Exception {
         Request request = new RequestBuilder("GET")


### PR DESCRIPTION
## Summary
- memoize the generated HTTP Basic authorization header on immutable `Realm` instances
- reuse one cached header for both request and proxy Basic authentication
- document `Realm.getBasicAuthHeader()` as an intentional public API introduced in 3.0.12
- document that concurrent first access may perform benign duplicate computation
- verify request and proxy paths return the same cached `String` instance

## API note
The accessor is public because `Realm` and the Netty authentication utilities are in different packages. It exposes only the immutable derived header value and avoids adding mutable cache management to the public surface.

## Validation
- `./mvnw -pl client -Dtest='org.asynchttpclient.util.AuthenticatorUtilsTest,org.asynchttpclient.RealmTest' test` (44 tests)
- existing focused authentication, compile, and package checks from the initial change

## Attribution
Codex on behalf of Pavel Ptashyts