### PR TITLE
Trim dead sensitive-logging wrappers and document scope

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/handler/HttpMessageFormatter.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/HttpMessageFormatter.java
@@ -30,9 +30,6 @@ import java.util.Map;
  */
 public final class HttpMessageFormatter {
 
-    /** The value used in place of sensitive header values. */
-    public static final String REDACTED = SensitiveLoggingUtils.REDACTED;
-
     private HttpMessageFormatter() {
     }
 
@@ -54,18 +51,8 @@ public final class HttpMessageFormatter {
     private static StringBuilder appendHeaders(StringBuilder value, HttpHeaders headers) {
         for (Map.Entry<String, String> header : headers) {
             value.append('\n').append(header.getKey()).append(": ")
-                    .append(isSensitiveHeader(header.getKey()) ? REDACTED : header.getValue());
+                    .append(SensitiveLoggingUtils.isSensitiveHeader(header.getKey()) ? SensitiveLoggingUtils.REDACTED : header.getValue());
         }
         return value;
-    }
-
-    /**
-     * Returns whether a header value must be redacted from logs.
-     *
-     * @param name the header name
-     * @return {@code true} for authentication and cookie headers when sensitive logging is disabled
-     */
-    public static boolean isSensitiveHeader(CharSequence name) {
-        return SensitiveLoggingUtils.isSensitiveHeader(name);
     }
 }

--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequest.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequest.java
@@ -21,6 +21,9 @@ import org.asynchttpclient.netty.request.body.NettyBody;
 
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
+// Deliberately no toString() override: NettyResponseFuture#toString renders this object via
+// Object.toString() so debug logs never include the wrapped httpRequest's headers. Adding a
+// toString() here that exposes httpRequest would leak Authorization/Cookie values into logs.
 public final class NettyRequest {
 
     @SuppressWarnings("rawtypes")

--- a/client/src/main/java/org/asynchttpclient/util/SensitiveLoggingUtils.java
+++ b/client/src/main/java/org/asynchttpclient/util/SensitiveLoggingUtils.java
@@ -23,6 +23,10 @@ import org.slf4j.LoggerFactory;
  * Shared policy for rendering sensitive HTTP headers in logs. The policy is read once from the
  * {@code org.asynchttpclient.enableSensitiveLogging} system property or {@code AHC_ENABLE_SENSITIVE_LOGGING} environment
  * variable when this class is initialized.
+ * <p>
+ * Covers request credential headers only. {@code WWW-Authenticate} and {@code Proxy-Authenticate} response
+ * challenge headers are logged unredacted, and request form/query/multipart/body values are out of scope since
+ * they have no reliable generic sensitivity classification.
  */
 public final class SensitiveLoggingUtils {
 


### PR DESCRIPTION
Motivation:
Non-blocking follow-ups from the PR #2279 review: dead public API surface, an undocumented invariant, and an undocumented scope gap.

Modification:
Removed unused HttpMessageFormatter.REDACTED/isSensitiveHeader wrappers, added an invariant comment to NettyRequest, and documented the redaction scope in SensitiveLoggingUtils javadoc.

Result:
No functional change