### PR TITLE
Read only when the channel does not auto-read

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/handler/AsyncHttpClientHandler.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/AsyncHttpClientHandler.java
@@ -173,23 +173,22 @@ public abstract class AsyncHttpClientHandler extends ChannelInboundHandlerAdapte
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) {
-        readIfNotAutoRead(ctx);
+        readIfNeeded(ctx);
     }
 
     @Override
     public void channelReadComplete(ChannelHandlerContext ctx) {
-        readIfNotAutoRead(ctx);
+        readIfNeeded(ctx);
     }
 
     /**
-     * Requests the next read only when the channel will not do it by itself. Netty's HeadContext already
-     * calls Channel#read() after firing channelActive and channelReadComplete whenever autoRead is on, so
-     * reading here as well only repeated the outbound pipeline traversal and doBeginRead. AsyncHttpClient
-     * never clears autoRead, which defaults to on, so this is the usual path; a caller that turns it off
-     * through a channel option still needs reads to be driven from here, which is why the call is kept
-     * rather than dropped.
+     * Requests the next read only when the channel will not do it by itself: Netty's {@code HeadContext}
+     * calls {@code Channel#read()} once channelActive and channelReadComplete have been fired whenever
+     * autoRead is on, so reading here as well would just repeat the outbound traversal and doBeginRead.
+     * Same guard as {@code SslHandler#readIfNeeded}, which {@code Http2ConnectionHandler}
+     * inlines in {@code channelReadComplete0}.
      */
-    private static void readIfNotAutoRead(ChannelHandlerContext ctx) {
+    private static void readIfNeeded(ChannelHandlerContext ctx) {
         if (!ctx.channel().config().isAutoRead()) {
             ctx.read();
         }

--- a/client/src/main/java/org/asynchttpclient/netty/handler/AsyncHttpClientHandler.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/AsyncHttpClientHandler.java
@@ -173,12 +173,26 @@ public abstract class AsyncHttpClientHandler extends ChannelInboundHandlerAdapte
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) {
-        ctx.read();
+        readIfNotAutoRead(ctx);
     }
 
     @Override
     public void channelReadComplete(ChannelHandlerContext ctx) {
-        ctx.read();
+        readIfNotAutoRead(ctx);
+    }
+
+    /**
+     * Requests the next read only when the channel will not do it by itself. Netty's HeadContext already
+     * calls Channel#read() after firing channelActive and channelReadComplete whenever autoRead is on, so
+     * reading here as well only repeated the outbound pipeline traversal and doBeginRead. AsyncHttpClient
+     * never clears autoRead, which defaults to on, so this is the usual path; a caller that turns it off
+     * through a channel option still needs reads to be driven from here, which is why the call is kept
+     * rather than dropped.
+     */
+    private static void readIfNotAutoRead(ChannelHandlerContext ctx) {
+        if (!ctx.channel().config().isAutoRead()) {
+            ctx.read();
+        }
     }
 
     void finishUpdate(NettyResponseFuture<?> future, Channel channel, boolean close) {

--- a/client/src/main/java/org/asynchttpclient/netty/handler/AsyncHttpClientHandler.java
+++ b/client/src/main/java/org/asynchttpclient/netty/handler/AsyncHttpClientHandler.java
@@ -185,8 +185,8 @@ public abstract class AsyncHttpClientHandler extends ChannelInboundHandlerAdapte
      * Requests the next read only when the channel will not do it by itself: Netty's {@code HeadContext}
      * calls {@code Channel#read()} once channelActive and channelReadComplete have been fired whenever
      * autoRead is on, so reading here as well would just repeat the outbound traversal and doBeginRead.
-     * Same guard as {@code SslHandler#readIfNeeded}, which {@code Http2ConnectionHandler}
-     * inlines in {@code channelReadComplete0}.
+     * Same guard as {@code Http2ConnectionHandler#channelReadComplete0}, which checks autoRead and nothing
+     * else; {@code SslHandler#readIfNeeded} adds a handshake condition on top of the same check.
      */
     private static void readIfNeeded(ChannelHandlerContext ctx) {
         if (!ctx.channel().config().isAutoRead()) {


### PR DESCRIPTION
## Problem

`AsyncHttpClientHandler` requested a read from both lifecycle callbacks:

```java
public void channelActive(ChannelHandlerContext ctx)       { ctx.read(); }
public void channelReadComplete(ChannelHandlerContext ctx) { ctx.read(); }
```

Netty's `HeadContext` already calls `Channel#read()` immediately after firing
either event whenever `autoRead` is on. AsyncHttpClient never clears `autoRead`
(no `ChannelOption.AUTO_READ` anywhere in the codebase) and Netty defaults it to
on, so that was the path for every connection: each read cycle traversed the
outbound pipeline and reached `doBeginRead` twice instead of once. The cost is
per read cycle, so it scales with how many reads a response takes.

## Change

Drive the read from the handler only when `autoRead` is off.

That is also a fix in its own right: a caller who disabled `autoRead` through
`setChannelOption` previously had the setting silently defeated by these two
unconditional reads, since the handler kept requesting reads regardless.

## Verification of the Netty behaviour

Checked against `netty-codec-http2` / `netty-transport` **4.2.16.Final**, the
version this project builds against, rather than assumed:

* `DefaultChannelPipeline$HeadContext.channelActive` and `.channelReadComplete`
  both call `readIfIsAutoRead()`, which is
  `if (channel.config().isAutoRead()) channel.read();`
* `DefaultChannelConfig`'s constructor initialises `autoRead` to `1`, so on.
* HTTP/2 stream channels inherit both behaviours:
  `AbstractHttp2StreamChannel$2 extends DefaultChannelPipeline`, and
  `Http2StreamChannelConfig extends DefaultChannelConfig` without overriding
  `isAutoRead`.

The last point matters because this is the shared base class of `HttpHandler`,
`WebSocketHandler` and `Http2Handler`, and neither of the two callbacks is
overridden by any of them, so the change applies to HTTP/1.1, WebSocket and
HTTP/2 stream channels alike.

## Verification of the build

`mvnw clean verify` - BUILD SUCCESS, 1371 tests, 0 failures, 0 errors,
19 skipped. Error Prone, NullAway and Revapi all clean.

The suites covering the paths most exposed to a change in read behaviour are
green: 168 HTTP/2 tests (`BasicHttp2Test`, `Http2MultiplexBugRegressionTest`,
`Http2StreamingBodyFlowControlTest`, `Http2StreamOrphanRegressionTest`,
`Http2ConformanceRegressionTest` and the rest) and 36 WebSocket tests
(`TextMessageTest`, `ByteMessageTest`, `CloseCodeReasonMessageTest`,
`WebSocketWriteFutureTest`, `ws.ProxyTunnellingTest`).

Caveat on the testing gate: `AGENTS.md` requires the build to run on JDK 11 and
no JDK 11 is installed on this machine, so it was run on **JDK 17** (also in the
CI matrix). The JDK 11 leg of CI on this PR is the real gate.

No public API change. Same review pass as #2300 and #2301.

Claude Code on behalf of @pavel-ptashyts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
