### PR TITLE
Validate converted HTTP/2 headers and trailers

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/handler/Http2Handler.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/Http2Handler.java
@@ -19,9 +19,10 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpHeadersFactory;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeadersFactory;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
@@ -56,6 +57,8 @@ import java.io.IOException;
 public final class Http2Handler extends AsyncHttpClientHandler {
 
     private static final HttpVersion HTTP_2 = new HttpVersion("HTTP", 2, 0, true);
+    private static final HttpHeadersFactory RESPONSE_HEADERS_FACTORY =
+            DefaultHttpHeadersFactory.headersFactory().withNameValidation(false);
 
     public Http2Handler(AsyncHttpClientConfig config, ChannelManager channelManager, NettyRequestSender requestSender) {
         super(config, channelManager, requestSender);
@@ -146,14 +149,7 @@ public final class Http2Handler extends AsyncHttpClientHandler {
         }
         HttpResponseStatus nettyStatus = HttpResponseStatus.valueOf(statusCode);
 
-        // Build HTTP/1.1-style headers, skipping HTTP/2 pseudo-headers (start with ':')
-        HttpHeaders responseHeaders = new DefaultHttpHeaders();
-        h2Headers.forEach(entry -> {
-            CharSequence name = entry.getKey();
-            if (name.length() > 0 && name.charAt(0) != ':') {
-                responseHeaders.add(name, entry.getValue());
-            }
-        });
+        HttpHeaders responseHeaders = copyHttp2Headers(h2Headers);
 
         // Build a synthetic HttpResponse so the existing interceptor chain can be reused unchanged
         HttpResponse syntheticResponse = new DefaultHttpResponse(HTTP_2, nettyStatus, responseHeaders);
@@ -222,13 +218,7 @@ public final class Http2Handler extends AsyncHttpClientHandler {
                                                   NettyResponseFuture<?> future, AsyncHandler<?> handler) throws Exception {
         Http2Headers h2Headers = headersFrame.headers();
 
-        HttpHeaders trailingHeaders = new DefaultHttpHeaders();
-        h2Headers.forEach(entry -> {
-            CharSequence name = entry.getKey();
-            if (name.length() > 0 && name.charAt(0) != ':') {
-                trailingHeaders.add(name, entry.getValue());
-            }
-        });
+        HttpHeaders trailingHeaders = copyHttp2Headers(h2Headers);
 
         boolean abort = false;
         if (!trailingHeaders.isEmpty()) {
@@ -238,6 +228,19 @@ public final class Http2Handler extends AsyncHttpClientHandler {
         if (abort || headersFrame.isEndStream()) {
             finishUpdate(future, channel, false);
         }
+    }
+
+    static HttpHeaders copyHttp2Headers(Http2Headers h2Headers) {
+        // The HTTP/2 decoder validates names but not values by default. Avoid repeating the name scan while
+        // retaining the HTTP/1 value validator that rejects CR/LF and other prohibited characters.
+        HttpHeaders headers = RESPONSE_HEADERS_FACTORY.newHeaders();
+        h2Headers.forEach(entry -> {
+            CharSequence name = entry.getKey();
+            if (name.length() > 0 && name.charAt(0) != ':') {
+                headers.add(name, entry.getValue());
+            }
+        });
+        return headers;
     }
 
     /**

--- a/client/src/main/java/org/asynchttpclient/netty/handler/Http2Handler.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/Http2Handler.java
@@ -42,6 +42,7 @@ import org.asynchttpclient.netty.channel.Channels;
 import org.asynchttpclient.netty.request.NettyRequestSender;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * HTTP/2 channel handler for stream child channels created by {@link io.netty.handler.codec.http2.Http2MultiplexHandler}.
@@ -57,8 +58,8 @@ import java.io.IOException;
 public final class Http2Handler extends AsyncHttpClientHandler {
 
     private static final HttpVersion HTTP_2 = new HttpVersion("HTTP", 2, 0, true);
-    private static final HttpHeadersFactory RESPONSE_HEADERS_FACTORY =
-            DefaultHttpHeadersFactory.headersFactory().withNameValidation(false);
+    private static final HttpHeadersFactory RESPONSE_HEADERS_FACTORY = DefaultHttpHeadersFactory.headersFactory();
+    private static final HttpHeadersFactory TRAILING_HEADERS_FACTORY = DefaultHttpHeadersFactory.trailersFactory();
 
     public Http2Handler(AsyncHttpClientConfig config, ChannelManager channelManager, NettyRequestSender requestSender) {
         super(config, channelManager, requestSender);
@@ -218,7 +219,7 @@ public final class Http2Handler extends AsyncHttpClientHandler {
                                                   NettyResponseFuture<?> future, AsyncHandler<?> handler) throws Exception {
         Http2Headers h2Headers = headersFrame.headers();
 
-        HttpHeaders trailingHeaders = copyHttp2Headers(h2Headers);
+        HttpHeaders trailingHeaders = copyHttp2Trailers(h2Headers);
 
         boolean abort = false;
         if (!trailingHeaders.isEmpty()) {
@@ -231,15 +232,22 @@ public final class Http2Handler extends AsyncHttpClientHandler {
     }
 
     static HttpHeaders copyHttp2Headers(Http2Headers h2Headers) {
-        // The HTTP/2 decoder validates names but not values by default. Avoid repeating the name scan while
-        // retaining the HTTP/1 value validator that rejects CR/LF and other prohibited characters.
-        HttpHeaders headers = RESPONSE_HEADERS_FACTORY.newHeaders();
-        h2Headers.forEach(entry -> {
+        return copyHttp2Headers(h2Headers, RESPONSE_HEADERS_FACTORY);
+    }
+
+    static HttpHeaders copyHttp2Trailers(Http2Headers h2Headers) {
+        return copyHttp2Headers(h2Headers, TRAILING_HEADERS_FACTORY);
+    }
+
+    private static HttpHeaders copyHttp2Headers(Http2Headers h2Headers, HttpHeadersFactory headersFactory) {
+        // HTTP/2 validation does not enforce HTTP token syntax or header values, so validate both while converting.
+        HttpHeaders headers = headersFactory.newHeaders();
+        for (Map.Entry<CharSequence, CharSequence> entry : h2Headers) {
             CharSequence name = entry.getKey();
             if (name.length() > 0 && name.charAt(0) != ':') {
                 headers.add(name, entry.getValue());
             }
-        });
+        }
         return headers;
     }
 

--- a/client/src/main/java/org/asynchttpclient/netty/handler/Http2Handler.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/Http2Handler.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultHttpHeadersFactory;
 import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpHeadersFactory;
 import io.netty.handler.codec.http.HttpResponse;
@@ -58,8 +59,7 @@ import java.util.Map;
 public final class Http2Handler extends AsyncHttpClientHandler {
 
     private static final HttpVersion HTTP_2 = new HttpVersion("HTTP", 2, 0, true);
-    private static final HttpHeadersFactory RESPONSE_HEADERS_FACTORY = DefaultHttpHeadersFactory.headersFactory();
-    private static final HttpHeadersFactory TRAILING_HEADERS_FACTORY = DefaultHttpHeadersFactory.trailersFactory();
+    private static final HttpHeadersFactory HEADERS_FACTORY = DefaultHttpHeadersFactory.headersFactory();
 
     public Http2Handler(AsyncHttpClientConfig config, ChannelManager channelManager, NettyRequestSender requestSender) {
         super(config, channelManager, requestSender);
@@ -232,23 +232,34 @@ public final class Http2Handler extends AsyncHttpClientHandler {
     }
 
     static HttpHeaders copyHttp2Headers(Http2Headers h2Headers) {
-        return copyHttp2Headers(h2Headers, RESPONSE_HEADERS_FACTORY);
+        return copyHttp2Headers(h2Headers, false);
     }
 
     static HttpHeaders copyHttp2Trailers(Http2Headers h2Headers) {
-        return copyHttp2Headers(h2Headers, TRAILING_HEADERS_FACTORY);
+        return copyHttp2Headers(h2Headers, true);
     }
 
-    private static HttpHeaders copyHttp2Headers(Http2Headers h2Headers, HttpHeadersFactory headersFactory) {
+    private static HttpHeaders copyHttp2Headers(Http2Headers h2Headers, boolean trailers) {
         // HTTP/2 validation does not enforce HTTP token syntax or header values, so validate both while converting.
-        HttpHeaders headers = headersFactory.newHeaders();
+        HttpHeaders headers = HEADERS_FACTORY.newHeaders();
         for (Map.Entry<CharSequence, CharSequence> entry : h2Headers) {
             CharSequence name = entry.getKey();
-            if (name.length() > 0 && name.charAt(0) != ':') {
-                headers.add(name, entry.getValue());
+            if (name.length() == 0 || name.charAt(0) == ':') {
+                continue;
             }
+            // The restriction is on the sender; drop prohibited trailers instead of failing after delivering the body.
+            if (trailers && !isPermittedTrailingHeader(name)) {
+                continue;
+            }
+            headers.add(name, entry.getValue());
         }
         return headers;
+    }
+
+    private static boolean isPermittedTrailingHeader(CharSequence name) {
+        return !HttpHeaderNames.CONTENT_LENGTH.contentEqualsIgnoreCase(name)
+                && !HttpHeaderNames.TRANSFER_ENCODING.contentEqualsIgnoreCase(name)
+                && !HttpHeaderNames.TRAILER.contentEqualsIgnoreCase(name);
     }
 
     /**

--- a/client/src/test/java/org/asynchttpclient/netty/handler/Http2HandlerTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/handler/Http2HandlerTest.java
@@ -1,0 +1,48 @@
+/*
+ *    Copyright (c) 2026 AsyncHttpClient Project. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.asynchttpclient.netty.handler;
+
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.Http2Headers;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class Http2HandlerTest {
+
+    @Test
+    void copiesDecoderValidatedHeaderNamesWithoutRevalidation() {
+        Http2Headers source = new DefaultHttp2Headers(false)
+                .status("200")
+                .add("invalid name", "value");
+
+        HttpHeaders copy = Http2Handler.copyHttp2Headers(source);
+
+        assertEquals("value", copy.get("invalid name"));
+        assertFalse(copy.contains(":status"));
+    }
+
+    @Test
+    void stillValidatesHeaderValues() {
+        Http2Headers source = new DefaultHttp2Headers(false)
+                .add("x-test", "value\r\ninjected");
+
+        assertThrows(IllegalArgumentException.class, () -> Http2Handler.copyHttp2Headers(source));
+    }
+}

--- a/client/src/test/java/org/asynchttpclient/netty/handler/Http2HandlerTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/handler/Http2HandlerTest.java
@@ -20,29 +20,60 @@ import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2Headers;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.TRAILER;
+import static io.netty.handler.codec.http.HttpHeaderNames.TRANSFER_ENCODING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class Http2HandlerTest {
 
     @Test
-    void copiesDecoderValidatedHeaderNamesWithoutRevalidation() {
+    void copiesRegularHeadersAndSkipsPseudoHeaders() {
         Http2Headers source = new DefaultHttp2Headers(false)
                 .status("200")
-                .add("invalid name", "value");
+                .add("x-test", "value");
 
         HttpHeaders copy = Http2Handler.copyHttp2Headers(source);
 
-        assertEquals("value", copy.get("invalid name"));
+        assertEquals("value", copy.get("x-test"));
         assertFalse(copy.contains(":status"));
     }
 
     @Test
-    void stillValidatesHeaderValues() {
+    void rejectsInvalidHeaderNames() {
+        Http2Headers source = new DefaultHttp2Headers(false)
+                .add("invalid\r\nname", "value");
+
+        assertThrows(IllegalArgumentException.class, () -> Http2Handler.copyHttp2Headers(source));
+    }
+
+    @Test
+    void skipsEmptyHeaderNames() {
+        Http2Headers source = new DefaultHttp2Headers(false)
+                .add("", "value");
+
+        assertTrue(Http2Handler.copyHttp2Headers(source).isEmpty());
+    }
+
+    @Test
+    void rejectsInvalidHeaderValues() {
         Http2Headers source = new DefaultHttp2Headers(false)
                 .add("x-test", "value\r\ninjected");
 
         assertThrows(IllegalArgumentException.class, () -> Http2Handler.copyHttp2Headers(source));
+    }
+
+    @Test
+    void rejectsProhibitedTrailingHeaders() {
+        for (CharSequence name : Arrays.asList(CONTENT_LENGTH, TRANSFER_ENCODING, TRAILER)) {
+            Http2Headers source = new DefaultHttp2Headers(false).add(name, "value");
+
+            assertThrows(IllegalArgumentException.class, () -> Http2Handler.copyHttp2Trailers(source), name.toString());
+        }
     }
 }

--- a/client/src/test/java/org/asynchttpclient/netty/handler/Http2HandlerTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/handler/Http2HandlerTest.java
@@ -20,11 +20,8 @@ import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2Headers;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderNames.TRAILER;
-import static io.netty.handler.codec.http.HttpHeaderNames.TRANSFER_ENCODING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -36,20 +33,31 @@ class Http2HandlerTest {
     void copiesRegularHeadersAndSkipsPseudoHeaders() {
         Http2Headers source = new DefaultHttp2Headers(false)
                 .status("200")
+                .add(CONTENT_LENGTH, "5")
                 .add("x-test", "value");
 
         HttpHeaders copy = Http2Handler.copyHttp2Headers(source);
 
+        assertEquals("5", copy.get(CONTENT_LENGTH));
         assertEquals("value", copy.get("x-test"));
         assertFalse(copy.contains(":status"));
     }
 
     @Test
     void rejectsInvalidHeaderNames() {
-        Http2Headers source = new DefaultHttp2Headers(false)
+        Http2Headers crlf = new DefaultHttp2Headers(false)
                 .add("invalid\r\nname", "value");
+        Http2Headers space = new DefaultHttp2Headers(false)
+                .add("invalid name", "value");
+        Http2Headers parenthesis = new DefaultHttp2Headers(false)
+                .add("invalid(name", "value");
 
-        assertThrows(IllegalArgumentException.class, () -> Http2Handler.copyHttp2Headers(source));
+        assertThrows(IllegalArgumentException.class, () -> Http2Handler.copyHttp2Headers(crlf));
+        assertThrows(IllegalArgumentException.class, () -> Http2Handler.copyHttp2Trailers(crlf));
+        assertThrows(IllegalArgumentException.class, () -> Http2Handler.copyHttp2Headers(space));
+        assertThrows(IllegalArgumentException.class, () -> Http2Handler.copyHttp2Trailers(space));
+        assertThrows(IllegalArgumentException.class, () -> Http2Handler.copyHttp2Headers(parenthesis));
+        assertThrows(IllegalArgumentException.class, () -> Http2Handler.copyHttp2Trailers(parenthesis));
     }
 
     @Test
@@ -66,14 +74,22 @@ class Http2HandlerTest {
                 .add("x-test", "value\r\ninjected");
 
         assertThrows(IllegalArgumentException.class, () -> Http2Handler.copyHttp2Headers(source));
+        assertThrows(IllegalArgumentException.class, () -> Http2Handler.copyHttp2Trailers(source));
     }
 
     @Test
-    void rejectsProhibitedTrailingHeaders() {
-        for (CharSequence name : Arrays.asList(CONTENT_LENGTH, TRANSFER_ENCODING, TRAILER)) {
-            Http2Headers source = new DefaultHttp2Headers(false).add(name, "value");
+    void dropsProhibitedTrailingHeaders() {
+        Http2Headers source = new DefaultHttp2Headers(false)
+                .status("200")
+                .add("grpc-status", "0")
+                .add(CONTENT_LENGTH, "5")
+                .add(TRAILER, "x-checksum");
 
-            assertThrows(IllegalArgumentException.class, () -> Http2Handler.copyHttp2Trailers(source), name.toString());
-        }
+        HttpHeaders copy = Http2Handler.copyHttp2Trailers(source);
+
+        assertEquals("0", copy.get("grpc-status"));
+        assertFalse(copy.contains(CONTENT_LENGTH));
+        assertFalse(copy.contains(TRAILER));
+        assertFalse(copy.contains(":status"));
     }
 }


### PR DESCRIPTION
## Summary

* retain complete HTTP token and value validation when converting HTTP/2 response headers and trailers
* drop the trailer-prohibited fields (Content-Length, Transfer-Encoding, Trailer) instead of rejecting them
* centralize pseudo-header filtering without a per-frame capturing lambda
* cover malformed names and values, empty names, and prohibited trailer fields

## Motivation

The original implementation assumed the HTTP/2 decoder had already performed complete header-name validation. Netty 4.2.15 validates HTTP/2 casing and pseudo-header rules, but it does not enforce the complete HTTP token syntax, and decoded values are not validated by default. Disabling name validation therefore removed the only complete check before headers reached user code.

This revision keeps Netty's normal header validation on both the response and trailer paths, so names are token-checked and values are CR/LF-checked exactly as they were before.

Trailers additionally drop the fields that cannot be processed after the content, matching HttpObjectDecoder.isPermittedTrailingHeader. Dropping rather than rejecting is deliberate. RFC 9110 section 6.5.1 puts the constraint on the sender, and the only recipient-level requirement in that section concerns merging trailers into the header section, which this code does not do. Rejecting would also fail a response whose body has already been delivered to the AsyncHandler, and would make HTTP/2 behave differently from HTTP/1 for the same server response, since HttpObjectDecoder drops these fields silently.

The shared enhanced-for copy path avoids a capturing lambda allocation for each response and trailer frame.

## Validation

* JDK 11 focused Http2HandlerTest: 5 tests passed
* JDK 11 `./mvnw clean verify`: build, tests, Javadocs, signing, and Revapi passed

## Attribution

Codex on behalf of Pavel Ptashyt
