### PR TITLE
keep method and digest-uri in A2 for qop=auth-int

### DIFF
--- a/client/src/main/java/org/asynchttpclient/Realm.java
+++ b/client/src/main/java/org/asynchttpclient/Realm.java
@@ -667,8 +667,10 @@ public class Realm {
                 if (entityBodyHash != null) {
                     sb.append(entityBodyHash);
                 } else {
-                    // Hash of empty body using the current algorithm
-                    sb.append(toHexString(md.digest()));
+                    // Hash of empty body using the current algorithm. Must append in place:
+                    // toHexString() would take the same recycled builder and reset it, dropping
+                    // the method and digest-uri already written above.
+                    appendBase16(sb, md.digest());
                 }
             } else if (qop != null && !"auth".equals(qop)) {
                 throw new UnsupportedOperationException("Digest qop not supported: " + qop);

--- a/client/src/test/java/org/asynchttpclient/RealmTest.java
+++ b/client/src/test/java/org/asynchttpclient/RealmTest.java
@@ -106,6 +106,32 @@ public class RealmTest {
         assertEquals(orig.getResponse(), expectedResponse);
     }
 
+    @RepeatedIfExceptionsTest(repeats = 5)
+    public void testAuthIntDigestKeepsMethodAndUriInA2() throws Exception {
+        String user = "user";
+        String pass = "pass";
+        String realm = "realm";
+        String nonce = "nonce";
+        String method = "POST";
+        Uri uri = Uri.create("http://ahc.io/foo");
+        String qop = "auth-int";
+        Realm orig = digestAuthRealm(user, pass)
+                .setNonce(nonce)
+                .setUri(uri)
+                .setMethodName(method)
+                .setRealmName(realm)
+                .setQop(qop)
+                .build();
+
+        String nc = orig.getNc();
+        String cnonce = orig.getCnonce();
+        String ha1 = getMd5(user + ':' + realm + ':' + pass);
+        String ha2 = getMd5(method + ':' + uri.getPath() + ':' + getMd5(""));
+        String expectedResponse = getMd5(ha1 + ':' + nonce + ':' + nc + ':' + cnonce + ':' + qop + ':' + ha2);
+
+        assertEquals(expectedResponse, orig.getResponse());
+    }
+
     // Phase 1: matchParam tests
     @Test
     public void testMatchParamUnquotedAlgorithm() {


### PR DESCRIPTION
Realm.Builder.ha2 writes A2 into the recycled StringBuilder that newResponse took from StringBuilderPool, but on the auth-int branch with no precomputed entity-body hash it calls toHexString, which takes that same thread-local builder and resets it, so the "POST:/secret:" already written is discarded. A2 comes out as the empty-body hash twice and the Digest response no longer binds the request method or the target URI. A server reaches this by answering with qop="auth-int" in WWW-Authenticate or Proxy-Authenticate, since parseRawQop picks auth-int when that is the only value offered.

Appending with appendBase16 keeps the hash in the buffer already being built, which is what newResponse does for HA1 and HA2 a few lines below. The added RealmTest case checks the response against the RFC 7616 A2 and fails on the current code.