### PR TITLE
Redact sensitive headers from debug logs

### DIFF
--- a/client/src/main/java/org/asynchttpclient/DefaultRequest.java
+++ b/client/src/main/java/org/asynchttpclient/DefaultRequest.java
@@ -37,6 +37,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.asynchttpclient.netty.handler.HttpMessageFormatter.REDACTED;
+import static org.asynchttpclient.netty.handler.HttpMessageFormatter.isSensitiveHeader;
 import static org.asynchttpclient.util.MiscUtils.isNonEmpty;
 
 public class DefaultRequest implements Request {
@@ -293,7 +295,7 @@ public class DefaultRequest implements Request {
                 sb.append('\t');
                 sb.append(header.getKey());
                 sb.append(':');
-                sb.append(header.getValue());
+                sb.append(isSensitiveHeader(header.getKey()) ? REDACTED : header.getValue());
             }
         }
 

--- a/client/src/main/java/org/asynchttpclient/DefaultRequest.java
+++ b/client/src/main/java/org/asynchttpclient/DefaultRequest.java
@@ -37,9 +37,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.asynchttpclient.netty.handler.HttpMessageFormatter.REDACTED;
-import static org.asynchttpclient.netty.handler.HttpMessageFormatter.isSensitiveHeader;
 import static org.asynchttpclient.util.MiscUtils.isNonEmpty;
+import static org.asynchttpclient.util.SensitiveLoggingUtils.REDACTED;
+import static org.asynchttpclient.util.SensitiveLoggingUtils.isSensitiveHeader;
 
 public class DefaultRequest implements Request {
 
@@ -294,7 +294,7 @@ public class DefaultRequest implements Request {
             for (Map.Entry<String, String> header : headers) {
                 sb.append('\t');
                 sb.append(header.getKey());
-                sb.append(':');
+                sb.append(": ");
                 sb.append(isSensitiveHeader(header.getKey()) ? REDACTED : header.getValue());
             }
         }

--- a/client/src/main/java/org/asynchttpclient/netty/NettyResponseFuture.java
+++ b/client/src/main/java/org/asynchttpclient/netty/NettyResponseFuture.java
@@ -710,6 +710,7 @@ public final class NettyResponseFuture<V> implements ListenableFuture<V> {
                 ",\n\tisDone=" + isDone + //
                 ",\n\tisCancelled=" + isCancelled + //
                 ",\n\tasyncHandler=" + asyncHandler + //
+                // NettyRequest deliberately keeps Object.toString() so request headers are not rendered here.
                 ",\n\tnettyRequest=" + nettyRequest + //
                 ",\n\tfuture=" + future + //
                 ",\n\turi=" + getUri() + //

--- a/client/src/main/java/org/asynchttpclient/netty/handler/HttpHandler.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/HttpHandler.java
@@ -58,7 +58,9 @@ public final class HttpHandler extends AsyncHttpClientHandler {
 
     private void handleHttpResponse(final HttpResponse response, final Channel channel, final NettyResponseFuture<?> future, AsyncHandler<?> handler) throws Exception {
         HttpRequest httpRequest = future.getNettyRequest().getHttpRequest();
-        logger.debug("\n\nRequest {}\n\nResponse {}\n", httpRequest, response);
+        if (logger.isDebugEnabled()) {
+            logger.debug("\n\nRequest {}\n\nResponse {}\n", HttpMessageFormatter.format(httpRequest), HttpMessageFormatter.format(response));
+        }
 
         future.setKeepAlive(config.getKeepAliveStrategy().keepAlive((InetSocketAddress) channel.remoteAddress(), future.getTargetRequest(), httpRequest, response));
 

--- a/client/src/main/java/org/asynchttpclient/netty/handler/HttpMessageFormatter.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/HttpMessageFormatter.java
@@ -1,0 +1,69 @@
+/*
+ *    Copyright (c) 2026 AsyncHttpClient Project. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.asynchttpclient.netty.handler;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+
+import java.util.Map;
+
+/** Formats HTTP messages for logging without rendering sensitive header values. */
+public final class HttpMessageFormatter {
+
+    /** The value used in place of sensitive header values. */
+    public static final String REDACTED = "<redacted>";
+
+    private HttpMessageFormatter() {
+    }
+
+    static String format(HttpRequest request) {
+        StringBuilder value = new StringBuilder()
+                .append(request.method()).append(' ')
+                .append(request.uri()).append(' ')
+                .append(request.protocolVersion());
+        return appendHeaders(value, request.headers()).toString();
+    }
+
+    static String format(HttpResponse response) {
+        StringBuilder value = new StringBuilder()
+                .append(response.protocolVersion()).append(' ')
+                .append(response.status());
+        return appendHeaders(value, response.headers()).toString();
+    }
+
+    private static StringBuilder appendHeaders(StringBuilder value, HttpHeaders headers) {
+        for (Map.Entry<String, String> header : headers) {
+            value.append('\n').append(header.getKey()).append(": ")
+                    .append(isSensitiveHeader(header.getKey()) ? REDACTED : header.getValue());
+        }
+        return value;
+    }
+
+    /**
+     * Returns whether a header value must be redacted from logs.
+     *
+     * @param name the header name
+     * @return {@code true} for authentication and cookie headers
+     */
+    public static boolean isSensitiveHeader(CharSequence name) {
+        return HttpHeaderNames.AUTHORIZATION.contentEqualsIgnoreCase(name)
+                || HttpHeaderNames.PROXY_AUTHORIZATION.contentEqualsIgnoreCase(name)
+                || HttpHeaderNames.COOKIE.contentEqualsIgnoreCase(name)
+                || HttpHeaderNames.SET_COOKIE.contentEqualsIgnoreCase(name);
+    }
+}

--- a/client/src/main/java/org/asynchttpclient/netty/handler/HttpMessageFormatter.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/HttpMessageFormatter.java
@@ -22,8 +22,17 @@ import io.netty.handler.codec.http.HttpResponse;
 
 import java.util.Map;
 
-/** Formats HTTP messages for logging without rendering sensitive header values. */
+/**
+ * Formats HTTP messages for logging. Sensitive header values are redacted unless the
+ * {@code org.asynchttpclient.enableSensitiveLogging} system property or {@code AHC_ENABLE_SENSITIVE_LOGGING} environment
+ * variable is set to {@code true} when this class is initialized. Enabling sensitive logging may expose credentials and
+ * session data.
+ */
 public final class HttpMessageFormatter {
+
+    private static final String ENABLE_SENSITIVE_LOGGING_PROPERTY = "org.asynchttpclient.enableSensitiveLogging";
+    private static final String ENABLE_SENSITIVE_LOGGING_ENVIRONMENT_VARIABLE = "AHC_ENABLE_SENSITIVE_LOGGING";
+    private static final boolean SENSITIVE_LOGGING_ENABLED = isSensitiveLoggingEnabled();
 
     /** The value used in place of sensitive header values. */
     public static final String REDACTED = "<redacted>";
@@ -54,16 +63,22 @@ public final class HttpMessageFormatter {
         return value;
     }
 
+    private static boolean isSensitiveLoggingEnabled() {
+        String propertyValue = System.getProperty(ENABLE_SENSITIVE_LOGGING_PROPERTY);
+        String value = propertyValue != null ? propertyValue : System.getenv(ENABLE_SENSITIVE_LOGGING_ENVIRONMENT_VARIABLE);
+        return Boolean.parseBoolean(value);
+    }
+
     /**
      * Returns whether a header value must be redacted from logs.
      *
      * @param name the header name
-     * @return {@code true} for authentication and cookie headers
+     * @return {@code true} for authentication and cookie headers when sensitive logging is disabled
      */
     public static boolean isSensitiveHeader(CharSequence name) {
-        return HttpHeaderNames.AUTHORIZATION.contentEqualsIgnoreCase(name)
+        return !SENSITIVE_LOGGING_ENABLED && (HttpHeaderNames.AUTHORIZATION.contentEqualsIgnoreCase(name)
                 || HttpHeaderNames.PROXY_AUTHORIZATION.contentEqualsIgnoreCase(name)
                 || HttpHeaderNames.COOKIE.contentEqualsIgnoreCase(name)
-                || HttpHeaderNames.SET_COOKIE.contentEqualsIgnoreCase(name);
+                || HttpHeaderNames.SET_COOKIE.contentEqualsIgnoreCase(name));
     }
 }

--- a/client/src/main/java/org/asynchttpclient/netty/handler/HttpMessageFormatter.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/HttpMessageFormatter.java
@@ -15,27 +15,23 @@
  */
 package org.asynchttpclient.netty.handler;
 
-import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import org.asynchttpclient.util.SensitiveLoggingUtils;
 
 import java.util.Map;
 
 /**
  * Formats HTTP messages for logging. Sensitive header values are redacted unless the
  * {@code org.asynchttpclient.enableSensitiveLogging} system property or {@code AHC_ENABLE_SENSITIVE_LOGGING} environment
- * variable is set to {@code true} when this class is initialized. Enabling sensitive logging may expose credentials and
- * session data.
+ * variable is set to {@code true} before the sensitive logging policy is initialized. Enabling sensitive logging may
+ * expose credentials and session data.
  */
 public final class HttpMessageFormatter {
 
-    private static final String ENABLE_SENSITIVE_LOGGING_PROPERTY = "org.asynchttpclient.enableSensitiveLogging";
-    private static final String ENABLE_SENSITIVE_LOGGING_ENVIRONMENT_VARIABLE = "AHC_ENABLE_SENSITIVE_LOGGING";
-    private static final boolean SENSITIVE_LOGGING_ENABLED = isSensitiveLoggingEnabled();
-
     /** The value used in place of sensitive header values. */
-    public static final String REDACTED = "<redacted>";
+    public static final String REDACTED = SensitiveLoggingUtils.REDACTED;
 
     private HttpMessageFormatter() {
     }
@@ -63,12 +59,6 @@ public final class HttpMessageFormatter {
         return value;
     }
 
-    private static boolean isSensitiveLoggingEnabled() {
-        String propertyValue = System.getProperty(ENABLE_SENSITIVE_LOGGING_PROPERTY);
-        String value = propertyValue != null ? propertyValue : System.getenv(ENABLE_SENSITIVE_LOGGING_ENVIRONMENT_VARIABLE);
-        return Boolean.parseBoolean(value);
-    }
-
     /**
      * Returns whether a header value must be redacted from logs.
      *
@@ -76,9 +66,6 @@ public final class HttpMessageFormatter {
      * @return {@code true} for authentication and cookie headers when sensitive logging is disabled
      */
     public static boolean isSensitiveHeader(CharSequence name) {
-        return !SENSITIVE_LOGGING_ENABLED && (HttpHeaderNames.AUTHORIZATION.contentEqualsIgnoreCase(name)
-                || HttpHeaderNames.PROXY_AUTHORIZATION.contentEqualsIgnoreCase(name)
-                || HttpHeaderNames.COOKIE.contentEqualsIgnoreCase(name)
-                || HttpHeaderNames.SET_COOKIE.contentEqualsIgnoreCase(name));
+        return SensitiveLoggingUtils.isSensitiveHeader(name);
     }
 }

--- a/client/src/main/java/org/asynchttpclient/netty/handler/WebSocketHandler.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/WebSocketHandler.java
@@ -110,7 +110,7 @@ public final class WebSocketHandler extends AsyncHttpClientHandler {
             HttpResponse response = (HttpResponse) e;
             if (logger.isDebugEnabled()) {
                 HttpRequest httpRequest = future.getNettyRequest().getHttpRequest();
-                logger.debug("\n\nRequest {}\n\nResponse {}\n", httpRequest, response);
+                logger.debug("\n\nRequest {}\n\nResponse {}\n", HttpMessageFormatter.format(httpRequest), HttpMessageFormatter.format(response));
             }
 
             WebSocketUpgradeHandler handler = getWebSocketUpgradeHandler(future);

--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
@@ -1105,7 +1105,8 @@ public final class NettyRequestSender {
         if (future.isReplayPossible()) {
             future.setChannelState(ChannelState.RECONNECTED);
 
-            LOGGER.debug("Trying to recover request {}\n", future.getNettyRequest().getHttpRequest());
+            HttpRequest request = future.getNettyRequest().getHttpRequest();
+            LOGGER.debug("Trying to recover request '{}' to '{}'\n", request.method(), request.uri());
             try {
                 future.getAsyncHandler().onRetry();
             } catch (Exception e) {
@@ -1413,7 +1414,7 @@ public final class NettyRequestSender {
         future.setChannelState(ChannelState.NEW);
         future.touch();
 
-        LOGGER.debug("\n\nReplaying Request {}\n for Future {}\n", newRequest, future);
+        LOGGER.debug("\n\nReplaying request '{}' to '{}'\n for Future {}\n", newRequest.getMethod(), newRequest.getUri(), future);
         try {
             future.getAsyncHandler().onRetry();
         } catch (Exception e) {

--- a/client/src/main/java/org/asynchttpclient/util/SensitiveLoggingUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/SensitiveLoggingUtils.java
@@ -1,0 +1,64 @@
+/*
+ *    Copyright (c) 2026 AsyncHttpClient Project. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.asynchttpclient.util;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Shared policy for rendering sensitive HTTP headers in logs. The policy is read once from the
+ * {@code org.asynchttpclient.enableSensitiveLogging} system property or {@code AHC_ENABLE_SENSITIVE_LOGGING} environment
+ * variable when this class is initialized.
+ */
+public final class SensitiveLoggingUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SensitiveLoggingUtils.class);
+    private static final String ENABLE_SENSITIVE_LOGGING_PROPERTY = "org.asynchttpclient.enableSensitiveLogging";
+    private static final String ENABLE_SENSITIVE_LOGGING_ENVIRONMENT_VARIABLE = "AHC_ENABLE_SENSITIVE_LOGGING";
+    private static final boolean SENSITIVE_LOGGING_ENABLED = isSensitiveLoggingEnabled();
+
+    /** The value used in place of sensitive header values. */
+    public static final String REDACTED = "<redacted>";
+
+    static {
+        if (SENSITIVE_LOGGING_ENABLED) {
+            LOGGER.warn("Sensitive HTTP header logging is enabled; credentials and session data may be written to logs");
+        }
+    }
+
+    private SensitiveLoggingUtils() {
+    }
+
+    /**
+     * Returns whether a header value must be redacted from logs.
+     *
+     * @param name the header name
+     * @return {@code true} for authentication and cookie headers when sensitive logging is disabled
+     */
+    public static boolean isSensitiveHeader(CharSequence name) {
+        return !SENSITIVE_LOGGING_ENABLED && (HttpHeaderNames.AUTHORIZATION.contentEqualsIgnoreCase(name)
+                || HttpHeaderNames.PROXY_AUTHORIZATION.contentEqualsIgnoreCase(name)
+                || HttpHeaderNames.COOKIE.contentEqualsIgnoreCase(name)
+                || HttpHeaderNames.SET_COOKIE.contentEqualsIgnoreCase(name));
+    }
+
+    private static boolean isSensitiveLoggingEnabled() {
+        String propertyValue = System.getProperty(ENABLE_SENSITIVE_LOGGING_PROPERTY);
+        String value = propertyValue != null ? propertyValue : System.getenv(ENABLE_SENSITIVE_LOGGING_ENVIRONMENT_VARIABLE);
+        return Boolean.parseBoolean(value);
+    }
+}

--- a/client/src/test/java/org/asynchttpclient/RequestBuilderTest.java
+++ b/client/src/test/java/org/asynchttpclient/RequestBuilderTest.java
@@ -21,6 +21,7 @@ import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -411,5 +412,24 @@ public class RequestBuilderTest {
 
         String contentType = request.getHeaders().get("Content-Type");
         assertEquals("text/plain", contentType, "Content-Type set via addHeader(Iterable) should not be modified");
+    }
+
+    @Test
+    public void testRequestToStringRedactsSensitiveHeaders() {
+        Request request = get("http://localhost/test")
+                .setHeader("Authorization", "Bearer request-secret")
+                .setHeader("Proxy-Authorization", "Basic proxy-secret")
+                .setHeader("Cookie", "session=cookie-secret")
+                .setHeader("X-Request-Id", "request-id")
+                .build();
+
+        String value = request.toString();
+        assertFalse(value.contains("request-secret"));
+        assertFalse(value.contains("proxy-secret"));
+        assertFalse(value.contains("cookie-secret"));
+        assertTrue(value.contains("Authorization:<redacted>"));
+        assertTrue(value.contains("Proxy-Authorization:<redacted>"));
+        assertTrue(value.contains("Cookie:<redacted>"));
+        assertTrue(value.contains("request-id"));
     }
 }

--- a/client/src/test/java/org/asynchttpclient/RequestBuilderTest.java
+++ b/client/src/test/java/org/asynchttpclient/RequestBuilderTest.java
@@ -427,9 +427,9 @@ public class RequestBuilderTest {
         assertFalse(value.contains("request-secret"));
         assertFalse(value.contains("proxy-secret"));
         assertFalse(value.contains("cookie-secret"));
-        assertTrue(value.contains("Authorization:<redacted>"));
-        assertTrue(value.contains("Proxy-Authorization:<redacted>"));
-        assertTrue(value.contains("Cookie:<redacted>"));
+        assertTrue(value.contains("Authorization: <redacted>"));
+        assertTrue(value.contains("Proxy-Authorization: <redacted>"));
+        assertTrue(value.contains("Cookie: <redacted>"));
         assertTrue(value.contains("request-id"));
     }
 }

--- a/client/src/test/java/org/asynchttpclient/netty/handler/HttpMessageFormatterTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/handler/HttpMessageFormatterTest.java
@@ -23,6 +23,8 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -60,5 +62,28 @@ public class HttpMessageFormatterTest {
         assertFalse(value.contains("response-secret"));
         assertTrue(value.contains("Set-Cookie: <redacted>"));
         assertTrue(value.contains("X-Request-Id: request-id"));
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = "org.asynchttpclient.enableSensitiveLogging", matches = "(?i)true")
+    public void shouldIncludeSensitiveHeadersWhenSystemPropertyEnabled() {
+        assertSensitiveHeadersIncluded();
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "AHC_ENABLE_SENSITIVE_LOGGING", matches = "(?i)true")
+    public void shouldIncludeSensitiveHeadersWhenEnvironmentVariableEnabled() {
+        assertSensitiveHeadersIncluded();
+    }
+
+    private static void assertSensitiveHeadersIncluded() {
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/test");
+        request.headers().set("Authorization", "Bearer request-secret");
+
+        String value = HttpMessageFormatter.format(request);
+
+        assertFalse(HttpMessageFormatter.isSensitiveHeader("Authorization"));
+        assertTrue(value.contains("Authorization: Bearer request-secret"));
+        assertFalse(value.contains(HttpMessageFormatter.REDACTED));
     }
 }

--- a/client/src/test/java/org/asynchttpclient/netty/handler/HttpMessageFormatterTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/handler/HttpMessageFormatterTest.java
@@ -1,0 +1,64 @@
+/*
+ *    Copyright (c) 2026 AsyncHttpClient Project. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.asynchttpclient.netty.handler;
+
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HttpMessageFormatterTest {
+
+    @Test
+    public void shouldRedactSensitiveRequestHeaders() {
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/test");
+        request.headers()
+                .set("Authorization", "Bearer request-secret")
+                .set("proxy-authorization", "Basic proxy-secret")
+                .set("Cookie", "session=cookie-secret")
+                .set("X-Request-Id", "request-id");
+
+        String value = HttpMessageFormatter.format(request);
+
+        assertFalse(value.contains("request-secret"));
+        assertFalse(value.contains("proxy-secret"));
+        assertFalse(value.contains("cookie-secret"));
+        assertTrue(value.contains("Authorization: <redacted>"));
+        assertTrue(value.contains("proxy-authorization: <redacted>"));
+        assertTrue(value.contains("X-Request-Id: request-id"));
+    }
+
+    @Test
+    public void shouldRedactSensitiveResponseHeaders() {
+        HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        response.headers()
+                .set("Set-Cookie", "session=response-secret")
+                .set("X-Request-Id", "request-id");
+
+        String value = HttpMessageFormatter.format(response);
+
+        assertFalse(value.contains("response-secret"));
+        assertTrue(value.contains("Set-Cookie: <redacted>"));
+        assertTrue(value.contains("X-Request-Id: request-id"));
+    }
+}

--- a/client/src/test/java/org/asynchttpclient/netty/handler/HttpMessageFormatterTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/handler/HttpMessageFormatterTest.java
@@ -23,9 +23,17 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -65,25 +73,61 @@ public class HttpMessageFormatterTest {
     }
 
     @Test
-    @EnabledIfSystemProperty(named = "org.asynchttpclient.enableSensitiveLogging", matches = "(?i)true")
-    public void shouldIncludeSensitiveHeadersWhenSystemPropertyEnabled() {
-        assertSensitiveHeadersIncluded();
+    public void shouldIncludeSensitiveHeadersWhenSystemPropertyEnabled() throws Exception {
+        String output = runProbe("true", null);
+
+        assertTrue(output.contains("Authorization: Bearer request-secret"), output);
+        assertTrue(output.contains("Sensitive HTTP header logging is enabled"), output);
     }
 
     @Test
-    @EnabledIfEnvironmentVariable(named = "AHC_ENABLE_SENSITIVE_LOGGING", matches = "(?i)true")
-    public void shouldIncludeSensitiveHeadersWhenEnvironmentVariableEnabled() {
-        assertSensitiveHeadersIncluded();
+    public void shouldIncludeSensitiveHeadersWhenEnvironmentVariableEnabled() throws Exception {
+        String output = runProbe(null, "true");
+
+        assertTrue(output.contains("Authorization: Bearer request-secret"), output);
+        assertTrue(output.contains("Sensitive HTTP header logging is enabled"), output);
     }
 
-    private static void assertSensitiveHeadersIncluded() {
-        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/test");
-        request.headers().set("Authorization", "Bearer request-secret");
+    @Test
+    public void systemPropertyShouldOverrideEnvironmentVariable() throws Exception {
+        String output = runProbe("false", "true");
 
-        String value = HttpMessageFormatter.format(request);
+        assertTrue(output.contains("Authorization: <redacted>"), output);
+        assertFalse(output.contains("Sensitive HTTP header logging is enabled"), output);
+    }
 
-        assertFalse(HttpMessageFormatter.isSensitiveHeader("Authorization"));
-        assertTrue(value.contains("Authorization: Bearer request-secret"));
-        assertFalse(value.contains(HttpMessageFormatter.REDACTED));
+    private static String runProbe(String propertyValue, String environmentValue) throws Exception {
+        List<String> command = new ArrayList<>();
+        command.add(javaExecutable().toString());
+        if (propertyValue != null) {
+            command.add("-Dorg.asynchttpclient.enableSensitiveLogging=" + propertyValue);
+        }
+        command.add("-cp");
+        command.add(System.getProperty("surefire.test.class.path", System.getProperty("java.class.path")));
+        command.add(SensitiveLoggingProbe.class.getName());
+
+        ProcessBuilder processBuilder = new ProcessBuilder(command).redirectErrorStream(true);
+        if (environmentValue == null) {
+            processBuilder.environment().remove("AHC_ENABLE_SENSITIVE_LOGGING");
+        } else {
+            processBuilder.environment().put("AHC_ENABLE_SENSITIVE_LOGGING", environmentValue);
+        }
+
+        Process process = processBuilder.start();
+        if (!process.waitFor(30, TimeUnit.SECONDS)) {
+            process.destroyForcibly();
+            throw new AssertionError("Sensitive logging probe timed out");
+        }
+        String output = new String(process.getInputStream().readAllBytes(), UTF_8);
+        assertEquals(0, process.exitValue(), output);
+        return output;
+    }
+
+    private static Path javaExecutable() throws IOException {
+        String executable = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win")
+                ? "java.exe"
+                : "java";
+        Path path = Paths.get(System.getProperty("java.home"), "bin", executable);
+        return path.toRealPath();
     }
 }

--- a/client/src/test/java/org/asynchttpclient/netty/handler/HttpMessageFormatterTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/handler/HttpMessageFormatterTest.java
@@ -23,8 +23,10 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -38,6 +40,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HttpMessageFormatterTest {
+
+    @TempDir
+    private Path tempDirectory;
 
     @Test
     public void shouldRedactSensitiveRequestHeaders() {
@@ -96,7 +101,7 @@ public class HttpMessageFormatterTest {
         assertFalse(output.contains("Sensitive HTTP header logging is enabled"), output);
     }
 
-    private static String runProbe(String propertyValue, String environmentValue) throws Exception {
+    private String runProbe(String propertyValue, String environmentValue) throws Exception {
         List<String> command = new ArrayList<>();
         command.add(javaExecutable().toString());
         if (propertyValue != null) {
@@ -106,7 +111,10 @@ public class HttpMessageFormatterTest {
         command.add(System.getProperty("surefire.test.class.path", System.getProperty("java.class.path")));
         command.add(SensitiveLoggingProbe.class.getName());
 
-        ProcessBuilder processBuilder = new ProcessBuilder(command).redirectErrorStream(true);
+        Path outputFile = Files.createTempFile(tempDirectory, "sensitive-logging-probe-", ".log");
+        ProcessBuilder processBuilder = new ProcessBuilder(command)
+                .redirectErrorStream(true)
+                .redirectOutput(outputFile.toFile());
         if (environmentValue == null) {
             processBuilder.environment().remove("AHC_ENABLE_SENSITIVE_LOGGING");
         } else {
@@ -116,9 +124,10 @@ public class HttpMessageFormatterTest {
         Process process = processBuilder.start();
         if (!process.waitFor(30, TimeUnit.SECONDS)) {
             process.destroyForcibly();
-            throw new AssertionError("Sensitive logging probe timed out");
+            process.waitFor(10, TimeUnit.SECONDS);
+            throw new AssertionError("Sensitive logging probe timed out\n" + Files.readString(outputFile, UTF_8));
         }
-        String output = new String(process.getInputStream().readAllBytes(), UTF_8);
+        String output = Files.readString(outputFile, UTF_8);
         assertEquals(0, process.exitValue(), output);
         return output;
     }

--- a/client/src/test/java/org/asynchttpclient/netty/handler/SensitiveLoggingProbe.java
+++ b/client/src/test/java/org/asynchttpclient/netty/handler/SensitiveLoggingProbe.java
@@ -1,0 +1,33 @@
+/*
+ *    Copyright (c) 2026 AsyncHttpClient Project. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.asynchttpclient.netty.handler;
+
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpVersion;
+
+public final class SensitiveLoggingProbe {
+
+    private SensitiveLoggingProbe() {
+    }
+
+    public static void main(String[] args) {
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/test");
+        request.headers().set("Authorization", "Bearer request-secret");
+        System.out.println(HttpMessageFormatter.format(request));
+    }
+}


### PR DESCRIPTION
## Summary

- redact authentication and cookie values in HTTP and WebSocket debug logs
- share the redaction policy through a neutral utility used by request and Netty logging
- allow sensitive logging through an explicit startup-only JVM property or environment variable
- warn once at startup when sensitive logging is enabled
- avoid rendering complete request objects in retry and replay logs by default
- add regression coverage for Netty message formatting, request output, and every startup configuration

## Root cause

Debug logging passed complete Netty request and response objects to SLF4J. Their
string representations included every header value, so user-supplied
`Authorization` headers and other credentials could be written to application
logs.

## Sensitive logging

Sensitive values remain redacted by default. Full header values can be enabled
before the sensitive logging policy is initialized with either:

- JVM property: `-Dorg.asynchttpclient.enableSensitiveLogging=true`
- environment variable: `AHC_ENABLE_SENSITIVE_LOGGING=true`

The JVM property takes precedence over the environment variable. The setting is
read once and remains immutable for the process. A warning is logged once when
sensitive logging is enabled because credentials and session data may be exposed.

## Scope

This change addresses the header disclosure reported in #1739 and #1740.
Request form, query, multipart, and arbitrary body values do not have a reliable
generic sensitivity classification and remain outside this change.

## Validation

- JDK 11 focused `HttpMessageFormatterTest` and `RequestBuilderTest`: 33 tests passed, 0 skipped
- JDK 11 system-property, environment-variable, and precedence paths execute in isolated JVMs
- JDK 11 `./mvnw clean verify`: passed, including Javadocs and Revapi
- GitHub Actions matrix: passed on Ubuntu, macOS, and Windows with JDK 11, 17, 21, and 25

Closes #1739
Closes #1740

Codex on behalf of Pavel Ptashyts