### PR TITLE
don't send proxy auth on a ws:// request tunnelled through CONNECT

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestFactory.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestFactory.java
@@ -322,8 +322,12 @@ public final class NettyRequestFactory {
         if (!connect) {
             addAuthorizationHeader(headers, perRequestAuthorizationHeader(request, realm));
         }
-        // only set proxy auth on request over plain HTTP, or when performing CONNECT
-        if (!uri.isSecured() || connect) {
+        // Proxy-Authorization belongs on a request the proxy itself receives: the CONNECT that opens a
+        // tunnel, or an absolute-form plaintext request sent directly to the proxy. A ws:// request over an
+        // HTTP proxy is tunnelled through CONNECT (see NettyRequestSender.needConnect), so its upgrade
+        // request travels through the tunnel to the origin, not the proxy — treat it like wss:// and keep
+        // the proxy credentials off it.
+        if (connect || (!uri.isSecured() && !uri.isWebSocket())) {
             setProxyAuthorizationHeader(headers, perRequestProxyAuthorizationHeader(request, proxyRealm));
         }
 
@@ -345,9 +349,10 @@ public final class NettyRequestFactory {
             // proxy tunnelling, connect need host and explicit port
             return uri.getAuthority();
 
-        } else if (proxyServer != null && !uri.isSecured() && proxyServer.getProxyType().isHttp()) {
+        } else if (proxyServer != null && !uri.isSecured() && !uri.isWebSocket() && proxyServer.getProxyType().isHttp()) {
             // proxy over HTTP, need full url, minus the userinfo: this request line is sent to the proxy in
-            // the clear and RFC 9110 §4.2.4 forbids userinfo in a generated request target
+            // the clear and RFC 9110 §4.2.4 forbids userinfo in a generated request target. A ws:// request
+            // is tunnelled through CONNECT, so its upgrade request reaches the origin in origin-form (below)
             return uri.toUrlWithoutUserInfo();
 
         } else {

--- a/client/src/test/java/org/asynchttpclient/netty/request/WebSocketProxyAuthorizationTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/request/WebSocketProxyAuthorizationTest.java
@@ -1,0 +1,81 @@
+/*
+ *    Copyright (c) 2026 AsyncHttpClient Project. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.asynchttpclient.netty.request;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.asynchttpclient.Realm;
+import org.asynchttpclient.Request;
+import org.asynchttpclient.proxy.ProxyServer;
+import org.junit.jupiter.api.Test;
+
+import static org.asynchttpclient.Dsl.basicAuthRealm;
+import static org.asynchttpclient.Dsl.config;
+import static org.asynchttpclient.Dsl.get;
+import static org.asynchttpclient.Dsl.proxyServer;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A ws:// request through an HTTP proxy is tunnelled with CONNECT, so its upgrade request travels through the
+ * established tunnel to the origin. It must therefore be treated like a wss:// tunnel: the proxy credentials
+ * belong only on the CONNECT (which the proxy actually receives), not on the tunnelled upgrade request where
+ * they would be exposed to the origin, and the request target must be origin-form.
+ */
+public class WebSocketProxyAuthorizationTest {
+
+    private static NettyRequestFactory factory() {
+        return new NettyRequestFactory(config().build());
+    }
+
+    @Test
+    public void connectRequestForWsCarriesProxyAuthorization() {
+        Request request = get("ws://origin.example.com/socket").build();
+        Realm proxyRealm = basicAuthRealm("puser", "psecret").setUsePreemptiveAuth(true).build();
+        ProxyServer proxy = proxyServer("proxy.example.com", 8080).build();
+
+        NettyRequest connect = factory().newNettyRequest(request, true, proxy, null, proxyRealm);
+
+        assertTrue(connect.getHttpRequest().headers().contains(HttpHeaderNames.PROXY_AUTHORIZATION),
+                "the CONNECT request must authenticate to the proxy");
+    }
+
+    @Test
+    public void tunneledWsUpgradeDoesNotCarryProxyAuthorization() {
+        Request request = get("ws://origin.example.com/socket").build();
+        Realm proxyRealm = basicAuthRealm("puser", "psecret").setUsePreemptiveAuth(true).build();
+        ProxyServer proxy = proxyServer("proxy.example.com", 8080).build();
+
+        NettyRequest tunneled = factory().newNettyRequest(request, false, proxy, null, proxyRealm);
+
+        assertFalse(tunneled.getHttpRequest().headers().contains(HttpHeaderNames.PROXY_AUTHORIZATION),
+                "the tunnelled ws:// upgrade reaches the origin, so it must not expose the proxy credentials");
+        assertEquals("/socket", tunneled.getHttpRequest().uri(),
+                "the tunnelled ws:// upgrade must use an origin-form request target");
+    }
+
+    @Test
+    public void plainHttpRequestToProxyKeepsProxyAuthorization() {
+        Request request = get("http://origin.example.com/resource").build();
+        Realm proxyRealm = basicAuthRealm("puser", "psecret").setUsePreemptiveAuth(true).build();
+        ProxyServer proxy = proxyServer("proxy.example.com", 8080).build();
+
+        NettyRequest direct = factory().newNettyRequest(request, false, proxy, null, proxyRealm);
+
+        assertTrue(direct.getHttpRequest().headers().contains(HttpHeaderNames.PROXY_AUTHORIZATION),
+                "a plaintext http:// request sent directly to the proxy still authenticates to it");
+    }
+}


### PR DESCRIPTION
WebSocketProxyAuthorizationTest#tunneledWsUpgradeDoesNotCarryProxyAuthorization:

    expected: <false> but was: <true>
    the tunnelled ws:// upgrade reaches the origin, so it must not expose the proxy credentials

A ws:// request through an HTTP proxy is tunnelled with CONNECT (NettyRequestSender.needConnect is true for any WebSocket URI), so the upgrade request that follows is sent through the tunnel to the origin. newNettyRequest gated Proxy-Authorization on !uri.isSecured(), and ws:// is not secured, so the proxy credentials (from ProxyServer.setRealm) were attached to that upgrade and reached the origin; wss:// was already handled since it is secured. requestUri had the same gap and emitted an absolute-form target instead of origin-form.

Excluding WebSocket URIs from the direct-to-proxy branch treats a tunnelled ws:// upgrade like wss://: origin-form request target, no proxy credentials on the request that leaves the tunnel. The CONNECT itself still carries Proxy-Authorization to authenticate to the proxy.