### PR TITLE
Use HPACK spelling for HTTP/2 compression

### DIFF
--- a/client/src/jmh/java/org/asynchttpclient/bench/AcceptEncodingHpackBenchmark.java
+++ b/client/src/jmh/java/org/asynchttpclient/bench/AcceptEncodingHpackBenchmark.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Measures the HPACK-encoded wire size of {@code accept-encoding} for the two value spellings:
  * <ul>
- *   <li>AHC current: {@code "gzip,deflate"} (no space) — built in
+ *   <li>AHC current: {@code "gzip,deflate"} (no space) - built in
  *       {@code HttpUtils.GZIP_DEFLATE = new AsciiString(GZIP + "," + DEFLATE)}.</li>
  *   <li>HPACK static table entry #16: {@code "gzip, deflate"} (with space, RFC 7541 App. A).</li>
  * </ul>

--- a/client/src/jmh/java/org/asynchttpclient/bench/AcceptEncodingHpackBenchmark.java
+++ b/client/src/jmh/java/org/asynchttpclient/bench/AcceptEncodingHpackBenchmark.java
@@ -41,8 +41,8 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>On a fresh encoder (first request of a connection) the static-table value matches as a single
  * indexed byte; the non-matching spelling is literal-encoded and inserted into the dynamic table.
- * This bench reports {@code gc.alloc.rate.norm} and the encoded byte count via the returned buffer's
- * readableBytes (consumed by the blackhole through the return value size).
+ * This bench reports encoding time and, when run with {@code -prof gc}, allocation. The returned encoded
+ * byte count prevents dead-code elimination; {@code AcceptEncodingHpackTest} verifies the wire sizes.
  */
 @State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)

--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
@@ -106,6 +106,7 @@ import static org.asynchttpclient.util.AuthenticatorUtils.perConnectionAuthoriza
 import static org.asynchttpclient.util.AuthenticatorUtils.perConnectionProxyAuthorizationHeader;
 import static org.asynchttpclient.util.HttpConstants.Methods.CONNECT;
 import static org.asynchttpclient.util.HttpConstants.Methods.GET;
+import static org.asynchttpclient.util.HttpUtils.GZIP_DEFLATE;
 import static org.asynchttpclient.util.HttpUtils.hostHeader;
 import static org.asynchttpclient.util.MiscUtils.getCause;
 import static org.asynchttpclient.util.ProxyUtils.getProxyServer;
@@ -113,6 +114,8 @@ import static org.asynchttpclient.util.ProxyUtils.getProxyServer;
 public final class NettyRequestSender {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NettyRequestSender.class);
+    private static final AsciiString HTTP2_HPACK_GZIP_DEFLATE =
+            new AsciiString(HttpHeaderValues.GZIP + ", " + HttpHeaderValues.DEFLATE);
 
     private final AsyncHttpClientConfig config;
     private final ChannelManager channelManager;
@@ -918,6 +921,7 @@ public final class NettyRequestSender {
             // Copy the HTTP/1.1 headers, dropping connection-specific names forbidden in HTTP/2 (RFC 7540
             // §8.1.2.2). iteratorCharSequence() avoids the per-name String the String-typed iterator forces;
             // see isHttp2ExcludedHeader and toLowerCaseHeaderName for the skip-check and lowercasing rules.
+            boolean preferHpackAcceptEncoding = preferHpackAcceptEncoding(future.getCurrentRequest());
             Iterator<Map.Entry<CharSequence, CharSequence>> it = httpRequest.headers().iteratorCharSequence();
             while (it.hasNext()) {
                 Map.Entry<CharSequence, CharSequence> entry = it.next();
@@ -933,7 +937,7 @@ public final class NettyRequestSender {
                         && !HttpHeaderValues.TRAILERS.contentEqualsIgnoreCase(value)) {
                     continue;
                 }
-                h2Headers.add(toLowerCaseHeaderName(name), value);
+                h2Headers.add(toLowerCaseHeaderName(name), http2HeaderValue(name, value, preferHpackAcceptEncoding));
             }
 
             // Determine the body to send: an in-memory buffer (DefaultFullHttpRequest content or a
@@ -969,6 +973,20 @@ public final class NettyRequestSender {
                 nettyRequest.release();
             }
         }
+    }
+
+    private boolean preferHpackAcceptEncoding(Request request) {
+        return config.isCompressionEnforced()
+                && !request.getHeaders().contains(HttpHeaderNames.ACCEPT_ENCODING);
+    }
+
+    private static CharSequence http2HeaderValue(CharSequence name, CharSequence value, boolean preferHpackAcceptEncoding) {
+        if (preferHpackAcceptEncoding
+                && HttpHeaderNames.ACCEPT_ENCODING.contentEqualsIgnoreCase(name)
+                && GZIP_DEFLATE.contentEquals(value)) {
+            return HTTP2_HPACK_GZIP_DEFLATE;
+        }
+        return value;
     }
 
     /**

--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
@@ -107,6 +107,7 @@ import static org.asynchttpclient.util.AuthenticatorUtils.perConnectionProxyAuth
 import static org.asynchttpclient.util.HttpConstants.Methods.CONNECT;
 import static org.asynchttpclient.util.HttpConstants.Methods.GET;
 import static org.asynchttpclient.util.HttpUtils.GZIP_DEFLATE;
+import static org.asynchttpclient.util.HttpUtils.GZIP_DEFLATE_HPACK;
 import static org.asynchttpclient.util.HttpUtils.hostHeader;
 import static org.asynchttpclient.util.MiscUtils.getCause;
 import static org.asynchttpclient.util.ProxyUtils.getProxyServer;
@@ -114,8 +115,6 @@ import static org.asynchttpclient.util.ProxyUtils.getProxyServer;
 public final class NettyRequestSender {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NettyRequestSender.class);
-    private static final AsciiString HTTP2_HPACK_GZIP_DEFLATE =
-            new AsciiString(HttpHeaderValues.GZIP + ", " + HttpHeaderValues.DEFLATE);
 
     private final AsyncHttpClientConfig config;
     private final ChannelManager channelManager;
@@ -921,7 +920,6 @@ public final class NettyRequestSender {
             // Copy the HTTP/1.1 headers, dropping connection-specific names forbidden in HTTP/2 (RFC 7540
             // §8.1.2.2). iteratorCharSequence() avoids the per-name String the String-typed iterator forces;
             // see isHttp2ExcludedHeader and toLowerCaseHeaderName for the skip-check and lowercasing rules.
-            boolean preferHpackAcceptEncoding = preferHpackAcceptEncoding(future.getCurrentRequest());
             Iterator<Map.Entry<CharSequence, CharSequence>> it = httpRequest.headers().iteratorCharSequence();
             while (it.hasNext()) {
                 Map.Entry<CharSequence, CharSequence> entry = it.next();
@@ -937,7 +935,7 @@ public final class NettyRequestSender {
                         && !HttpHeaderValues.TRAILERS.contentEqualsIgnoreCase(value)) {
                     continue;
                 }
-                h2Headers.add(toLowerCaseHeaderName(name), http2HeaderValue(name, value, preferHpackAcceptEncoding));
+                h2Headers.add(toLowerCaseHeaderName(name), http2HeaderValue(name, value));
             }
 
             // Determine the body to send: an in-memory buffer (DefaultFullHttpRequest content or a
@@ -975,16 +973,9 @@ public final class NettyRequestSender {
         }
     }
 
-    private boolean preferHpackAcceptEncoding(Request request) {
-        return config.isCompressionEnforced()
-                && !request.getHeaders().contains(HttpHeaderNames.ACCEPT_ENCODING);
-    }
-
-    private static CharSequence http2HeaderValue(CharSequence name, CharSequence value, boolean preferHpackAcceptEncoding) {
-        if (preferHpackAcceptEncoding
-                && HttpHeaderNames.ACCEPT_ENCODING.contentEqualsIgnoreCase(name)
-                && GZIP_DEFLATE.contentEquals(value)) {
-            return HTTP2_HPACK_GZIP_DEFLATE;
+    private static CharSequence http2HeaderValue(CharSequence name, CharSequence value) {
+        if (value == GZIP_DEFLATE && HttpHeaderNames.ACCEPT_ENCODING.contentEqualsIgnoreCase(name)) {
+            return GZIP_DEFLATE_HPACK;
         }
         return value;
     }

--- a/client/src/main/java/org/asynchttpclient/util/HttpUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/HttpUtils.java
@@ -37,6 +37,8 @@ public final class HttpUtils {
 
     public static final AsciiString ACCEPT_ALL_HEADER_VALUE = new AsciiString("*/*");
     public static final AsciiString GZIP_DEFLATE = new AsciiString(HttpHeaderValues.GZIP + "," + HttpHeaderValues.DEFLATE);
+    /** RFC 7541 Appendix A static table entry 16. */
+    public static final AsciiString GZIP_DEFLATE_HPACK = new AsciiString(HttpHeaderValues.GZIP + ", " + HttpHeaderValues.DEFLATE);
     private static final String CONTENT_TYPE_CHARSET_ATTRIBUTE = "charset=";
     private static final String CONTENT_TYPE_BOUNDARY_ATTRIBUTE = "boundary=";
     private static final String BROTLY_ACCEPT_ENCODING_SUFFIX = ", br";

--- a/client/src/test/java/org/asynchttpclient/BasicHttp2Test.java
+++ b/client/src/test/java/org/asynchttpclient/BasicHttp2Test.java
@@ -75,6 +75,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
+import static io.netty.handler.codec.http.HttpHeaderNames.ACCEPT_ENCODING;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -1045,6 +1046,31 @@ public class BasicHttp2Test {
             // and the values still round-trip for the forwarded headers
             assertEquals("v1", response.getHeader("X-x-mixed-case"));
             assertEquals("v2", response.getHeader("X-another-custom-header"));
+        }
+    }
+
+    @Test
+    public void generatedAcceptEncodingUsesHpackStaticValueOverHttp2() throws Exception {
+        try (AsyncHttpClient client = http2ClientWithConfig(builder -> builder.setCompressionEnforced(true))) {
+            Response response = client.prepareGet(httpsUrl("/echo"))
+                    .execute()
+                    .get(30, SECONDS);
+
+            assertEquals(200, response.getStatusCode());
+            assertEquals("gzip, deflate", response.getHeader("X-accept-encoding"));
+        }
+    }
+
+    @Test
+    public void userAcceptEncodingSpellingIsPreservedOverHttp2() throws Exception {
+        try (AsyncHttpClient client = http2ClientWithConfig(builder -> builder.setCompressionEnforced(true))) {
+            Response response = client.prepareGet(httpsUrl("/echo"))
+                    .setHeader(ACCEPT_ENCODING, "gzip,deflate")
+                    .execute()
+                    .get(30, SECONDS);
+
+            assertEquals(200, response.getStatusCode());
+            assertEquals("gzip,deflate", response.getHeader("X-accept-encoding"));
         }
     }
 

--- a/client/src/test/java/org/asynchttpclient/BasicHttp2Test.java
+++ b/client/src/test/java/org/asynchttpclient/BasicHttp2Test.java
@@ -26,6 +26,8 @@ import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.compression.Brotli;
+import io.netty.handler.codec.compression.Zstd;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.QueryStringDecoder;
@@ -1057,7 +1059,15 @@ public class BasicHttp2Test {
                     .get(30, SECONDS);
 
             assertEquals(200, response.getStatusCode());
-            assertEquals("gzip, deflate", response.getHeader("X-accept-encoding"));
+            List<String> expected = new ArrayList<>();
+            expected.add("gzip, deflate");
+            if (Brotli.isAvailable()) {
+                expected.add("br");
+            }
+            if (Zstd.isAvailable()) {
+                expected.add("zstd");
+            }
+            assertEquals(expected, response.getHeaders("X-accept-encoding"));
         }
     }
 

--- a/client/src/test/java/org/asynchttpclient/BasicHttpTest.java
+++ b/client/src/test/java/org/asynchttpclient/BasicHttpTest.java
@@ -64,6 +64,7 @@ import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
 import static io.netty.handler.codec.http.HttpHeaderNames.TRANSFER_ENCODING;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.asynchttpclient.Dsl.asyncHttpClient;
 import static org.asynchttpclient.Dsl.config;
 import static org.asynchttpclient.Dsl.get;
 import static org.asynchttpclient.Dsl.head;
@@ -104,6 +105,18 @@ public class BasicHttpTest extends HttpTest {
 
     private String getTargetUrl() {
         return server.getHttpUrl() + "/foo/bar";
+    }
+
+    @RepeatedIfExceptionsTest(repeats = 5)
+    public void generatedAcceptEncodingKeepsHttp1Spelling() throws Exception {
+        server.enqueueEcho();
+        try (AsyncHttpClient client = asyncHttpClient(config().setCompressionEnforced(true))) {
+            Response response = client.prepareGet(getTargetUrl())
+                    .execute()
+                    .get(TIMEOUT, SECONDS);
+
+            assertEquals("gzip,deflate", response.getHeader("X-Accept-Encoding"));
+        }
     }
 
     @RepeatedIfExceptionsTest(repeats = 5)

--- a/client/src/test/java/org/asynchttpclient/netty/request/AcceptEncodingHpackTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/request/AcceptEncodingHpackTest.java
@@ -1,0 +1,51 @@
+/*
+ *    Copyright (c) 2026 AsyncHttpClient Project. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.asynchttpclient.netty.request;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.DefaultHttp2HeadersEncoder;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.handler.codec.http2.Http2HeadersEncoder;
+import io.netty.util.AsciiString;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AcceptEncodingHpackTest {
+
+    private static final AsciiString ACCEPT_ENCODING = AsciiString.cached("accept-encoding");
+
+    @Test
+    public void staticTableSpellingUsesOneByteIndexedRepresentation() throws Exception {
+        assertTrue(encodedLength("gzip,deflate") > 1);
+        assertEquals(1, encodedLength("gzip, deflate"));
+    }
+
+    private static int encodedLength(String value) throws Exception {
+        Http2HeadersEncoder encoder = new DefaultHttp2HeadersEncoder();
+        Http2Headers headers = new DefaultHttp2Headers().add(ACCEPT_ENCODING, value);
+        ByteBuf output = Unpooled.buffer();
+        try {
+            encoder.encodeHeaders(3, headers, output);
+            return output.readableBytes();
+        } finally {
+            output.release();
+        }
+    }
+}

--- a/client/src/test/java/org/asynchttpclient/netty/request/AcceptEncodingHpackTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/request/AcceptEncodingHpackTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/** Verifies Netty HPACK wire sizes; {@code BasicHttp2Test} covers AHC's production request path. */
 public class AcceptEncodingHpackTest {
 
     private static final AsciiString ACCEPT_ENCODING = AsciiString.cached("accept-encoding");


### PR DESCRIPTION
## Summary

- rewrite only AHC's generated default `Accept-Encoding` value from `gzip,deflate` to `gzip, deflate` while copying headers into HTTP/2 frames
- allow HPACK to use static-table entry 16 for the generated value
- preserve user-supplied `Accept-Encoding` spelling and leave HTTP/1 output unchanged
- add HTTP/2 behavioral coverage and a deterministic encoded-size test
- correct the existing JMH benchmark documentation about its returned value

## Performance evidence

With Netty 4.2.15.Final and a fresh HPACK encoder:

- `gzip,deflate`: 14 encoded bytes
- `gzip, deflate`: 1 encoded byte through the indexed static-table representation

A short JMH validation on JDK 21 with `-prof gc` measured 1032 B/op for the literal spelling and 680 B/op for the static-table spelling. Timing was noisy, so this PR relies on the deterministic wire-size test rather than claiming a stable CPU improvement.

## Validation

- `./mvnw -pl client -Dtest='org.asynchttpclient.netty.request.AcceptEncodingHpackTest,org.asynchttpclient.BasicHttp2Test#generatedAcceptEncodingUsesHpackStaticValueOverHttp2+userAcceptEncodingSpellingIsPreservedOverHttp2' test` (3 tests)
- `AcceptEncodingHpackBenchmark -f 1 -wi 3 -i 5 -w 500ms -r 500ms -prof gc`
- existing full `BasicHttp2Test` validation from the initial change

## Attribution

Codex on behalf of Pavel Ptashyts