### PR TITLE
Fix idle pool cleaner generation race

### DIFF
--- a/client/src/main/java/org/asynchttpclient/channel/ChannelPool.java
+++ b/client/src/main/java/org/asynchttpclient/channel/ChannelPool.java
@@ -28,7 +28,7 @@ public interface ChannelPool {
      *
      * @param channel      an I/O channel
      * @param partitionKey a key used to retrieve the cached channel
-     * @return true if added.
+     * @return true if the offer was accepted; false if the channel was rejected
      */
     boolean offer(Channel channel, Object partitionKey);
 

--- a/client/src/main/java/org/asynchttpclient/netty/channel/DefaultChannelPool.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/DefaultChannelPool.java
@@ -52,10 +52,11 @@ public final class DefaultChannelPool implements ChannelPool {
     private static final AttributeKey<IdleState> IDLE_STATE_ATTRIBUTE_KEY = AttributeKey.valueOf("channelIdleState");
 
     // The partition deques hold the bare Channel; per-checkout idle state (start timestamp + the
-    // generation/ownership CAS state) lives on the channel's IDLE_STATE_ATTRIBUTE_KEY attribute,
+    // generation/ownership/reset CAS state) lives on the channel's IDLE_STATE_ATTRIBUTE_KEY attribute,
     // which is allocated once per physical connection and reused across every pool cycle.
     private final ConcurrentHashMap<Object, ConcurrentLinkedDeque<Channel>> partitions = new ConcurrentHashMap<>();
     private final AtomicBoolean isClosed = new AtomicBoolean(false);
+    private final AtomicBoolean duplicateOfferLogged = new AtomicBoolean(false);
     private final Timer nettyTimer;
     private final long connectionTtl;
     private final boolean connectionTtlEnabled;
@@ -119,19 +120,10 @@ public final class DefaultChannelPool implements ChannelPool {
             return false;
         }
 
-        boolean offered = offer0(channel, partitionKey, now);
-        if (connectionTtlEnabled && offered) {
-            registerChannelCreation(channel, partitionKey, now);
-        }
-
-        return offered;
+        return offer0(channel, partitionKey, now);
     }
 
     private boolean offer0(Channel channel, Object partitionKey, long now) {
-        ConcurrentLinkedDeque<Channel> partition = partitions.get(partitionKey);
-        if (partition == null) {
-            partition = partitions.computeIfAbsent(partitionKey, pk -> new ConcurrentLinkedDeque<>());
-        }
         // Reuse the channel's IdleState instead of allocating a holder per offer; reset() transfers an
         // owned generation to a new leasable generation before offerFirst publishes the channel.
         Attribute<IdleState> idleStateAttribute = channel.attr(IDLE_STATE_ATTRIBUTE_KEY);
@@ -142,9 +134,18 @@ public final class DefaultChannelPool implements ChannelPool {
             idleState = existingIdleState == null ? newIdleState : existingIdleState;
         }
         if (!idleState.reset(now)) {
-            return false;
+            if (LOGGER.isDebugEnabled() && duplicateOfferLogged.compareAndSet(false, true)) {
+                LOGGER.debug("Ignoring duplicate pool offer for channel {}", channel);
+            }
+            return true;
         }
-        return partition.offerFirst(channel);
+        ConcurrentLinkedDeque<Channel> partition =
+                partitions.computeIfAbsent(partitionKey, pk -> new ConcurrentLinkedDeque<>());
+        boolean offered = partition.offerFirst(channel);
+        if (connectionTtlEnabled && offered) {
+            registerChannelCreation(channel, partitionKey, now);
+        }
+        return offered;
     }
 
     private static void registerChannelCreation(Channel channel, Object partitionKey, long now) {
@@ -295,19 +296,21 @@ public final class DefaultChannelPool implements ChannelPool {
      * {@link #IDLE_STATE_ATTRIBUTE_KEY} attribute, then reused across every pool checkout so no holder
      * is allocated per offer.
      *
-     * <p>The low bit of {@code state} is the ownership flag; the remaining bits advance by two on every
-     * offer because bit zero is reserved. A successful {@code poll()} lease and a {@code removeAll()}
-     * tombstone both claim the current generation. The cleaner can therefore claim only the exact
-     * generation whose expiry it evaluated, without temporarily claiming a newer entry while checking
-     * whether {@code start} changed.
+     * <p>The low bit of {@code state} is the ownership flag and the next bit marks a reset in progress;
+     * the remaining bits advance by four on every offer. A successful {@code poll()} lease, a
+     * {@code removeAll()} tombstone, and the cleaner's pre-close claim all own the current generation.
+     * The cleaner can therefore claim only the exact generation whose expiry it evaluated, without
+     * temporarily claiming a newer entry while checking whether {@code start} changed.
      *
-     * <p>A generation can be reset only while owned. New state starts owned, and {@code poll()} claims
-     * a generation before returning it, so {@code offer()} transfers ownership instead of performing a
-     * non-atomic update from a leasable generation.
+     * <p>A generation can be reset only while owned and not already being reset. New state starts owned,
+     * and reset first claims the generation's reset bit before publishing the timestamp and next leasable
+     * generation. Concurrent or delayed resets therefore cannot transfer a generation they did not claim.
      */
     static final class IdleState {
 
         private static final long OWNED_MASK = 1L;
+        private static final long RESETTING_MASK = 2L;
+        private static final long GENERATION_INCREMENT = 4L;
         private static final AtomicLongFieldUpdater<IdleState> STATE_UPDATER =
                 AtomicLongFieldUpdater.newUpdater(IdleState.class, "state");
 
@@ -330,6 +333,10 @@ public final class DefaultChannelPool implements ChannelPool {
             return (stateSnapshot & OWNED_MASK) != 0;
         }
 
+        private static boolean isResetting(long stateSnapshot) {
+            return (stateSnapshot & RESETTING_MASK) != 0;
+        }
+
         /** Atomically claim the current generation. */
         boolean takeOwnership() {
             return tryTakeOwnership(state);
@@ -341,15 +348,20 @@ public final class DefaultChannelPool implements ChannelPool {
                     && STATE_UPDATER.compareAndSet(this, stateSnapshot, stateSnapshot | OWNED_MASK);
         }
 
-        /** Transfer an owned generation to a new leasable generation. Called on every offer. */
-        synchronized boolean reset(long now) {
-            long stateSnapshot = state;
-            if (!isOwned(stateSnapshot)) {
+        /** Attempt to transfer the current owned generation to a new leasable generation. */
+        boolean reset(long now) {
+            return tryReset(state, now);
+        }
+
+        /** Transfer {@code stateSnapshot} if it is still owned, current, and not already being reset. */
+        boolean tryReset(long stateSnapshot, long now) {
+            if (!isOwned(stateSnapshot) || isResetting(stateSnapshot)
+                    || !STATE_UPDATER.compareAndSet(this, stateSnapshot, stateSnapshot | RESETTING_MASK)) {
                 return false;
             }
-            long nextGeneration = (stateSnapshot & ~OWNED_MASK) + 2;
             start = now;
-            return STATE_UPDATER.compareAndSet(this, stateSnapshot, nextGeneration);
+            state = (stateSnapshot & ~(OWNED_MASK | RESETTING_MASK)) + GENERATION_INCREMENT;
+            return true;
         }
     }
 
@@ -430,10 +442,10 @@ public final class DefaultChannelPool implements ChannelPool {
 
                 long stateSnapshot = idleState.snapshot();
                 if (IdleState.isOwned(stateSnapshot)) {
-                    // In-deque + owned ==> a removeAll(Channel) tombstone, or a node a concurrent poll()
-                    // has already leased and unlinked. Either way: unlink, never close — the owner of the
-                    // claim is responsible for closing it. Unlinking an already-unlinked node through the
-                    // iterator is a harmless no-op.
+                    // In-deque + owned ==> a removeAll(Channel) tombstone, a node a concurrent poll()
+                    // already leased and unlinked, or an old node whose generation is being reset.
+                    // Either way: unlink, never close — the owner of the claim handles the channel.
+                    // Unlinking an already-unlinked node through the iterator is a harmless no-op.
                     it.remove();
                     continue;
                 }

--- a/client/src/main/java/org/asynchttpclient/netty/channel/DefaultChannelPool.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/DefaultChannelPool.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.function.Predicate;
 
 import static org.asynchttpclient.util.DateUtils.unpreciseMillisTime;
@@ -52,8 +52,8 @@ public final class DefaultChannelPool implements ChannelPool {
     private static final AttributeKey<IdleState> IDLE_STATE_ATTRIBUTE_KEY = AttributeKey.valueOf("channelIdleState");
 
     // The partition deques hold the bare Channel; per-checkout idle state (start timestamp + the
-    // owned/tombstone CAS flag) lives on the channel's IDLE_STATE_ATTRIBUTE_KEY attribute, which is
-    // allocated once per physical connection and reused across every pool cycle (no per-offer holder).
+    // generation/ownership CAS state) lives on the channel's IDLE_STATE_ATTRIBUTE_KEY attribute,
+    // which is allocated once per physical connection and reused across every pool cycle.
     private final ConcurrentHashMap<Object, ConcurrentLinkedDeque<Channel>> partitions = new ConcurrentHashMap<>();
     private final AtomicBoolean isClosed = new AtomicBoolean(false);
     private final Timer nettyTimer;
@@ -132,9 +132,8 @@ public final class DefaultChannelPool implements ChannelPool {
         if (partition == null) {
             partition = partitions.computeIfAbsent(partitionKey, pk -> new ConcurrentLinkedDeque<>());
         }
-        // Reuse the channel's IdleState instead of allocating a holder per offer; reset() stamps the
-        // idle start and clears the owned flag (must happen-before offerFirst publishes the channel,
-        // so any thread that observes it in the deque also observes owned == 0).
+        // Reuse the channel's IdleState instead of allocating a holder per offer; reset() publishes a
+        // new idle generation before offerFirst publishes the channel.
         Attribute<IdleState> idleStateAttribute = channel.attr(IDLE_STATE_ATTRIBUTE_KEY);
         IdleState idleState = idleStateAttribute.get();
         if (idleState == null) {
@@ -293,52 +292,62 @@ public final class DefaultChannelPool implements ChannelPool {
      * {@link #IDLE_STATE_ATTRIBUTE_KEY} attribute, then reused across every pool checkout so no holder
      * is allocated per offer.
      *
-     * <p>{@code owned} is a single CAS flag with two roles, both meaning "this idle entry is claimed,
-     * do not lease it": a successful {@code poll()} lease, or a {@code removeAll()} tombstone. The pool
-     * upholds the invariant that a channel sitting in a partition deque has {@code owned == 0} unless it
-     * was tombstoned, because {@link #reset(long)} clears the flag before {@code offerFirst} publishes
-     * the channel and {@code poll()} unlinks a channel from the deque before claiming it. {@code start}
-     * doubles as a generation token: it changes on every offer, letting the cleaner detect a channel
-     * that was leased and re-offered between its expiry check and its claim.
+     * <p>The low bit of {@code state} is the ownership flag; the remaining bits are incremented on
+     * every offer. A successful {@code poll()} lease and a {@code removeAll()} tombstone both claim the
+     * current generation. The cleaner can therefore claim only the exact generation whose expiry it
+     * evaluated, without temporarily claiming a newer entry while checking whether {@code start}
+     * changed.
      */
     static final class IdleState {
 
-        private static final AtomicIntegerFieldUpdater<IdleState> OWNED_UPDATER =
-                AtomicIntegerFieldUpdater.newUpdater(IdleState.class, "owned");
+        private static final long OWNED_MASK = 1L;
+        private static final AtomicLongFieldUpdater<IdleState> STATE_UPDATER =
+                AtomicLongFieldUpdater.newUpdater(IdleState.class, "state");
 
         private volatile long start;
-        @SuppressWarnings("unused")
-        private volatile int owned;
+        private volatile long state;
 
         long start() {
             return start;
         }
 
+        long snapshot() {
+            return state;
+        }
+
         boolean isOwned() {
-            return owned != 0;
+            return isOwned(state);
         }
 
-        /** Atomically claim this entry; returns true only for the caller that transitions 0 -> 1. */
+        static boolean isOwned(long stateSnapshot) {
+            return (stateSnapshot & OWNED_MASK) != 0;
+        }
+
+        /** Atomically claim the current generation. */
         boolean takeOwnership() {
-            return OWNED_UPDATER.getAndSet(this, 1) == 0;
+            return takeOwnership(state);
         }
 
-        /** Undo a claim taken via {@link #takeOwnership()} (used only on the cleaner re-offer race). */
-        void releaseOwnership() {
-            owned = 0;
+        /** Atomically claim {@code stateSnapshot}, provided it is still the current generation. */
+        boolean takeOwnership(long stateSnapshot) {
+            return !isOwned(stateSnapshot)
+                    && STATE_UPDATER.compareAndSet(this, stateSnapshot, stateSnapshot | OWNED_MASK);
         }
 
-        /** Stamp the idle start and mark the channel leasable again. Called on every offer. */
+        /** Stamp a new idle generation and mark the channel leasable again. Called on every offer. */
         void reset(long now) {
+            long nextGeneration = (state & ~OWNED_MASK) + 2;
+            // Keep the new generation unavailable until its timestamp is published.
+            state = nextGeneration | OWNED_MASK;
             start = now;
-            owned = 0;
+            state = nextGeneration;
         }
     }
 
     private final class IdleChannelDetector implements TimerTask {
 
-        private boolean isIdleTimeoutExpired(IdleState idleState, long now) {
-            return maxIdleTimeEnabled && now - idleState.start() >= maxIdleTime;
+        private boolean isIdleTimeoutExpired(long idleStart, long now) {
+            return maxIdleTimeEnabled && now - idleStart >= maxIdleTime;
         }
 
         @Override
@@ -410,7 +419,8 @@ public final class DefaultChannelPool implements ChannelPool {
                     continue;
                 }
 
-                if (idleState.isOwned()) {
+                long stateSnapshot = idleState.snapshot();
+                if (IdleState.isOwned(stateSnapshot)) {
                     // In-deque + owned ==> a removeAll(Channel) tombstone, or a node a concurrent poll()
                     // has already leased and unlinked. Either way: unlink, never close — the owner of the
                     // claim is responsible for closing it. Unlinking an already-unlinked node through the
@@ -419,22 +429,17 @@ public final class DefaultChannelPool implements ChannelPool {
                     continue;
                 }
 
-                boolean isIdleTimeoutExpired = isIdleTimeoutExpired(idleState, now);
+                long idleStart = idleState.start();
+                boolean isIdleTimeoutExpired = isIdleTimeoutExpired(idleStart, now);
                 boolean isRemotelyClosed = !Channels.isChannelActive(channel);
                 boolean isTtlExpired = isTtlExpired(channel, now);
                 if (!isIdleTimeoutExpired && !isRemotelyClosed && !isTtlExpired) {
                     continue; // healthy idle channel, leave it for poll()
                 }
 
-                long startSnapshot = idleState.start();
-                // Claim before closing so we never close a channel poll() is leasing concurrently.
-                if (!idleState.takeOwnership()) {
-                    continue; // poll() (or removeAll(Channel)) won the claim; that owner now handles the channel
-                }
-                if (idleState.start() != startSnapshot) {
-                    // The channel was leased and re-offered (fresh start) between the expiry check and
-                    // the claim, so it is leasable again — release it instead of closing it.
-                    idleState.releaseOwnership();
+                // Claim the generation evaluated above. A lease and re-offer changes the generation,
+                // so this CAS cannot claim the fresh entry or interfere with a concurrent poll of it.
+                if (!idleState.takeOwnership(stateSnapshot)) {
                     continue;
                 }
 

--- a/client/src/main/java/org/asynchttpclient/netty/channel/DefaultChannelPool.java
+++ b/client/src/main/java/org/asynchttpclient/netty/channel/DefaultChannelPool.java
@@ -132,15 +132,18 @@ public final class DefaultChannelPool implements ChannelPool {
         if (partition == null) {
             partition = partitions.computeIfAbsent(partitionKey, pk -> new ConcurrentLinkedDeque<>());
         }
-        // Reuse the channel's IdleState instead of allocating a holder per offer; reset() publishes a
-        // new idle generation before offerFirst publishes the channel.
+        // Reuse the channel's IdleState instead of allocating a holder per offer; reset() transfers an
+        // owned generation to a new leasable generation before offerFirst publishes the channel.
         Attribute<IdleState> idleStateAttribute = channel.attr(IDLE_STATE_ATTRIBUTE_KEY);
         IdleState idleState = idleStateAttribute.get();
         if (idleState == null) {
-            idleState = new IdleState();
-            idleStateAttribute.set(idleState);
+            IdleState newIdleState = new IdleState();
+            IdleState existingIdleState = idleStateAttribute.setIfAbsent(newIdleState);
+            idleState = existingIdleState == null ? newIdleState : existingIdleState;
         }
-        idleState.reset(now);
+        if (!idleState.reset(now)) {
+            return false;
+        }
         return partition.offerFirst(channel);
     }
 
@@ -292,11 +295,15 @@ public final class DefaultChannelPool implements ChannelPool {
      * {@link #IDLE_STATE_ATTRIBUTE_KEY} attribute, then reused across every pool checkout so no holder
      * is allocated per offer.
      *
-     * <p>The low bit of {@code state} is the ownership flag; the remaining bits are incremented on
-     * every offer. A successful {@code poll()} lease and a {@code removeAll()} tombstone both claim the
-     * current generation. The cleaner can therefore claim only the exact generation whose expiry it
-     * evaluated, without temporarily claiming a newer entry while checking whether {@code start}
-     * changed.
+     * <p>The low bit of {@code state} is the ownership flag; the remaining bits advance by two on every
+     * offer because bit zero is reserved. A successful {@code poll()} lease and a {@code removeAll()}
+     * tombstone both claim the current generation. The cleaner can therefore claim only the exact
+     * generation whose expiry it evaluated, without temporarily claiming a newer entry while checking
+     * whether {@code start} changed.
+     *
+     * <p>A generation can be reset only while owned. New state starts owned, and {@code poll()} claims
+     * a generation before returning it, so {@code offer()} transfers ownership instead of performing a
+     * non-atomic update from a leasable generation.
      */
     static final class IdleState {
 
@@ -305,7 +312,7 @@ public final class DefaultChannelPool implements ChannelPool {
                 AtomicLongFieldUpdater.newUpdater(IdleState.class, "state");
 
         private volatile long start;
-        private volatile long state;
+        private volatile long state = OWNED_MASK;
 
         long start() {
             return start;
@@ -325,22 +332,24 @@ public final class DefaultChannelPool implements ChannelPool {
 
         /** Atomically claim the current generation. */
         boolean takeOwnership() {
-            return takeOwnership(state);
+            return tryTakeOwnership(state);
         }
 
         /** Atomically claim {@code stateSnapshot}, provided it is still the current generation. */
-        boolean takeOwnership(long stateSnapshot) {
+        boolean tryTakeOwnership(long stateSnapshot) {
             return !isOwned(stateSnapshot)
                     && STATE_UPDATER.compareAndSet(this, stateSnapshot, stateSnapshot | OWNED_MASK);
         }
 
-        /** Stamp a new idle generation and mark the channel leasable again. Called on every offer. */
-        void reset(long now) {
-            long nextGeneration = (state & ~OWNED_MASK) + 2;
-            // Keep the new generation unavailable until its timestamp is published.
-            state = nextGeneration | OWNED_MASK;
+        /** Transfer an owned generation to a new leasable generation. Called on every offer. */
+        synchronized boolean reset(long now) {
+            long stateSnapshot = state;
+            if (!isOwned(stateSnapshot)) {
+                return false;
+            }
+            long nextGeneration = (stateSnapshot & ~OWNED_MASK) + 2;
             start = now;
-            state = nextGeneration;
+            return STATE_UPDATER.compareAndSet(this, stateSnapshot, nextGeneration);
         }
     }
 
@@ -439,7 +448,7 @@ public final class DefaultChannelPool implements ChannelPool {
 
                 // Claim the generation evaluated above. A lease and re-offer changes the generation,
                 // so this CAS cannot claim the fresh entry or interfere with a concurrent poll of it.
-                if (!idleState.takeOwnership(stateSnapshot)) {
+                if (!idleState.tryTakeOwnership(stateSnapshot)) {
                     continue;
                 }
 

--- a/client/src/test/java/org/asynchttpclient/netty/channel/DefaultChannelPoolTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/channel/DefaultChannelPoolTest.java
@@ -31,6 +31,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -243,6 +244,63 @@ public class DefaultChannelPoolTest {
         assertSame(channel, pool.poll(KEY));
 
         pool.destroy();
+    }
+
+    @Test
+    public void cleanerDoesNotCloseChannelReofferedAfterExpiryCheck() throws Exception {
+        CapturingTimer timer = new CapturingTimer();
+        DefaultChannelPool pool = idlePool(timer, Duration.ofMillis(1));
+        BlockingActiveChannel channel = new BlockingActiveChannel();
+
+        pool.offer(channel, KEY);
+        idleState(channel).reset(0);
+        channel.blockNextActiveCheck();
+
+        CompletableFuture<Void> cleanerRun = CompletableFuture.runAsync(timer::fire);
+        try {
+            assertTrue(channel.awaitActiveCheck(), "cleaner must reach the active-channel check");
+            assertSame(channel, pool.poll(KEY));
+            assertTrue(pool.offer(channel, KEY));
+        } finally {
+            channel.resumeActiveCheck();
+        }
+        cleanerRun.get(5, TimeUnit.SECONDS);
+
+        assertTrue(channel.isActive(), "cleaner must not close a freshly re-offered channel");
+        assertSame(channel, pool.poll(KEY), "freshly re-offered channel must remain leasable");
+
+        pool.destroy();
+    }
+
+    @Test
+    public void staleCleanerClaimDoesNotHideReofferedChannelFromPoll() throws Exception {
+        DefaultChannelPool pool = noReaperPool();
+        Channel channel = new EmbeddedChannel();
+
+        assertTrue(pool.offer(channel, KEY));
+        DefaultChannelPool.IdleState idleState = idleState(channel);
+        long staleSnapshot = idleState.snapshot();
+
+        assertSame(channel, pool.poll(KEY));
+        assertTrue(pool.offer(channel, KEY));
+
+        assertFalse(idleState.takeOwnership(staleSnapshot), "cleaner must not claim a newer idle generation");
+        assertSame(channel, pool.poll(KEY), "a failed stale claim must not hide the fresh generation");
+
+        pool.destroy();
+    }
+
+    @Test
+    public void idleGenerationChangesWhenTimestampIsReused() {
+        DefaultChannelPool.IdleState idleState = new DefaultChannelPool.IdleState();
+        idleState.reset(1);
+        long firstGeneration = idleState.snapshot();
+
+        assertTrue(idleState.takeOwnership());
+        idleState.reset(1);
+
+        assertFalse(idleState.takeOwnership(firstGeneration));
+        assertFalse(idleState.isOwned());
     }
 
     // ---- reap pass unlinks many channels in a single tick (O(n) iterator-remove) ----
@@ -490,12 +548,49 @@ public class DefaultChannelPoolTest {
 
     // ---- helpers ----
 
-    private static Object idleState(Channel channel) throws Exception {
+    private static DefaultChannelPool.IdleState idleState(Channel channel) throws Exception {
         Field keyField = DefaultChannelPool.class.getDeclaredField("IDLE_STATE_ATTRIBUTE_KEY");
         keyField.setAccessible(true);
         @SuppressWarnings("unchecked")
-        io.netty.util.AttributeKey<Object> key = (io.netty.util.AttributeKey<Object>) keyField.get(null);
+        io.netty.util.AttributeKey<DefaultChannelPool.IdleState> key =
+                (io.netty.util.AttributeKey<DefaultChannelPool.IdleState>) keyField.get(null);
         return channel.attr(key).get();
+    }
+
+    private static final class BlockingActiveChannel extends EmbeddedChannel {
+
+        private final AtomicBoolean blockNextActiveCheck = new AtomicBoolean();
+        private final CountDownLatch activeCheck = new CountDownLatch(1);
+        private final CountDownLatch resumeActiveCheck = new CountDownLatch(1);
+
+        @Override
+        public boolean isActive() {
+            AtomicBoolean block = blockNextActiveCheck;
+            if (block != null && block.compareAndSet(true, false)) {
+                activeCheck.countDown();
+                try {
+                    if (!resumeActiveCheck.await(5, TimeUnit.SECONDS)) {
+                        throw new AssertionError("active-channel check was not resumed");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError("active-channel check was interrupted", e);
+                }
+            }
+            return super.isActive();
+        }
+
+        void blockNextActiveCheck() {
+            blockNextActiveCheck.set(true);
+        }
+
+        boolean awaitActiveCheck() throws InterruptedException {
+            return activeCheck.await(5, TimeUnit.SECONDS);
+        }
+
+        void resumeActiveCheck() {
+            resumeActiveCheck.countDown();
+        }
     }
 
     private static Channel channelWithRemoteAddress(String host) {

--- a/client/src/test/java/org/asynchttpclient/netty/channel/DefaultChannelPoolTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/channel/DefaultChannelPoolTest.java
@@ -88,6 +88,22 @@ public class DefaultChannelPoolTest {
     }
 
     @Test
+    public void duplicateOfferDoesNotResetLeasableGeneration() throws Exception {
+        DefaultChannelPool pool = noReaperPool();
+        Channel channel = new EmbeddedChannel();
+
+        assertTrue(pool.offer(channel, KEY));
+        long generation = idleState(channel).snapshot();
+
+        assertFalse(pool.offer(channel, KEY), "an already leasable channel must not be offered again");
+        assertEquals(generation, idleState(channel).snapshot());
+        assertEquals(1, partitionSize(pool, KEY));
+        assertSame(channel, pool.poll(KEY));
+
+        pool.destroy();
+    }
+
+    @Test
     public void reofferingReusesTheSameIdleStateInstance() throws Exception {
         DefaultChannelPool pool = noReaperPool();
         Channel channel = new EmbeddedChannel();
@@ -267,25 +283,8 @@ public class DefaultChannelPoolTest {
         cleanerRun.get(5, TimeUnit.SECONDS);
 
         assertTrue(channel.isActive(), "cleaner must not close a freshly re-offered channel");
+        assertEquals(1, partitionSize(pool, KEY), "cleaner must not unlink the fresh generation");
         assertSame(channel, pool.poll(KEY), "freshly re-offered channel must remain leasable");
-
-        pool.destroy();
-    }
-
-    @Test
-    public void staleCleanerClaimDoesNotHideReofferedChannelFromPoll() throws Exception {
-        DefaultChannelPool pool = noReaperPool();
-        Channel channel = new EmbeddedChannel();
-
-        assertTrue(pool.offer(channel, KEY));
-        DefaultChannelPool.IdleState idleState = idleState(channel);
-        long staleSnapshot = idleState.snapshot();
-
-        assertSame(channel, pool.poll(KEY));
-        assertTrue(pool.offer(channel, KEY));
-
-        assertFalse(idleState.takeOwnership(staleSnapshot), "cleaner must not claim a newer idle generation");
-        assertSame(channel, pool.poll(KEY), "a failed stale claim must not hide the fresh generation");
 
         pool.destroy();
     }
@@ -293,13 +292,13 @@ public class DefaultChannelPoolTest {
     @Test
     public void idleGenerationChangesWhenTimestampIsReused() {
         DefaultChannelPool.IdleState idleState = new DefaultChannelPool.IdleState();
-        idleState.reset(1);
+        assertTrue(idleState.reset(1));
         long firstGeneration = idleState.snapshot();
 
         assertTrue(idleState.takeOwnership());
-        idleState.reset(1);
+        assertTrue(idleState.reset(1));
 
-        assertFalse(idleState.takeOwnership(firstGeneration));
+        assertFalse(idleState.tryTakeOwnership(firstGeneration));
         assertFalse(idleState.isOwned());
     }
 
@@ -473,11 +472,15 @@ public class DefaultChannelPoolTest {
 
     @Test
     public void concurrentOfferPollRemoveAllIsConsistent() throws Exception {
-        // Real timer so the cleaner reaps tombstones concurrently with offer/poll/removeAll.
-        // TTL only (idle disabled) so the cleaner never closes our shared EmbeddedChannels cross-thread.
+        // Real timer so the cleaner claims expired entries and reaps tombstones concurrently with
+        // offer/poll/removeAll.
         HashedWheelTimer timer = new HashedWheelTimer(10, TimeUnit.MILLISECONDS);
-        DefaultChannelPool pool = new DefaultChannelPool(Duration.ZERO, Duration.ofHours(1),
+        DefaultChannelPool pool = new DefaultChannelPool(Duration.ofMillis(20), Duration.ofHours(1),
                 PoolLeaseStrategy.LIFO, timer, Duration.ofMillis(10));
+        CountDownLatch cleanerClosedChannel = new CountDownLatch(1);
+        Channel expiringChannel = new EmbeddedChannel();
+        expiringChannel.closeFuture().addListener(future -> cleanerClosedChannel.countDown());
+        assertTrue(pool.offer(expiringChannel, "expiring-partition"));
 
         final int channelCount = 16;
         Channel[] channels = new Channel[channelCount];
@@ -531,6 +534,8 @@ public class DefaultChannelPoolTest {
         if (failure.get() != null) {
             fail("worker threw: " + failure.get(), failure.get());
         }
+        assertTrue(cleanerClosedChannel.await(5, TimeUnit.SECONDS),
+                "soak must exercise the cleaner ownership and close path");
         assertTrue(leasedInactive.isEmpty(), "poll must never lease an inactive channel");
 
         // Drain leases, then let the cleaner run a couple of ticks and confirm no tombstone leak:
@@ -565,6 +570,7 @@ public class DefaultChannelPoolTest {
 
         @Override
         public boolean isActive() {
+            // EmbeddedChannel calls this from its constructor before subclass fields are initialized.
             AtomicBoolean block = blockNextActiveCheck;
             if (block != null && block.compareAndSet(true, false)) {
                 activeCheck.countDown();

--- a/client/src/test/java/org/asynchttpclient/netty/channel/DefaultChannelPoolTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/channel/DefaultChannelPoolTest.java
@@ -88,19 +88,36 @@ public class DefaultChannelPoolTest {
     }
 
     @Test
-    public void duplicateOfferDoesNotResetLeasableGeneration() throws Exception {
+    public void duplicateOfferIsHarmlessNoOp() throws Exception {
         DefaultChannelPool pool = noReaperPool();
         Channel channel = new EmbeddedChannel();
 
         assertTrue(pool.offer(channel, KEY));
         long generation = idleState(channel).snapshot();
 
-        assertFalse(pool.offer(channel, KEY), "an already leasable channel must not be offered again");
+        assertTrue(pool.offer(channel, "other-partition"));
         assertEquals(generation, idleState(channel).snapshot());
         assertEquals(1, partitionSize(pool, KEY));
+        assertEquals(0, partitionSize(pool, "other-partition"));
+        assertTrue(channel.isActive());
         assertSame(channel, pool.poll(KEY));
 
         pool.destroy();
+    }
+
+    @Test
+    public void staleResetCannotTransferNewerOwnedGeneration() {
+        DefaultChannelPool.IdleState idleState = new DefaultChannelPool.IdleState();
+        assertTrue(idleState.reset(1000));
+        assertTrue(idleState.takeOwnership());
+        long staleSnapshot = idleState.snapshot();
+
+        assertTrue(idleState.tryReset(staleSnapshot, 5000));
+        assertTrue(idleState.takeOwnership());
+
+        assertFalse(idleState.tryReset(staleSnapshot, 1000));
+        assertEquals(5000, idleState.start());
+        assertTrue(idleState.isOwned());
     }
 
     @Test
@@ -265,11 +282,17 @@ public class DefaultChannelPoolTest {
     @Test
     public void cleanerDoesNotCloseChannelReofferedAfterExpiryCheck() throws Exception {
         CapturingTimer timer = new CapturingTimer();
-        DefaultChannelPool pool = idlePool(timer, Duration.ofMillis(1));
+        DefaultChannelPool pool = new DefaultChannelPool(Duration.ofMillis(1), Duration.ZERO,
+                PoolLeaseStrategy.FIFO, timer, Duration.ofMillis(1));
         BlockingActiveChannel channel = new BlockingActiveChannel();
+        Channel untouchedChannel = new EmbeddedChannel();
 
-        pool.offer(channel, KEY);
-        idleState(channel).reset(0);
+        assertTrue(pool.offer(channel, KEY));
+        assertTrue(idleState(channel).takeOwnership());
+        assertTrue(idleState(channel).reset(0));
+        assertTrue(pool.offer(untouchedChannel, KEY));
+        assertTrue(idleState(untouchedChannel).takeOwnership());
+        assertTrue(idleState(untouchedChannel).reset(Long.MAX_VALUE));
         channel.blockNextActiveCheck();
 
         CompletableFuture<Void> cleanerRun = CompletableFuture.runAsync(timer::fire);
@@ -283,7 +306,8 @@ public class DefaultChannelPoolTest {
         cleanerRun.get(5, TimeUnit.SECONDS);
 
         assertTrue(channel.isActive(), "cleaner must not close a freshly re-offered channel");
-        assertEquals(1, partitionSize(pool, KEY), "cleaner must not unlink the fresh generation");
+        assertEquals(2, partitionSize(pool, KEY), "cleaner must not unlink the fresh generation");
+        assertSame(untouchedChannel, pool.poll(KEY));
         assertSame(channel, pool.poll(KEY), "freshly re-offered channel must remain leasable");
 
         pool.destroy();


### PR DESCRIPTION
## Summary

- claim the exact idle generation evaluated by the channel pool cleaner
- keep generation and ownership in one atomic state without restoring per-offer allocations
- cover stale close, fresh entry loss, and equal-timestamp generations with regression tests

Fixes #2284

## Testing

- `./mvnw -pl client -Dtest=DefaultChannelPoolTest test` (19 tests passed)
- full JDK 11 `./mvnw clean verify` attempt: 1,326 tests passed and one unrelated timing assertion failed in `SemaphoreTest.combinedCheckAcquireTime`
- immediate isolated `SemaphoreTest` rerun passed (10/10)

Codex on behalf of Pavel Ptashyts