### PR TITLE
Document blocking SPNEGO hostname lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,11 @@ Response response = client
 
 Supported schemes: **Basic**, **Digest**, **NTLM**, **SPNEGO/Kerberos**, **SCRAM-SHA-256**.
 
+SPNEGO/Kerberos canonical-hostname resolution is disabled by default. Enabling it with
+`setUseCanonicalHostname(true)` performs a blocking JVM lookup while generating the authentication token; during
+an authentication retry, that work can run on a Netty event-loop thread. When the service principal name is known,
+provide it with `setServicePrincipalName(...)` instead of enabling hostname canonicalization.
+
 ## Proxy Support
 
 ```java

--- a/client/src/main/java/org/asynchttpclient/Realm.java
+++ b/client/src/main/java/org/asynchttpclient/Realm.java
@@ -221,6 +221,9 @@ public class Realm {
         return servicePrincipalName;
     }
 
+    /**
+     * Returns whether SPNEGO/Kerberos authentication canonicalizes the target hostname through the JVM resolver.
+     */
     public boolean isUseCanonicalHostname() {
         return useCanonicalHostname;
     }
@@ -421,6 +424,11 @@ public class Realm {
             return this;
         }
 
+        /**
+         * Enables JVM canonical-hostname resolution when deriving the SPNEGO/Kerberos service principal name.
+         * Resolution is blocking and can run on a Netty event-loop thread during authentication retries. Prefer
+         * {@link #setServicePrincipalName(String)} when the service principal name is known.
+         */
         public Builder setUseCanonicalHostname(boolean useCanonicalHostname) {
             this.useCanonicalHostname = useCanonicalHostname;
             return this;


### PR DESCRIPTION
## Summary

- document that SPNEGO/Kerberos canonical-hostname resolution performs a blocking JVM lookup
- identify authentication retries as a path where the lookup can run on a Netty event-loop thread
- direct users with a known service principal to `setServicePrincipalName(...)`, which avoids hostname canonicalization

## Motivation

`setUseCanonicalHostname(true)` is opt-in, but `SpnegoEngine` derives the service principal with `InetAddress.getByName(...).getCanonicalHostName()`. This synchronous lookup can delay unrelated channel work when authentication is retried from an event-loop thread.

Changing or bypassing canonicalization can select a different Kerberos service principal and break authentication. Adding an AsyncHttpClient-specific cache would also introduce hostname freshness semantics separate from the JVM DNS cache, while not eliminating the first blocking lookup. This PR therefore documents the risk and the existing behavior-preserving mitigation without changing runtime semantics.

## Validation

- `./mvnw -B -ntp -pl client -DskipTests -Dgpg.skip=true verify` (compilation, Javadocs, and Revapi)

The required JDK 11 `./mvnw clean verify` was not run because JDK 11 is not available in the local environment. This documentation-only change does not alter runtime behavior; CI will exercise the supported JDK matrix.

Codex on behalf of Pavel Ptashyts
