### PR TITLE
Skip redirect set lookup for non-3xx responses

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Interceptors.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Interceptors.java
@@ -125,11 +125,7 @@ public class Interceptors {
             return continue100Interceptor.exitAfterHandling100(channel, future);
         }
 
-        // Range check first: REDIRECT_STATUSES is a Set<Integer>, so contains(statusCode) boxed a fresh
-        // Integer on every response (status codes are outside Integer's valueOf cache). The set is public
-        // and mutable, so the lookup is kept rather than inlined as a switch, and a caller that registered
-        // an extra 3xx status still has it honoured.
-        if (statusCode >= 300 && statusCode < 400 && Redirect30xInterceptor.REDIRECT_STATUSES.contains(statusCode)) {
+        if (Redirect30xInterceptor.isRedirect(statusCode)) {
             return redirect30xInterceptor.exitAfterHandlingRedirect(channel, future, response, request, statusCode, realm);
         }
 

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Interceptors.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Interceptors.java
@@ -125,7 +125,11 @@ public class Interceptors {
             return continue100Interceptor.exitAfterHandling100(channel, future);
         }
 
-        if (Redirect30xInterceptor.REDIRECT_STATUSES.contains(statusCode)) {
+        // Range check first: REDIRECT_STATUSES is a Set<Integer>, so contains(statusCode) boxed a fresh
+        // Integer on every response (status codes are outside Integer's valueOf cache). The set is public
+        // and mutable, so the lookup is kept rather than inlined as a switch, and a caller that registered
+        // an extra 3xx status still has it honoured.
+        if (statusCode >= 300 && statusCode < 400 && Redirect30xInterceptor.REDIRECT_STATUSES.contains(statusCode)) {
             return redirect30xInterceptor.exitAfterHandlingRedirect(channel, future, response, request, statusCode, realm);
         }
 

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Redirect30xInterceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Redirect30xInterceptor.java
@@ -18,6 +18,7 @@ package org.asynchttpclient.netty.handler.intercept;
 import io.netty.channel.Channel;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.cookie.Cookie;
 import org.asynchttpclient.AsyncHttpClientConfig;
@@ -68,6 +69,16 @@ public class Redirect30xInterceptor {
         REDIRECT_STATUSES.add(SEE_OTHER_303);
         REDIRECT_STATUSES.add(TEMPORARY_REDIRECT_307);
         REDIRECT_STATUSES.add(PERMANENT_REDIRECT_308);
+    }
+
+    /**
+     * Whether {@code statusCode} is a redirect this interceptor follows. Only a 3xx can be, and the class
+     * check takes an {@code int}, so it keeps the {@link #REDIRECT_STATUSES} lookup, which boxes, off the
+     * responses that make up almost all traffic. The set is still consulted rather than inlined here because
+     * it is public and mutable, so an extra 3xx status a caller registered stays honoured.
+     */
+    static boolean isRedirect(int statusCode) {
+        return HttpStatusClass.REDIRECTION.contains(statusCode) && REDIRECT_STATUSES.contains(statusCode);
     }
 
     private final ChannelManager channelManager;

--- a/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Redirect30xInterceptor.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/intercept/Redirect30xInterceptor.java
@@ -73,9 +73,9 @@ public class Redirect30xInterceptor {
 
     /**
      * Whether {@code statusCode} is a redirect this interceptor follows. Only a 3xx can be, and the class
-     * check takes an {@code int}, so it keeps the {@link #REDIRECT_STATUSES} lookup, which boxes, off the
-     * responses that make up almost all traffic. The set is still consulted rather than inlined here because
-     * it is public and mutable, so an extra 3xx status a caller registered stays honoured.
+     * check takes an {@code int}, so the boxing {@link #REDIRECT_STATUSES} lookup stays off the 2xx, 4xx
+     * and 5xx responses that carry almost all traffic. The set is consulted rather than inlined because it
+     * is public and mutable, so an extra 3xx a caller registered is honoured.
      */
     static boolean isRedirect(int statusCode) {
         return HttpStatusClass.REDIRECTION.contains(statusCode) && REDIRECT_STATUSES.contains(statusCode);

--- a/client/src/test/java/org/asynchttpclient/netty/handler/intercept/Redirect30xInterceptorTest.java
+++ b/client/src/test/java/org/asynchttpclient/netty/handler/intercept/Redirect30xInterceptorTest.java
@@ -1,0 +1,52 @@
+/*
+ *    Copyright (c) 2026 AsyncHttpClient Project. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.asynchttpclient.netty.handler.intercept;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests {@link Redirect30xInterceptor#isRedirect(int)}: the 3xx class check and the
+ * {@link Redirect30xInterceptor#REDIRECT_STATUSES} membership must agree, so a 3xx that is not a followed
+ * redirect is rejected just like a non-3xx status.
+ */
+public class Redirect30xInterceptorTest {
+
+    @Test
+    public void acceptsTheFollowedRedirectStatuses() {
+        for (int statusCode : new int[]{301, 302, 303, 307, 308}) {
+            assertTrue(Redirect30xInterceptor.isRedirect(statusCode), statusCode + " should be a redirect");
+        }
+    }
+
+    @Test
+    public void rejects3xxStatusesThatAreNotFollowed() {
+        // in the 3xx class, but not redirects this interceptor acts on: 304 in particular must fall through
+        // to the normal response path rather than be treated as a redirect
+        for (int statusCode : new int[]{300, 304, 305, 306, 399}) {
+            assertFalse(Redirect30xInterceptor.isRedirect(statusCode), statusCode + " should not be a redirect");
+        }
+    }
+
+    @Test
+    public void rejectsStatusesOutsideThe3xxClass() {
+        for (int statusCode : new int[]{100, 200, 204, 299, 400, 404, 500}) {
+            assertFalse(Redirect30xInterceptor.isRedirect(statusCode), statusCode + " should not be a redirect");
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`Interceptors.exitAfterIntercept` runs for every HTTP response and tested the
redirect status like this:

```java
if (Redirect30xInterceptor.REDIRECT_STATUSES.contains(statusCode)) {
```

`REDIRECT_STATUSES` is a `Set<Integer>` and `statusCode` is an `int`, so the
call autoboxes. `Integer.valueOf` caches -128..127, which covers 100..103 but
nothing else a response carries, so every 2xx / 4xx / 5xx response allocated a
fresh `Integer` and hashed it, only to answer `false`. Those are almost all of
the traffic.

## Change

Move the test into a package-private `Redirect30xInterceptor.isRedirect(int)`,
next to the set it guards, and gate the set lookup behind Netty's
`HttpStatusClass.REDIRECTION.contains(int)`. That check takes a primitive, so
only a genuine 3xx pays for the boxing.

The set is still consulted rather than inlined as a `switch` over the five
known codes. `REDIRECT_STATUSES` is `public` and a mutable `HashSet`; changing
what it means is out of scope for a performance change, so any 3xx a caller
registered keeps working. Behaviour differs only for a non-3xx code added to
the set, which would not be a redirect status.

No public API change.

## Scope

One predicate, its two call sites, and a unit test. Related per-response
allocations found in the same method (`responseHeaders.getAll(SET_COOKIE)`
allocates a `LinkedList` per response even with no `Set-Cookie` present) are
left for a separate PR.

## Tests

`Redirect30xInterceptorTest` covers `isRedirect(int)` directly: the five
followed statuses, the 3xx that are not followed (300, 304, 305, 306, 399 -
304 above all, which must reach the normal response path), and non-3xx codes.

The redirect paths themselves are already covered by `Relative302Test`,
`PerRequestRelative302Test`, `PostRedirectGetTest`, `RedirectBodyTest`,
`HttpToHttpsRedirectTest`, `RedirectCredentialSecurityTest`,
`RedirectConnectionUsageTest`, `Head302Test`,
`StripAuthorizationOnRedirectHttpTest` and `ws.RedirectTest`.

## Verification

<!-- re-run `mvnw clean verify` on the current head and paste the counts;
     the previous run predates Redirect30xInterceptorTest -->

Caveat on the testing gate: `AGENTS.md` requires the build to run on JDK 11 and
no JDK 11 is installed on this machine, so it was run on **JDK 17** (also in the
CI matrix). The JDK 11 leg of CI on this PR is the real gate.

Follows the same review pass as #2300.

Claude Code on behalf of @pavel-ptashyts

🤖 Generated with [Claude Code](https://claude.com/claude-code)