### PR TITLE
Guard debug logs in pollPooledChannel

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
@@ -1373,6 +1373,10 @@ public final class NettyRequestSender {
         Uri uri = request.getUri();
         String virtualHost = request.getVirtualHost();
 
+        // SLF4J has no three-argument overload, so every debug statement below binds to
+        // debug(String, Object...) and allocates its varargs array at the call site whatever the level. This
+        // is the steady-state connection-reuse path, so they are all guarded explicitly.
+
         // Round-robin mode: poll with the IP-aware key so reuse stays pinned to the chosen IP (both the
         // HTTP/2 registry and the HTTP/1.1 pool).
         Object override = future != null ? future.getPartitionKeyOverride() : null;
@@ -1380,9 +1384,6 @@ public final class NettyRequestSender {
             if (!uri.isWebSocket()) {
                 Channel h2Channel = channelManager.pollHttp2Connection(override);
                 if (h2Channel != null) {
-                    // SLF4J has no three-argument overload, so every log statement in this method binds to
-                    // debug(String, Object...) and allocates its varargs array at the call site whatever the
-                    // level. This is the steady-state connection-reuse path, so guard them all explicitly.
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug("Using HTTP/2 multiplexed Channel '{}' for '{}' to '{}'", h2Channel, request.getMethod(), uri);
                     }

--- a/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
+++ b/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java
@@ -1380,12 +1380,17 @@ public final class NettyRequestSender {
             if (!uri.isWebSocket()) {
                 Channel h2Channel = channelManager.pollHttp2Connection(override);
                 if (h2Channel != null) {
-                    LOGGER.debug("Using HTTP/2 multiplexed Channel '{}' for '{}' to '{}'", h2Channel, request.getMethod(), uri);
+                    // SLF4J has no three-argument overload, so every log statement in this method binds to
+                    // debug(String, Object...) and allocates its varargs array at the call site whatever the
+                    // level. This is the steady-state connection-reuse path, so guard them all explicitly.
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("Using HTTP/2 multiplexed Channel '{}' for '{}' to '{}'", h2Channel, request.getMethod(), uri);
+                    }
                     return h2Channel;
                 }
             }
             Channel channel = channelManager.poll(override);
-            if (channel != null) {
+            if (channel != null && LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Using pooled Channel '{}' for '{}' to '{}'", channel, request.getMethod(), uri);
             }
             return channel;
@@ -1406,14 +1411,16 @@ public final class NettyRequestSender {
         if (!uri.isWebSocket()) {
             Channel h2Channel = channelManager.pollHttp2Connection(partitionKey);
             if (h2Channel != null) {
-                LOGGER.debug("Using HTTP/2 multiplexed Channel '{}' for '{}' to '{}'", h2Channel, request.getMethod(), uri);
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Using HTTP/2 multiplexed Channel '{}' for '{}' to '{}'", h2Channel, request.getMethod(), uri);
+                }
                 return h2Channel;
             }
         }
 
         final Channel channel = channelManager.poll(partitionKey);
 
-        if (channel != null) {
+        if (channel != null && LOGGER.isDebugEnabled()) {
             LOGGER.debug("Using pooled Channel '{}' for '{}' to '{}'", channel, request.getMethod(), uri);
         }
         return channel;


### PR DESCRIPTION
## Problem

`NettyRequestSender.pollPooledChannel` runs on every request. Four of its
log statements pass three arguments:

```java
LOGGER.debug("Using pooled Channel '{}' for '{}' to '{}'", channel, request.getMethod(), uri);
```

SLF4J's `Logger` declares overloads for one and two arguments only, so a
three-argument call binds to `debug(String, Object...)` and the compiler
emits the `Object[3]` at the call site. The array is therefore allocated
before `debug` is entered, whatever the configured level — the placeholder
mechanism only defers *formatting*, not argument boxing.

Both pooled-channel branches are the steady-state keep-alive path, so a
client logging at INFO or above allocated one throwaway array per served
request.

## Change

Wrap the four statements in `isDebugEnabled()`.

`sendRequestWithOpenChannel` a few lines up already guards its own
three-argument statement, so the shape is not new to this file. Its guard
does a little more than avoid the array, though: it also hoists
`future.getNettyRequest().getHttpRequest()` inside the branch, so two method
calls are skipped as well. The precedent stands, the reasoning there is just
wider than it is here.

## Scope

Deliberately limited to `pollPooledChannel`. The same pattern exists in a
few colder places (`TimeoutTimerTask`, the GOAWAY handler, the orphan-channel
branch in `AsyncHttpClientHandler`); those are not per-request and are left
alone to keep this focused.

No public API change. No new tests: this is an allocation removal with no
observable behaviour change, and the existing suite covers both branches
(`ConnectionPoolTest`, `MaxTotalConnectionTest`, `ClientStatsTest`).

## Verification

`mvnw clean verify` — BUILD SUCCESS, 1371 tests, 0 failures, 0 errors,
19 skipped. Error Prone, NullAway and Revapi all clean.

Caveat on the testing gate: `AGENTS.md` requires the build to run on JDK 11
and no JDK 11 is installed on this machine, so it was run on **JDK 17**
(also in the CI matrix). The JDK 11 leg of CI on this PR is the real gate.

Claude Code on behalf of @pavel-ptashyts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
