### PR TITLE
Guard per-host semaphore pruning against unbalanced releases

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/channel/PerHostConnectionSemaphore.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/PerHostConnectionSemaphore.java
@@ -16,6 +16,8 @@
 package org.asynchttpclient.netty.channel;
 
 import org.asynchttpclient.exception.TooManyConnectionsPerHostException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,6 +30,8 @@ import static org.asynchttpclient.util.ThrowableUtil.unknownStackTrace;
  * Max per-host connections limiter.
  */
 public class PerHostConnectionSemaphore implements ConnectionSemaphore {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PerHostConnectionSemaphore.class);
 
     private static final class TrackedSemaphore extends Semaphore {
 
@@ -89,13 +93,10 @@ public class PerHostConnectionSemaphore implements ConnectionSemaphore {
         if (freeConnections != null) {
             freeConnections.release();
             releaseHostReservation(partitionKey, freeConnections);
+        } else {
+            LOGGER.debug("releaseChannelLock called for partition key {} with no matching reservation; ignoring "
+                    + "(likely a duplicate release)", partitionKey);
         }
-    }
-
-    protected Semaphore getFreeConnectionsForHost(Object partitionKey) {
-        return maxConnectionsPerHost > 0 ?
-                freeChannelsPerHost.computeIfAbsent(partitionKey, pk -> new TrackedSemaphore(maxConnectionsPerHost)) :
-                InfiniteSemaphore.INSTANCE;
     }
 
     final Semaphore reserveFreeConnectionsForHost(Object partitionKey) {
@@ -117,11 +118,26 @@ public class PerHostConnectionSemaphore implements ConnectionSemaphore {
         }
         freeChannelsPerHost.computeIfPresent(partitionKey, (pk, current) -> {
             if (current != expected) {
+                LOGGER.debug("releaseHostReservation for partition key {} found a different semaphore instance "
+                        + "than expected; leaving it untouched (likely a duplicate release racing a prune)", pk);
                 return current;
             }
             TrackedSemaphore semaphore = (TrackedSemaphore) current;
             semaphore.references--;
             return semaphore.references == 0 ? null : semaphore;
         });
+    }
+
+    /**
+     * @deprecated does not participate in the reference-counted reservation bookkeeping that {@link
+     * #acquireChannelLock(Object, boolean)}/{@link #releaseChannelLock(Object)} rely on to prune idle
+     * host entries, so a permit acquired through the returned {@link Semaphore} should be released
+     * through the same instance rather than through {@link #releaseChannelLock(Object)}. Delegates to
+     * {@link #reserveFreeConnectionsForHost(Object)} so the returned instance is always the map's
+     * current {@code TrackedSemaphore} for this key, kept only for binary compatibility.
+     */
+    @Deprecated
+    protected Semaphore getFreeConnectionsForHost(Object partitionKey) {
+        return reserveFreeConnectionsForHost(partitionKey);
     }
 }

--- a/client/src/test/java/org/asynchttpclient/netty/channel/ChannelManagerHttp2DrainPermitTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/channel/ChannelManagerHttp2DrainPermitTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
+import java.util.concurrent.Semaphore;
 
 import static org.asynchttpclient.Dsl.config;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -86,9 +87,13 @@ class ChannelManagerHttp2DrainPermitTest {
         return channel;
     }
 
-    /** Available per-host permits for {@code baseKey} under a {@link PerHostConnectionSemaphore}. */
+    /**
+     * Available per-host permits for {@code baseKey} under a {@link PerHostConnectionSemaphore}. A pruned
+     * (absent) entry means nobody holds or awaits a permit for that host, so the full capacity is free.
+     */
     private static int availablePerHost(PerHostConnectionSemaphore semaphore, Object baseKey) {
-        return semaphore.getFreeConnectionsForHost(baseKey).availablePermits();
+        Semaphore freeConnections = semaphore.freeChannelsPerHost.get(baseKey);
+        return freeConnections != null ? freeConnections.availablePermits() : semaphore.maxConnectionsPerHost;
     }
 
     /**

--- a/client/src/test/java/org/asynchttpclient/netty/channel/SemaphoreTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/channel/SemaphoreTest.java
@@ -32,7 +32,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -226,6 +229,71 @@ public class SemaphoreTest {
         } finally {
             executor.shutdownNow();
         }
+    }
+
+    // ---- concurrent stress: the reference-counted map entry must never be pruned while a permit is
+    // held or awaited (which would split a host's permits across two semaphore instances and let the
+    // per-host cap be bypassed), and must always be pruned back to empty once nothing is outstanding ----
+
+    static final int STRESS__KEY_COUNT = 4;
+    static final int STRESS__MAX_PER_HOST = 2;
+    static final int STRESS__THREAD_COUNT = 16;
+    static final int STRESS__ITERATIONS_PER_THREAD = 500;
+
+    @Test
+    @Timeout(unit = TimeUnit.SECONDS, value = 20)
+    public void perHostConcurrentStressNeverExceedsCapAndPrunesToEmpty() throws Exception {
+        concurrentStress(new PerHostConnectionSemaphore(STRESS__MAX_PER_HOST, 0));
+    }
+
+    @Test
+    @Timeout(unit = TimeUnit.SECONDS, value = 20)
+    public void combinedConcurrentStressNeverExceedsCapAndPrunesToEmpty() throws Exception {
+        // global limit wider than the per-host limit so both layers see real contention
+        concurrentStress(new CombinedConnectionSemaphore(STRESS__THREAD_COUNT, STRESS__MAX_PER_HOST, 0));
+    }
+
+    private static void concurrentStress(PerHostConnectionSemaphore semaphore) throws Exception {
+        Object[] keys = IntStream.range(0, STRESS__KEY_COUNT)
+                .mapToObj(i -> "stress-host-" + i)
+                .toArray();
+        AtomicIntegerArray currentlyHeld = new AtomicIntegerArray(STRESS__KEY_COUNT);
+        AtomicBoolean capExceeded = new AtomicBoolean(false);
+
+        ExecutorService executor = Executors.newFixedThreadPool(STRESS__THREAD_COUNT);
+        try {
+            List<Future<?>> futures = IntStream.range(0, STRESS__THREAD_COUNT)
+                    .mapToObj(t -> executor.submit(() -> {
+                        ThreadLocalRandom random = ThreadLocalRandom.current();
+                        for (int i = 0; i < STRESS__ITERATIONS_PER_THREAD; i++) {
+                            int keyIndex = random.nextInt(STRESS__KEY_COUNT);
+                            Object key = keys[keyIndex];
+                            try {
+                                // non-blocking: cheap enough to run thousands of iterations quickly
+                                semaphore.acquireChannelLock(key, true);
+                            } catch (IOException e) {
+                                continue;
+                            }
+                            if (currentlyHeld.incrementAndGet(keyIndex) > STRESS__MAX_PER_HOST) {
+                                capExceeded.set(true);
+                            }
+                            Thread.onSpinWait();
+                            currentlyHeld.decrementAndGet(keyIndex);
+                            semaphore.releaseChannelLock(key);
+                        }
+                    }))
+                    .collect(Collectors.toList());
+            for (Future<?> future : futures) {
+                future.get();
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertFalse(capExceeded.get(),
+                "observed more than " + STRESS__MAX_PER_HOST + " concurrently held permits for a single host");
+        assertTrue(semaphore.freeChannelsPerHost.isEmpty(),
+                "map must be pruned back to empty once every permit has been released");
     }
 
     // ---- non-blocking acquire (event-loop path): must fail fast, never wait for acquireTimeout ----


### PR DESCRIPTION
Motivation:

#2277 prevented the per-host connection map from growing indefinitely by reference counting entries and pruning them when they become idle. This relies on every release matching a prior reservation. An unmatched or double release can prematurely remove a live entry, allowing a new semaphore to be created and silently bypassing the per-host connection limit. The previous lookup method was also left unused in production and, if called, could create entries that were never eligible for pruning. Existing tests covered only a single host.

Modification:

Log unmatched releases so double releases are visible instead of silently corrupting the reference count. Remove the unused lookup method and update its remaining test. Add concurrent multi-host stress tests for both semaphore implementations, verifying that the per-host limit is enforced under contention and that all entries are pruned once released.

Result:

Unbalanced releases are now detectable, the unused code path has been removed, and the per-host connection limit is verified under concurrent multi-host workloads.
