### PR TITLE
Document Basic auth header caching, guard against stale copies

### DIFF
--- a/client/src/main/java/org/asynchttpclient/Realm.java
+++ b/client/src/main/java/org/asynchttpclient/Realm.java
@@ -249,7 +249,8 @@ public class Realm {
 
     /**
      * Returns the lazily computed and cached HTTP Basic authorization header for this immutable realm.
-     * Concurrent first calls may compute the same value more than once.
+     * Always encodes {@link #getPrincipal()} and {@link #getPassword()} as a Basic header, regardless
+     * of {@link #getScheme()}. Concurrent first calls may compute the same value more than once.
      *
      * @return the Basic authorization header
      * @since 3.0.12

--- a/client/src/test/java/org/asynchttpclient/util/AuthenticatorUtilsTest.java
+++ b/client/src/test/java/org/asynchttpclient/util/AuthenticatorUtilsTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -64,6 +65,19 @@ public class AuthenticatorUtilsTest {
         assertEquals("Basic dXNlcjpwYXNz", first);
         assertSame(first, second);
         assertSame(first, proxy);
+    }
+
+    @Test
+    void basicAuthHeaderCacheIsNotSharedAcrossRealms() {
+        Realm realmA = new Realm.Builder("user", "pass")
+                .setScheme(Realm.AuthScheme.BASIC)
+                .build();
+        Realm realmB = new Realm.Builder("user", "pass")
+                .setScheme(Realm.AuthScheme.BASIC)
+                .build();
+
+        assertEquals(realmA.getBasicAuthHeader(), realmB.getBasicAuthHeader());
+        assertNotSame(realmA.getBasicAuthHeader(), realmB.getBasicAuthHeader());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

#2267 introduced `Realm.getBasicAuthHeader()` to cache the computed HTTP Basic authorization header on immutable `Realm` instances. Two follow-ups remained: its Javadoc did not clarify that it always generates a Basic header regardless of the configured `AuthScheme`, and there was no test verifying that the cached header is scoped to each `Realm` instance rather than shared across instances.

Modification:

Update the `Realm.getBasicAuthHeader()` Javadoc to explicitly document that it always encodes credentials as a Basic authorization header, regardless of the configured scheme. Add a test verifying that two distinct `Realm` instances with identical credentials produce equal but distinct cached header instances.

Result:

The behavior of `Realm.getBasicAuthHeader()` is now explicitly documented, and its per-instance caching is protected by a regression test against accidental cache sharing.
