### PR TITLE
use SecureRandom for the multipart boundary and websocket key

### DIFF
--- a/client/src/main/java/org/asynchttpclient/util/HttpUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/HttpUtils.java
@@ -24,8 +24,8 @@ import org.jetbrains.annotations.Nullable;
 import java.net.URLEncoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.security.SecureRandom;
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -114,9 +114,13 @@ public final class HttpUtils {
     // The pool of ASCII chars to be used for generating a multipart boundary.
     private static final byte[] MULTIPART_CHARS = "-_1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".getBytes(US_ASCII);
 
+    // The boundary is what separates parts whose content is not escaped, so it must be unpredictable,
+    // like the cnonce in Realm and the SCRAM nonce.
+    private static final ThreadLocal<SecureRandom> BOUNDARY_RANDOM = ThreadLocal.withInitial(SecureRandom::new);
+
     // a random size from 30 to 40
     public static byte[] computeMultipartBoundary() {
-        ThreadLocalRandom random = ThreadLocalRandom.current();
+        SecureRandom random = BOUNDARY_RANDOM.get();
         byte[] bytes = new byte[random.nextInt(11) + 30];
         for (int i = 0; i < bytes.length; i++) {
             bytes[i] = MULTIPART_CHARS[random.nextInt(MULTIPART_CHARS.length)];

--- a/client/src/main/java/org/asynchttpclient/ws/WebSocketUtils.java
+++ b/client/src/main/java/org/asynchttpclient/ws/WebSocketUtils.java
@@ -15,8 +15,7 @@
  */
 package org.asynchttpclient.ws;
 
-import io.netty.util.internal.ThreadLocalRandom;
-
+import java.security.SecureRandom;
 import java.util.Base64;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -25,16 +24,16 @@ import static org.asynchttpclient.util.MessageDigestUtils.pooledSha1MessageDiges
 public final class WebSocketUtils {
     private static final String MAGIC_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
+    // RFC 6455 section 10.3 requires the handshake nonce to come from a strong source of entropy.
+    private static final ThreadLocal<SecureRandom> KEY_RANDOM = ThreadLocal.withInitial(SecureRandom::new);
+
     private WebSocketUtils() {
         // Prevent outside initialization
     }
 
     public static String getWebSocketKey() {
         byte[] nonce = new byte[16];
-        ThreadLocalRandom random = ThreadLocalRandom.current();
-        for (int i = 0; i < nonce.length; i++) {
-            nonce[i] = (byte) random.nextInt(256);
-        }
+        KEY_RANDOM.get().nextBytes(nonce);
         return Base64.getEncoder().encodeToString(nonce);
     }
 

--- a/client/src/test/java/org/asynchttpclient/util/HttpUtilsTest.java
+++ b/client/src/test/java/org/asynchttpclient/util/HttpUtilsTest.java
@@ -28,7 +28,9 @@ import java.net.URLEncoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static io.netty.handler.codec.http.HttpHeaderValues.APPLICATION_JSON;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
@@ -117,6 +119,20 @@ public class HttpUtilsTest {
         DefaultAsyncHttpClientConfig config = new DefaultAsyncHttpClientConfig.Builder().setFollowRedirect(true).build();
         boolean followRedirect = HttpUtils.followRedirect(config, request);
         assertFalse(followRedirect, "Follow redirect value set in request should be given priority");
+    }
+
+    @RepeatedIfExceptionsTest(repeats = 5)
+    public void testComputeMultipartBoundary() {
+        String allowed = "-_1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        Set<String> boundaries = new HashSet<>();
+        for (int i = 0; i < 1000; i++) {
+            String boundary = new String(HttpUtils.computeMultipartBoundary(), US_ASCII);
+            assertTrue(boundary.length() >= 30 && boundary.length() <= 40, "Unexpected boundary length: " + boundary.length());
+            for (int j = 0; j < boundary.length(); j++) {
+                assertTrue(allowed.indexOf(boundary.charAt(j)) != -1, "Illegal boundary char: " + boundary.charAt(j));
+            }
+            assertTrue(boundaries.add(boundary), "Boundary was generated twice: " + boundary);
+        }
     }
 
     private static void formUrlEncoding(Charset charset) throws Exception {


### PR DESCRIPTION
computeMultipartBoundary draws the boundary from ThreadLocalRandom, which the JDK documents as not cryptographically secure: every value is mix32 over a per-thread 64-bit seed that advances by the fixed constant GAMMA, so an observer who recovers that state reproduces the whole sequence the thread will emit. Part content is never escaped, so the boundary is the only separator, and a caller that puts attacker-controlled bytes in any one field (a proxied upload, a user-supplied form value) lets that attacker close the part early and append a forged Content-Disposition, which the receiving server parses as an extra form field. getWebSocketKey builds the 16-byte Sec-WebSocket-Key nonce from the same generator, and RFC 6455 section 10.3 asks for a strong source of entropy there. Both now use a ThreadLocal<SecureRandom>, the same idiom already used for the Digest cnonce in Realm and the SCRAM nonce in ScramEngine.